### PR TITLE
Route bbox and Polyline convenience

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,7 +2,7 @@ name: Android CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -2,7 +2,7 @@ name: iOS CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "*" ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -29,6 +29,13 @@ jobs:
 
     - name: Checkout repo
       uses: actions/checkout@v3
+
+    - name: Configure Package.swift for local development
+      run: sed -i '' 's/let useLocalFramework = false/let useLocalFramework = true/' Package.swift
+
+    - name: Build iOS XCFramework
+      run: ./build-ios.sh --release
+      working-directory: common
     
     - name: Test ${{ matrix.scheme }} on ${{ matrix.destination }}
       run: xcodebuild -scheme ${{ matrix.scheme }} test -skipMacroValidation -destination '${{ matrix.destination }}' | xcbeautify && exit ${PIPESTATUS[0]}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust (Common)
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,9 +22,3 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
       working-directory: common
-    # - name: Build iOS XCFramework
-      # run: ./build-ios.sh
-      # working-directory: common
-    # - name: Build Android Shared Library
-      # run: ./build-android.sh
-      # working-directory: common

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "3b88d990bc39ed5347852a536c0efd942a07fc97",
-        "version" : "6.0.0-pre9599200f2529de44ba62d4662cddb445dc19397d"
+        "revision" : "3df876f8f2c6c591b0f66a29b3e216020afc885c",
+        "version" : "6.0.0"
       }
     },
     {
@@ -16,6 +16,15 @@
       "state" : {
         "branch" : "main",
         "revision" : "b8deecb8adc3b911de311ead5a13b98fbf2d7824"
+      }
+    },
+    {
+      "identity" : "maplibre-swiftui-dsl-playground",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stadiamaps/maplibre-swiftui-dsl-playground",
+      "state" : {
+        "branch" : "main",
+        "revision" : "39e1d896ac9e898242c91ffc7726b631a0eb187e"
       }
     },
     {
@@ -32,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
-        "version" : "509.0.2"
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,6 @@ import PackageDescription
 
 let binaryTarget: Target
 let maplibreSwiftUIDSLPackage: Package.Dependency
-// TODO: Define this via an env variable that doesn't need to be checked in?
 let useLocalFramework = false
 let useLocalMapLibreSwiftUIDSL = false
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ for info on expectations and dev environment setup.
 
 #### iOS
 
-See the [ferrostar-ios-demo](https://github.com/stadiamaps/ferrostar-ios-demo) repo
-for a demonstration of the current status.
+See the [Demo App](apple/DemoApp) repo
+for an up to date demo app that works in your simulator.
+The slightly older [ferrostar-ios-demo](https://github.com/stadiamaps/ferrostar-ios-demo)
+shows an example that is designed to work with "live" location updates on a real device.
+This will soon be completely mereged into the iOS demo app in this repo.
 
 #### Android
 

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/Extensions.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/Extensions.kt
@@ -1,0 +1,8 @@
+package com.stadiamaps.ferrostar.core
+
+import uniffi.ferrostar.Route
+import uniffi.ferrostar.getRoutePolyline
+
+@Throws
+fun Route.getPolyline(precision: UInt): String =
+    getRoutePolyline(this, precision)

--- a/apple/DemoApp/README.md
+++ b/apple/DemoApp/README.md
@@ -7,7 +7,7 @@ in an iOS application.
 
 1. Sign up for a [free Stadia Maps account](https://client.stadiamaps.com/signup/?utm_content=ferrostar_ios&utm_campaign=ferrostar_demos&utm_source=github)
 2. Go through property setup and create an API key.
-3. Update the `API-Keys.plist` with your API key. Shown below opened as XML/Source: 
+3. Create an `API-Keys.plist` file with your API key. Shown below opened as XML/Source: 
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>

--- a/apple/Sources/FerrostarCore/ModelWrappers.swift
+++ b/apple/Sources/FerrostarCore/ModelWrappers.swift
@@ -28,7 +28,7 @@ public struct Route {
     }
 
     public func getPolyline(precision: UInt32) throws -> String {
-        return try routeToPolyline(route: inner, precision: precision)
+        return try getRoutePolyline(route: inner, precision: precision)
     }
 }
 

--- a/apple/Sources/FerrostarCore/ModelWrappers.swift
+++ b/apple/Sources/FerrostarCore/ModelWrappers.swift
@@ -26,6 +26,10 @@ public struct Route {
             CLLocationCoordinate2D(geographicCoordinates: point)
         }
     }
+
+    public func getPolyline(precision: UInt32) throws -> String {
+        return try routeToPolyline(route: inner, precision: precision)
+    }
 }
 
 /// A Swift wrapper around `UniFFI.TripState`.

--- a/apple/Sources/UniFFI/ferrostar.swift
+++ b/apple/Sources/UniFFI/ferrostar.swift
@@ -946,6 +946,58 @@ public func FfiConverterTypeRouteResponseParser_lower(_ value: RouteResponsePars
     return FfiConverterTypeRouteResponseParser.lower(value)
 }
 
+public struct BoundingBox {
+    public var sw: GeographicCoordinate
+    public var ne: GeographicCoordinate
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(sw: GeographicCoordinate, ne: GeographicCoordinate) {
+        self.sw = sw
+        self.ne = ne
+    }
+}
+
+extension BoundingBox: Equatable, Hashable {
+    public static func == (lhs: BoundingBox, rhs: BoundingBox) -> Bool {
+        if lhs.sw != rhs.sw {
+            return false
+        }
+        if lhs.ne != rhs.ne {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(sw)
+        hasher.combine(ne)
+    }
+}
+
+public struct FfiConverterTypeBoundingBox: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BoundingBox {
+        return
+            try BoundingBox(
+                sw: FfiConverterTypeGeographicCoordinate.read(from: &buf),
+                ne: FfiConverterTypeGeographicCoordinate.read(from: &buf)
+            )
+    }
+
+    public static func write(_ value: BoundingBox, into buf: inout [UInt8]) {
+        FfiConverterTypeGeographicCoordinate.write(value.sw, into: &buf)
+        FfiConverterTypeGeographicCoordinate.write(value.ne, into: &buf)
+    }
+}
+
+public func FfiConverterTypeBoundingBox_lift(_ buf: RustBuffer) throws -> BoundingBox {
+    return try FfiConverterTypeBoundingBox.lift(buf)
+}
+
+public func FfiConverterTypeBoundingBox_lower(_ value: BoundingBox) -> RustBuffer {
+    return FfiConverterTypeBoundingBox.lower(value)
+}
+
 public struct CourseOverGround {
     public var degrees: UInt16
     public var accuracy: UInt16
@@ -1148,14 +1200,16 @@ public func FfiConverterTypeNavigationControllerConfig_lower(_ value: Navigation
 
 public struct Route {
     public var geometry: [GeographicCoordinate]
+    public var bbox: BoundingBox
     public var distance: Double
     public var waypoints: [GeographicCoordinate]
     public var steps: [RouteStep]
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(geometry: [GeographicCoordinate], distance: Double, waypoints: [GeographicCoordinate], steps: [RouteStep]) {
+    public init(geometry: [GeographicCoordinate], bbox: BoundingBox, distance: Double, waypoints: [GeographicCoordinate], steps: [RouteStep]) {
         self.geometry = geometry
+        self.bbox = bbox
         self.distance = distance
         self.waypoints = waypoints
         self.steps = steps
@@ -1165,6 +1219,9 @@ public struct Route {
 extension Route: Equatable, Hashable {
     public static func == (lhs: Route, rhs: Route) -> Bool {
         if lhs.geometry != rhs.geometry {
+            return false
+        }
+        if lhs.bbox != rhs.bbox {
             return false
         }
         if lhs.distance != rhs.distance {
@@ -1181,6 +1238,7 @@ extension Route: Equatable, Hashable {
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(geometry)
+        hasher.combine(bbox)
         hasher.combine(distance)
         hasher.combine(waypoints)
         hasher.combine(steps)
@@ -1192,6 +1250,7 @@ public struct FfiConverterTypeRoute: FfiConverterRustBuffer {
         return
             try Route(
                 geometry: FfiConverterSequenceTypeGeographicCoordinate.read(from: &buf),
+                bbox: FfiConverterTypeBoundingBox.read(from: &buf),
                 distance: FfiConverterDouble.read(from: &buf),
                 waypoints: FfiConverterSequenceTypeGeographicCoordinate.read(from: &buf),
                 steps: FfiConverterSequenceTypeRouteStep.read(from: &buf)
@@ -1200,6 +1259,7 @@ public struct FfiConverterTypeRoute: FfiConverterRustBuffer {
 
     public static func write(_ value: Route, into buf: inout [UInt8]) {
         FfiConverterSequenceTypeGeographicCoordinate.write(value.geometry, into: &buf)
+        FfiConverterTypeBoundingBox.write(value.bbox, into: &buf)
         FfiConverterDouble.write(value.distance, into: &buf)
         FfiConverterSequenceTypeGeographicCoordinate.write(value.waypoints, into: &buf)
         FfiConverterSequenceTypeRouteStep.write(value.steps, into: &buf)

--- a/apple/Sources/UniFFI/ferrostar.swift
+++ b/apple/Sources/UniFFI/ferrostar.swift
@@ -2452,6 +2452,17 @@ public func createValhallaRequestGenerator(endpointUrl: String, profile: String)
     )
 }
 
+public func getRoutePolyline(route: Route, precision: UInt32) throws -> String {
+    return try FfiConverterString.lift(
+        rustCallWithError(FfiConverterTypeModelError.lift) {
+            uniffi_ferrostar_fn_func_get_route_polyline(
+                FfiConverterTypeRoute.lower(route),
+                FfiConverterUInt32.lower(precision), $0
+            )
+        }
+    )
+}
+
 public func locationSimulationFromCoordinates(coordinates: [GeographicCoordinate]) throws -> LocationSimulationState {
     return try FfiConverterTypeLocationSimulationState.lift(
         rustCallWithError(FfiConverterTypeSimulationError.lift) {
@@ -2483,17 +2494,6 @@ public func locationSimulationFromRoute(route: Route) throws -> LocationSimulati
     )
 }
 
-public func routeToPolyline(route: Route, precision: UInt32) throws -> String {
-    return try FfiConverterString.lift(
-        rustCallWithError(FfiConverterTypeModelError.lift) {
-            uniffi_ferrostar_fn_func_route_to_polyline(
-                FfiConverterTypeRoute.lower(route),
-                FfiConverterUInt32.lower(precision), $0
-            )
-        }
-    )
-}
-
 private enum InitializationResult {
     case ok
     case contractVersionMismatch
@@ -2519,6 +2519,9 @@ private var initializationResult: InitializationResult {
     if uniffi_ferrostar_checksum_func_create_valhalla_request_generator() != 42515 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_ferrostar_checksum_func_get_route_polyline() != 7053 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_ferrostar_checksum_func_location_simulation_from_coordinates() != 32668 {
         return InitializationResult.apiChecksumMismatch
     }
@@ -2526,9 +2529,6 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_ferrostar_checksum_func_location_simulation_from_route() != 52353 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_ferrostar_checksum_func_route_to_polyline() != 26870 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_ferrostar_checksum_method_navigationcontroller_advance_to_next_step() != 5714 {

--- a/apple/Tests/FerrostarCoreTests/FerrostarCoreTests.swift
+++ b/apple/Tests/FerrostarCoreTests/FerrostarCoreTests.swift
@@ -58,7 +58,7 @@ final class FerrostarCoreTests: XCTestCase {
 
         let geom = [GeographicCoordinate(lng: 0, lat: 0), GeographicCoordinate(lng: 1, lat: 1)]
         let instructionContent = VisualInstructionContent(text: "Sail straight", maneuverType: .depart, maneuverModifier: .straight, roundaboutExitDegrees: nil)
-        let mockRoute = UniFFI.Route(geometry: geom, distance: 1, waypoints: geom, steps: [RouteStep(geometry: geom, distance: 1, roadName: "foo road", instruction: "Sail straight", visualInstructions: [VisualInstruction(primaryContent: instructionContent, secondaryContent: nil, triggerDistanceBeforeManeuver: 42)], spokenInstructions: [])])
+        let mockRoute = UniFFI.Route(geometry: geom, bbox: BoundingBox(sw: geom.first!, ne: geom.last!), distance: 1, waypoints: geom, steps: [RouteStep(geometry: geom, distance: 1, roadName: "foo road", instruction: "Sail straight", visualInstructions: [VisualInstruction(primaryContent: instructionContent, secondaryContent: nil, triggerDistanceBeforeManeuver: 42)], spokenInstructions: [])])
 
         let routeAdapter = RouteAdapter(requestGenerator: MockRouteRequestGenerator(), responseParser: MockRouteResponseParser(routes: [mockRoute]))
 

--- a/apple/Tests/FerrostarCoreTests/__Snapshots__/FerrostarCoreTests/test200MockRouteResponse.1.txt
+++ b/apple/Tests/FerrostarCoreTests/__Snapshots__/FerrostarCoreTests/test200MockRouteResponse.1.txt
@@ -1,6 +1,13 @@
 ▿ 1 element
   ▿ Route
     ▿ inner: Route
+      ▿ bbox: BoundingBox
+        ▿ ne: GeographicCoordinate
+          - lat: 1.0
+          - lng: 1.0
+        ▿ sw: GeographicCoordinate
+          - lat: 0.0
+          - lng: 0.0
       - distance: 1.0
       ▿ geometry: 2 elements
         ▿ GeographicCoordinate

--- a/apple/Tests/FerrostarCoreTests/__Snapshots__/ValhallaCoreTests/testValhallaRouteParsing.1.txt
+++ b/apple/Tests/FerrostarCoreTests/__Snapshots__/ValhallaCoreTests/testValhallaRouteParsing.1.txt
@@ -1,6 +1,13 @@
 ▿ 1 element
   ▿ Route
     ▿ inner: Route
+      ▿ bbox: BoundingBox
+        ▿ ne: GeographicCoordinate
+          - lat: 60.535008
+          - lng: -149.543469
+        ▿ sw: GeographicCoordinate
+          - lat: 60.534716
+          - lng: -149.548581
       - distance: 284.0
       ▿ geometry: 10 elements
         ▿ GeographicCoordinate

--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -36,6 +36,22 @@ impl From<GeographicCoordinate> for Point {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, uniffi::Record)]
+#[cfg_attr(test, derive(Serialize))]
+pub struct BoundingBox {
+    pub sw: GeographicCoordinate,
+    pub ne: GeographicCoordinate,
+}
+
+impl From<Rect> for BoundingBox {
+    fn from(value: Rect) -> Self {
+        Self {
+            sw: value.min().into(),
+            ne: value.max().into(),
+        }
+    }
+}
+
 /// The direction in which the user/device is observed to be traveling.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, uniffi::Record)]
 pub struct CourseOverGround {
@@ -79,6 +95,7 @@ impl From<UserLocation> for Point {
 #[cfg_attr(test, derive(Serialize))]
 pub struct Route {
     pub geometry: Vec<GeographicCoordinate>,
+    pub bbox: BoundingBox,
     /// The total route distance, in meters.
     pub distance: f64,
     /// The ordered list of waypoints to visit, including the starting point.

--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -228,3 +228,27 @@ pub struct VisualInstruction {
     /// How far (in meters) from the upcoming maneuver the instruction should start being displayed
     pub trigger_distance_before_maneuver: f64,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_polyline_encode() {
+        let sw = GeographicCoordinate {lng: 0.0, lat: 0.0};
+        let ne = GeographicCoordinate {lng: 1.0, lat: 1.0};
+        let route = Route {
+            geometry: vec![sw, ne],
+            bbox: BoundingBox { sw, ne },
+            distance: 0.0,
+            waypoints: vec![],
+            steps: vec![],
+        };
+
+        let polyline5 = get_route_polyline(&route, 5).expect("Unable to encode polyline for route");
+        insta::assert_yaml_snapshot!(polyline5);
+
+        let polyline6 = get_route_polyline(&route, 6).expect("Unable to encode polyline for route");
+        insta::assert_yaml_snapshot!(polyline6);
+    }
+}

--- a/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_standard_osrm.snap
+++ b/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_standard_osrm.snap
@@ -39,6 +39,13 @@ expression: routes
       lat: 52.523269
     - lng: 13.428554
       lat: 52.523239
+  bbox:
+    sw:
+      lng: 13.387228
+      lat: 52.517033
+    ne:
+      lng: 13.430413
+      lat: 52.529684
   distance: 4731.8
   waypoints:
     - lng: 13.388798

--- a/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_valhalla_osrm.snap
+++ b/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_valhalla_osrm.snap
@@ -283,6 +283,13 @@ expression: routes
       lat: 59.452169
     - lng: 24.730034
       lat: 59.452226
+  bbox:
+    sw:
+      lng: 24.729829
+      lat: 59.442596
+    ne:
+      lng: 24.765372
+      lat: 59.452226
   distance: 2604.35
   waypoints:
     - lng: 24.765368

--- a/common/ferrostar/src/simulation.rs
+++ b/common/ferrostar/src/simulation.rs
@@ -104,7 +104,8 @@ mod tests {
             GeographicCoordinate { lng: 1.0, lat: 1.0 },
             GeographicCoordinate { lng: 2.0, lat: 2.0 },
             GeographicCoordinate { lng: 3.0, lat: 3.0 },
-        ]).expect("Unable to initialize simulation");
+        ])
+        .expect("Unable to initialize simulation");
 
         let mut states = vec![state.clone()];
         for _ in 0..4 {

--- a/common/ferrostar/src/snapshots/ferrostar__models__tests__polyline_encode-2.snap
+++ b/common/ferrostar/src/snapshots/ferrostar__models__tests__polyline_encode-2.snap
@@ -1,0 +1,6 @@
+---
+source: ferrostar/src/models.rs
+expression: polyline6
+---
+"??_c`|@_c`|@"
+

--- a/common/ferrostar/src/snapshots/ferrostar__models__tests__polyline_encode.snap
+++ b/common/ferrostar/src/snapshots/ferrostar__models__tests__polyline_encode.snap
@@ -1,0 +1,6 @@
+---
+source: ferrostar/src/models.rs
+expression: polyline5
+---
+"??_ibE_ibE"
+

--- a/common/rust-toolchain.toml
+++ b/common/rust-toolchain.toml
@@ -12,6 +12,7 @@ targets = [
     # iOS
     "aarch64-apple-ios",
     "x86_64-apple-ios",
+    "aarch64-apple-ios-sim",
 
     # Android
     "armv7-linux-androideabi",


### PR DESCRIPTION
Few improvements here...

* Adds route bbox as we discussed (fixes #40)
* Adds a polyline helper function that we live coded today + some convenience extensions for both iOS and Swift
* Builds an XCFramework and rewrites Package.swift to use it during CI so we can actually test changes to core when they get committed rather than using a release artifact which is guaranteed to be out of date