### PR TITLE
Route Deviation Detection v1

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -83,7 +83,10 @@ jobs:
         name: libferrostar-rs.xcframework.zip
 
     - name: Unzip libferrostar-rs.xcframework
-      run: unzip libferrostar-rs.xcframework.zip
+      run: unzip libferrostar-rs.xcframework.zip -d common
+
+    - name: Configure Package.swift for local development
+      run: sed -i '' 's/let useLocalFramework = false/let useLocalFramework = true/' Package.swift
 
     - name: Install xcbeautify
       run: brew install xcbeautify

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -44,7 +44,7 @@ jobs:
         name: libferrostar-rs.xcframework.zip
 
     - name: Unzip libferrostar-rs.xcframework
-      run: unzip libferrostar-rs.xcframework.zip && mkdir -p common/target/ios/ && mv libferrostar-rs.xcframework common/target/ios/
+      run: unzip libferrostar-rs.xcframework.zip
 
     - name: Configure Package.swift for local development
       run: sed -i '' 's/let useLocalFramework = false/let useLocalFramework = true/' Package.swift

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-ferrostar:
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
     - name: Checkout repo
@@ -26,7 +26,7 @@ jobs:
         retention-days: 5
 
   build-demo:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: build-ferrostar
     strategy:
       matrix:
@@ -70,7 +70,7 @@ jobs:
         retention-days: 5
 
   test:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: build-ferrostar
     strategy:
       matrix:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -14,9 +14,6 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
 
-    - name: Configure Package.swift for local development
-      run: sed -i '' 's/let useLocalFramework = false/let useLocalFramework = true/' Package.swift
-
     - name: Build iOS XCFramework
       run: ./build-ios.sh --release
       working-directory: common
@@ -47,7 +44,10 @@ jobs:
         name: libferrostar-rs.xcframework.zip
 
     - name: Unzip libferrostar-rs.xcframework
-      run: unzip libferrostar-rs.xcframework.zip
+      run: unzip libferrostar-rs.xcframework.zip && mkdir -p common/target/ios/ && mv libferrostar-rs.xcframework common/target/ios/
+
+    - name: Configure Package.swift for local development
+      run: sed -i '' 's/let useLocalFramework = false/let useLocalFramework = true/' Package.swift
 
     - name: Install xcbeautify
       run: brew install xcbeautify

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -44,7 +44,7 @@ jobs:
         name: libferrostar-rs.xcframework.zip
 
     - name: Unzip libferrostar-rs.xcframework
-      run: unzip libferrostar-rs.xcframework.zip
+      run: unzip libferrostar-rs.xcframework.zip -d common
 
     - name: Configure Package.swift for local development
       run: sed -i '' 's/let useLocalFramework = false/let useLocalFramework = true/' Package.swift

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v4

--- a/android/MapLibreUI/build.gradle
+++ b/android/MapLibreUI/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace 'com.stadiamaps.ferrostar.maplibreui'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 29
@@ -36,16 +36,18 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.core:core-ktx:1.12.0'
     implementation platform('org.jetbrains.kotlin:kotlin-bom:1.8.0')
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.activity:activity-compose:1.7.2'
-    implementation platform('androidx.compose:compose-bom:2022.10.00')
+    implementation 'androidx.activity:activity-compose:1.8.2'
+
+    implementation platform('androidx.compose:compose-bom:2024.02.00')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2'
+
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0'
 
     implementation 'org.ramani-maps:ramani-maplibre:0.2.0'
 
@@ -56,8 +58,8 @@ dependencies {
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation platform('androidx.compose:compose-bom:2022.10.00')
 
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.02.00')
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.2.0' apply false
-    id 'com.android.library' version '8.2.0' apply false
+    id 'com.android.application' version '8.2.2' apply false
+    id 'com.android.library' version '8.2.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
     id 'com.github.willir.rust.cargo-ndk-android' version '0.3.4' apply false
 }

--- a/android/compose-ui/build.gradle
+++ b/android/compose-ui/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace 'com.stadiamaps.ferrostar.maplibreui'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 29
@@ -36,11 +36,11 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.core:core-ktx:1.12.0'
     implementation platform('org.jetbrains.kotlin:kotlin-bom:1.8.0')
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.activity:activity-compose:1.7.2'
-    implementation platform('androidx.compose:compose-bom:2022.10.00')
+    implementation 'androidx.activity:activity-compose:1.8.2'
+    implementation platform('androidx.compose:compose-bom:2024.02.00')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
@@ -52,7 +52,7 @@ dependencies {
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation platform('androidx.compose:compose-bom:2022.10.00')
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.02.00')
 
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'

--- a/android/core/build.gradle
+++ b/android/core/build.gradle
@@ -37,11 +37,11 @@ android {
 dependencies {
     implementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
 
-    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0'
 
     implementation "net.java.dev.jna:jna:5.12.0@aar"
 

--- a/android/core/build.gradle
+++ b/android/core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2'
 
-    implementation "net.java.dev.jna:jna:5.9.0@aar"
+    implementation "net.java.dev.jna:jna:5.12.0@aar"
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/FerrostarCoreTest.kt
+++ b/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/FerrostarCoreTest.kt
@@ -14,20 +14,26 @@ import okhttp3.mock.url
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
 import org.junit.Test
+import uniffi.ferrostar.BoundingBox
 import uniffi.ferrostar.GeographicCoordinate
+import uniffi.ferrostar.ManeuverModifier
+import uniffi.ferrostar.ManeuverType
 import uniffi.ferrostar.Route
 import uniffi.ferrostar.RouteAdapter
 import uniffi.ferrostar.RouteRequest
 import uniffi.ferrostar.RouteRequestGenerator
 import uniffi.ferrostar.RouteResponseParser
+import uniffi.ferrostar.RouteStep
 import uniffi.ferrostar.UserLocation
+import uniffi.ferrostar.VisualInstruction
+import uniffi.ferrostar.VisualInstructionContent
 import java.time.Instant
 
 private val valhallaEndpointUrl = "https://api.stadiamaps.com/navigate/v1"
 
 // Simple test to ensure that the extensibility with native code is working.
 
-class MockRouteRequestGenerator: RouteRequestGenerator {
+class MockRouteRequestGenerator : RouteRequestGenerator {
     override fun generateRequest(
         userLocation: UserLocation,
         waypoints: List<GeographicCoordinate>
@@ -46,6 +52,40 @@ class FerrostarCoreTest {
         }
     """.trimIndent().toResponseBody(MediaTypes.MEDIATYPE_JSON)
 
+    // Mocked route
+    private val mockGeom = listOf(
+        GeographicCoordinate(lng = 0.0, lat = 0.0),
+        GeographicCoordinate(lng = 1.0, lat = 1.0)
+    )
+    private val instructionContent = VisualInstructionContent(
+        text = "Sail straight",
+        maneuverType = ManeuverType.DEPART,
+        maneuverModifier = ManeuverModifier.STRAIGHT,
+        roundaboutExitDegrees = null
+    )
+    private val mockRoute = Route(
+        geometry = mockGeom,
+        bbox = BoundingBox(sw = mockGeom.first(), ne = mockGeom.last()),
+        distance = 1.0,
+        waypoints = mockGeom,
+        steps = listOf(
+            RouteStep(
+                geometry = mockGeom,
+                distance = 1.0,
+                roadName = "foo road",
+                instruction = "Sail straight",
+                visualInstructions = listOf(
+                    VisualInstruction(
+                        primaryContent = instructionContent,
+                        secondaryContent = null,
+                        triggerDistanceBeforeManeuver = 42.0
+                    )
+                ),
+                spokenInstructions = listOf()
+            )
+        )
+    )
+
     @Test
     fun test401UnauthorizedRouteResponse() = runTest {
         val interceptor = MockInterceptor().apply {
@@ -61,15 +101,24 @@ class FerrostarCoreTest {
         }
 
         val core = FerrostarCore(
-            routeAdapter = RouteAdapter(requestGenerator = MockRouteRequestGenerator(), responseParser = MockRouteResponseParser(routes = listOf())),
+            routeAdapter = RouteAdapter(
+                requestGenerator = MockRouteRequestGenerator(),
+                responseParser = MockRouteResponseParser(routes = listOf())
+            ),
             httpClient = OkHttpClient.Builder().addInterceptor(interceptor).build(),
+            locationProvider = SimulatedLocationProvider(),
             delegate = null
         )
 
         try {
             // Tests that the core generates a request and attempts to process it, but throws due to the mocked network layer
             core.getRoutes(
-                initialLocation = UserLocation(coordinates = GeographicCoordinate(-149.543469, 60.5347155), 0.0, null, Instant.now()),
+                initialLocation = UserLocation(
+                    coordinates = GeographicCoordinate(
+                        -149.543469,
+                        60.5347155
+                    ), 0.0, null, Instant.now()
+                ),
                 waypoints = listOf(GeographicCoordinate(-149.5485806, 60.5349908))
             )
             fail("Expected the request to fail")
@@ -78,5 +127,38 @@ class FerrostarCoreTest {
         }
     }
 
-    // TODO: successful test
+    @Test
+    fun test200MockRouteResponse() = runTest {
+        val interceptor = MockInterceptor().apply {
+            rule(post, url eq valhallaEndpointUrl) {
+                respond(200, "".toResponseBody())
+            }
+
+            rule(get) {
+                respond {
+                    throw IllegalStateException("an IO error")
+                }
+            }
+        }
+
+        val core = FerrostarCore(
+            routeAdapter = RouteAdapter(
+                requestGenerator = MockRouteRequestGenerator(),
+                responseParser = MockRouteResponseParser(routes = listOf(mockRoute))
+            ),
+            httpClient = OkHttpClient.Builder().addInterceptor(interceptor).build(),
+            locationProvider = SimulatedLocationProvider(),
+            delegate = null
+        )
+        val routes = core.getRoutes(
+            initialLocation = UserLocation(
+                coordinates = GeographicCoordinate(
+                    lng = -149.543469,
+                    lat = 60.5347155
+                ), horizontalAccuracy = 6.0, courseOverGround = null, timestamp = Instant.now()
+            ), waypoints = listOf(GeographicCoordinate(lng = -149.5485806, lat = 60.5349908))
+        )
+
+        assertEquals(listOf(mockRoute), routes)
+    }
 }

--- a/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/FerrostarCoreTest.kt
+++ b/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/FerrostarCoreTest.kt
@@ -62,7 +62,8 @@ class FerrostarCoreTest {
 
         val core = FerrostarCore(
             routeAdapter = RouteAdapter(requestGenerator = MockRouteRequestGenerator(), responseParser = MockRouteResponseParser(routes = listOf())),
-            httpClient = OkHttpClient.Builder().addInterceptor(interceptor).build()
+            httpClient = OkHttpClient.Builder().addInterceptor(interceptor).build(),
+            delegate = null
         )
 
         try {

--- a/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/ValhallaCoreTest.kt
+++ b/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/ValhallaCoreTest.kt
@@ -248,6 +248,7 @@ class ValhallaCoreTest {
             valhallaEndpointURL = URL(valhallaEndpointUrl),
             profile = "auto",
             httpClient = OkHttpClient.Builder().addInterceptor(interceptor).build(),
+            locationProvider = SimulatedLocationProvider(),
             delegate = null
         )
 

--- a/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/ValhallaCoreTest.kt
+++ b/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/ValhallaCoreTest.kt
@@ -247,7 +247,8 @@ class ValhallaCoreTest {
         val core = FerrostarCore(
             valhallaEndpointURL = URL(valhallaEndpointUrl),
             profile = "auto",
-            httpClient = OkHttpClient.Builder().addInterceptor(interceptor).build()
+            httpClient = OkHttpClient.Builder().addInterceptor(interceptor).build(),
+            delegate = null
         )
 
         return runTest {

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/FerrostarCore.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/FerrostarCore.kt
@@ -117,6 +117,8 @@ class FerrostarCore(
         val controller = _navigationController
 
         if (controller != null) {
+            // TODO: Figure out where to work in off route behaviors
+
             _state?.update { currentValue ->
                 controller.updateUserLocation(
                     location = location.userLocation(),

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
@@ -22,31 +22,31 @@ data class NavigationUiState(
 )
 
 class NavigationViewModel(
-    tripStateFlow: StateFlow<TripState>,
+    stateFlow: StateFlow<FerrostarCoreState>,
     initialUserLocation: Location,
     private val routeGeometry: List<GeographicCoordinate>,
 ) : ViewModel() {
     private var lastLocation: UserLocation = initialUserLocation.userLocation()
 
-    val uiState = tripStateFlow.map { tripState ->
-        lastLocation = when (tripState) {
-            is TripState.Navigating -> tripState.snappedUserLocation
+    val uiState = stateFlow.map { coreState ->
+        lastLocation = when (coreState.tripState) {
+            is TripState.Navigating -> coreState.tripState.snappedUserLocation
             is TripState.Complete -> lastLocation
         }
 
-        uiStateForTripState(tripState, lastLocation)
+        uiState(coreState, lastLocation)
         // This awkward dance is required because Kotlin doesn't have a way to map over StateFlows
         // without converting to a generic Flow in the process.
-    }.stateIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(), initialValue = uiStateForTripState(tripStateFlow.value, initialUserLocation.userLocation()))
+    }.stateIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(), initialValue = uiState(stateFlow.value, initialUserLocation.userLocation()))
 
-    private fun uiStateForTripState(tripState: TripState, location: UserLocation) = NavigationUiState(
+    private fun uiState(coreState: FerrostarCoreState, location: UserLocation) = NavigationUiState(
         snappedLocation = location,
         // TODO: Heading/course over ground
         heading = null,
         routeGeometry = routeGeometry,
-        visualInstruction = visualInstructionForState(tripState),
+        visualInstruction = visualInstructionForState(coreState.tripState),
         spokenInstruction = null,
-        distanceToNextManeuver = distanceForState(tripState)
+        distanceToNextManeuver = distanceForState(coreState.tripState)
     )
 }
 

--- a/android/demo-app/build.gradle
+++ b/android/demo-app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'com.stadiamaps.ferrostar'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.stadiamaps.ferrostar.demo"
         minSdk 29
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/android/demo-app/build.gradle
+++ b/android/demo-app/build.gradle
@@ -47,14 +47,17 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.10.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
-    implementation 'androidx.activity:activity-compose:1.7.2'
-    implementation platform('androidx.compose:compose-bom:2022.10.00')
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    implementation 'androidx.activity:activity-compose:1.8.2'
+
+    implementation platform('androidx.compose:compose-bom:2024.02.00')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
+
+    implementation 'androidx.compose.ui:ui-tooling-preview'
 
     implementation project(':core')
     implementation project(':MapLibreUI')
@@ -65,10 +68,9 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation platform('androidx.compose:compose-bom:2022.10.00')
+
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.02.00')
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
-    debugImplementation 'androidx.compose.ui:ui-tooling'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest'
 
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
@@ -32,6 +32,7 @@ import okhttp3.OkHttpClient
 import uniffi.ferrostar.GeographicCoordinate
 import uniffi.ferrostar.LocationSimulationState
 import uniffi.ferrostar.NavigationControllerConfig
+import uniffi.ferrostar.RouteDeviationTracking
 import uniffi.ferrostar.SimulationSpeed
 import uniffi.ferrostar.StepAdvanceMode
 import uniffi.ferrostar.advanceLocationSimulation
@@ -84,7 +85,8 @@ class MainActivity : ComponentActivity() {
                             StepAdvanceMode.RelativeLineStringDistance(
                                 minimumHorizontalAccuracy = 25U,
                                 automaticAdvanceDistance = 10U
-                            )
+                            ),
+                            RouteDeviationTracking.StaticThreshold(25U, 10.0)
                         ),
                         locationProvider = locationProvider,
                         startingLocation = initialSimulatedLocation

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import uniffi.ferrostar.GeographicCoordinate
-import uniffi.ferrostar.LocationSimulationState
 import uniffi.ferrostar.NavigationControllerConfig
 import uniffi.ferrostar.RouteDeviationTracking
 import uniffi.ferrostar.SimulationSpeed
@@ -38,6 +37,7 @@ import uniffi.ferrostar.StepAdvanceMode
 import uniffi.ferrostar.advanceLocationSimulation
 import uniffi.ferrostar.locationSimulationFromRoute
 import java.net.URL
+import java.time.Duration
 import java.time.Instant
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -50,14 +50,14 @@ class MainActivity : ComponentActivity() {
         Instant.now()
     )
     private val locationProvider = SimulatedLocationProvider()
-    private val httpClient = OkHttpClient.Builder().build()
+    private val httpClient = OkHttpClient.Builder().callTimeout(Duration.ofSeconds(15)).build()
 
     // NOTE: This is a public instance which is suitable for development, but not for heavy use.
     // This server is suitable for testing and building your app, but once you are ready to go live,
     // YOU MUST USE ANOTHER SERVER.
     //
     // See https://github.com/stadiamaps/ferrostar/blob/main/VENDORS.md for options
-    val core = FerrostarCore(
+    private val core = FerrostarCore(
         valhallaEndpointURL = URL("https://valhalla1.openstreetmap.de/route"),
         profile = "bicycle",
         httpClient = httpClient

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
@@ -90,10 +90,9 @@ class MainActivity : ComponentActivity() {
                         startingLocation = initialSimulatedLocation
                     )
 
-                    val delayBetweenSteps = 1.toDuration(DurationUnit.SECONDS)
                     var simulationState = locationSimulationFromRoute(route)
                     while (true) {
-                        delay(delayBetweenSteps)
+                        delay(1.toDuration(DurationUnit.SECONDS))
                         simulationState = advanceLocationSimulation(simulationState, SimulationSpeed.JUMP_TO_NEXT_LOCATION)
                         locationProvider.lastLocation = SimulatedLocation(
                             simulationState.currentLocation,

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
@@ -62,8 +62,8 @@ class MainActivity : ComponentActivity() {
         profile = "bicycle",
         httpClient = httpClient,
         locationProvider = locationProvider,
-        // TODO: Example showing the delegate in action
-        delegate = null,
+        // NOTE: Not all applications will need a delegate. Read the NavigationDelegate documentation for details.
+        delegate = NavigationDelegate(),
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -71,6 +71,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             var navigationViewModel by remember { mutableStateOf<NavigationViewModel?>(null) }
+            locationProvider.lastLocation = initialSimulatedLocation
 
             LaunchedEffect(savedInstanceState) {
                 // Fetch a route in the background
@@ -91,7 +92,6 @@ class MainActivity : ComponentActivity() {
                             ),
                             RouteDeviationTracking.StaticThreshold(25U, 10.0)
                         ),
-                        startingLocation = initialSimulatedLocation
                     )
 
                     var simulationState = locationSimulationFromRoute(route)

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
@@ -61,6 +61,7 @@ class MainActivity : ComponentActivity() {
         valhallaEndpointURL = URL("https://valhalla1.openstreetmap.de/route"),
         profile = "bicycle",
         httpClient = httpClient,
+        locationProvider = locationProvider,
         // TODO: Example showing the delegate in action
         delegate = null,
     )
@@ -90,7 +91,6 @@ class MainActivity : ComponentActivity() {
                             ),
                             RouteDeviationTracking.StaticThreshold(25U, 10.0)
                         ),
-                        locationProvider = locationProvider,
                         startingLocation = initialSimulatedLocation
                     )
 

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
@@ -60,7 +60,9 @@ class MainActivity : ComponentActivity() {
     private val core = FerrostarCore(
         valhallaEndpointURL = URL("https://valhalla1.openstreetmap.de/route"),
         profile = "bicycle",
-        httpClient = httpClient
+        httpClient = httpClient,
+        // TODO: Example showing the delegate in action
+        delegate = null,
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/NavigationDelegate.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/NavigationDelegate.kt
@@ -1,0 +1,40 @@
+package com.stadiamaps.ferrostar
+
+import com.stadiamaps.ferrostar.core.CorrectiveAction
+import com.stadiamaps.ferrostar.core.FerrostarCore
+import com.stadiamaps.ferrostar.core.FerrostarCoreDelegate
+import uniffi.ferrostar.GeographicCoordinate
+import uniffi.ferrostar.NavigationControllerConfig
+import uniffi.ferrostar.Route
+import uniffi.ferrostar.RouteDeviationTracking
+import uniffi.ferrostar.StepAdvanceMode
+
+/**
+ * Not all navigation apps will require a navigation delegate. In fact, we hope that most don't!
+ * In case you do though, this sample implementation shows what you'll need to get started
+ * by re-implementing the default behaviors of the core.
+ */
+class NavigationDelegate : FerrostarCoreDelegate {
+    override fun correctiveActionForDeviation(
+        core: FerrostarCore,
+        deviationInMeters: Double,
+        remainingWaypoints: List<GeographicCoordinate>
+    ): CorrectiveAction = CorrectiveAction.GetNewRoutes(remainingWaypoints)
+
+    override fun loadedAlternativeRoutes(core: FerrostarCore, routes: List<Route>) {
+        // Automatically accepts the first new route if the framework was calculating a new route
+        // due to the user being off course.
+        // Pretty sensible default.
+        if (core.isCalculatingNewRoute && routes.isNotEmpty()) {
+            core.startNavigation(
+                routes.first(), NavigationControllerConfig(
+                    StepAdvanceMode.RelativeLineStringDistance(
+                        minimumHorizontalAccuracy = 25U,
+                        automaticAdvanceDistance = 10U
+                    ),
+                    RouteDeviationTracking.StaticThreshold(25U, 10.0)
+                )
+            )
+        }
+    }
+}

--- a/apple/DemoApp/Demo/Navigation Delegate.swift
+++ b/apple/DemoApp/Demo/Navigation Delegate.swift
@@ -1,0 +1,41 @@
+//
+//  Navigation Delegate.swift
+//  Ferrostar Demo
+//
+//  Created by Ian Wagner on 2024-02-25.
+//
+
+import CoreLocation
+import FerrostarCore
+
+/// Not all navigation apps will require a navigation delegate. In fact, we hope that most don't!
+///
+/// In case you do though, this sample implementation shows what you'll need to get started
+/// by re-implementing the default behaviors of the core.
+class NavigationDelegate: FerrostarCoreDelegate {
+    func core(_ core: FerrostarCore, correctiveActionForDeviation deviationInMeters: Double) -> CorrectiveAction {
+        // If the user is off course, we'll try to calculate a new route using the remaining waypoints.
+        if let remainingWaypoints = core.state?.remainingWaypoints {
+            return .getNewRoutes(waypoints: remainingWaypoints)
+        } else {
+            return .doNothing
+        }
+    }
+    
+    func core(_ core: FerrostarCore, loadedAlternateRoutes routes: [Route]) {
+        // Automatically accept the first new route if the framework was calculating a new route
+        // due to the user being off course.
+        // Pretty sensible default.
+        if core.state?.isCalculatingNewRoute ?? false,
+           let route = routes.first {
+            do {
+                try core.startNavigation(
+                    route: route,
+                    stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 32, automaticAdvanceDistance: 10),
+                    routeDeviationTracking: .staticThreshold(minimumHorizontalAccuracy: 25, maxAcceptableDeviation: 20))
+            } catch {
+                // Users of the framework my develop their own responses here, such as notifying the user if appropriate
+            }
+        }
+    }
+}

--- a/apple/DemoApp/Demo/Navigation Delegate.swift
+++ b/apple/DemoApp/Demo/Navigation Delegate.swift
@@ -9,17 +9,12 @@ import CoreLocation
 import FerrostarCore
 
 /// Not all navigation apps will require a navigation delegate. In fact, we hope that most don't!
-///
 /// In case you do though, this sample implementation shows what you'll need to get started
 /// by re-implementing the default behaviors of the core.
 class NavigationDelegate: FerrostarCoreDelegate {
-    func core(_ core: FerrostarCore, correctiveActionForDeviation deviationInMeters: Double) -> CorrectiveAction {
+    func core(_ core: FerrostarCore, correctiveActionForDeviation deviationInMeters: Double, remainingWaypoints waypoints: [CLLocationCoordinate2D]) -> CorrectiveAction {
         // If the user is off course, we'll try to calculate a new route using the remaining waypoints.
-        if let remainingWaypoints = core.state?.remainingWaypoints {
-            return .getNewRoutes(waypoints: remainingWaypoints)
-        } else {
-            return .doNothing
-        }
+        return .getNewRoutes(waypoints: waypoints)
     }
     
     func core(_ core: FerrostarCore, loadedAlternateRoutes routes: [Route]) {

--- a/apple/DemoApp/Demo/NavigationView.swift
+++ b/apple/DemoApp/Demo/NavigationView.swift
@@ -175,7 +175,7 @@ struct NavigationView: View {
         
         try ferrostarCore.startNavigation(
             route: route,
-            stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 32, automaticAdvanceDistance: 10))
+            stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 32, automaticAdvanceDistance: 10), routeDeviationTracking: .none)
         
         if let simulated = locationManager as? SimulatedLocationProvider {
             try simulated.startSimulating(route: route)

--- a/apple/DemoApp/Demo/NavigationView.swift
+++ b/apple/DemoApp/Demo/NavigationView.swift
@@ -17,7 +17,7 @@ struct NavigationView: View {
     private let initialLocation = CLLocation(latitude: 37.332726,
                                              longitude: -122.031790)
     
-    private var locationManager: LocationProviding
+    private var locationProvider: LocationProviding
     @ObservedObject private var ferrostarCore: FerrostarCore
     
     @State private var isFetchingRoutes = false
@@ -34,19 +34,19 @@ struct NavigationView: View {
     init() {
         let simulated = SimulatedLocationProvider(location: initialLocation)
         simulated.warpFactor = 10
-        locationManager = simulated
+        locationProvider = simulated
         self.ferrostarCore = FerrostarCore(
             valhallaEndpointUrl: URL(string: "https://api.stadiamaps.com/route/v1?api_key=\(APIKeys.shared.stadiaMapsAPIKey)")!,
             profile: "pedestrian",
-            locationManager: locationManager
+            locationProvider: locationProvider
         )
 
         // TODO: Example showing delegate
     }
     
     var body: some View {
-        let locationServicesEnabled = locationManager.authorizationStatus == .authorizedAlways
-            || locationManager.authorizationStatus == .authorizedWhenInUse
+        let locationServicesEnabled = locationProvider.authorizationStatus == .authorizedAlways
+            || locationProvider.authorizationStatus == .authorizedWhenInUse
 
         NavigationStack {
             NavigationMapView(
@@ -149,7 +149,7 @@ struct NavigationView: View {
     // MARK: Conveniences
     
     func getRoutes() async {
-        guard let userLocation = locationManager.lastLocation else {
+        guard let userLocation = locationProvider.lastLocation else {
             print("No user location")
             return
         }
@@ -176,15 +176,15 @@ struct NavigationView: View {
             route: route,
             stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 32, automaticAdvanceDistance: 10), routeDeviationTracking: .none)
         
-        if let simulated = locationManager as? SimulatedLocationProvider {
+        if let simulated = locationProvider as? SimulatedLocationProvider {
             try simulated.startSimulating(route: route)
             print("DemoApp: starting route simulation")
         }
     }
     
     var locationLabel: String {
-        guard let userLocation = locationManager.lastLocation else {
-            return "No location - authed as \(locationManager.authorizationStatus)"
+        guard let userLocation = locationProvider.lastLocation else {
+            return "No location - authed as \(locationProvider.authorizationStatus)"
         }
         
         return "±\(Int(userLocation.horizontalAccuracy))m accuracy"

--- a/apple/DemoApp/Demo/NavigationView.swift
+++ b/apple/DemoApp/Demo/NavigationView.swift
@@ -172,10 +172,14 @@ struct NavigationView: View {
             return
         }
         
+        // Starts the navigation state machine.
+        // It's worth having a look through the parameters,
+        // as most of the configuration happens here.
         try ferrostarCore.startNavigation(
             route: route,
-            stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 32, automaticAdvanceDistance: 10), routeDeviationTracking: .none)
-        
+            stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 32, automaticAdvanceDistance: 10),
+            routeDeviationTracking: .staticThreshold(minimumHorizontalAccuracy: 25, maxAcceptableDeviation: 20))
+
         if let simulated = locationProvider as? SimulatedLocationProvider {
             try simulated.startSimulating(route: route)
             print("DemoApp: starting route simulation")

--- a/apple/DemoApp/Demo/NavigationView.swift
+++ b/apple/DemoApp/Demo/NavigationView.swift
@@ -35,14 +35,13 @@ struct NavigationView: View {
         let simulated = SimulatedLocationProvider(location: initialLocation)
         simulated.warpFactor = 10
         locationManager = simulated
-        
-        _ferrostarCore = ObservedObject(
-            wrappedValue: FerrostarCore(
-                valhallaEndpointUrl: URL(string: "https://api.stadiamaps.com/route/v1?api_key=\(APIKeys.shared.stadiaMapsAPIKey)")!,
-                profile: "pedestrian",
-                locationManager: locationManager
-            )
+        self.ferrostarCore = FerrostarCore(
+            valhallaEndpointUrl: URL(string: "https://api.stadiamaps.com/route/v1?api_key=\(APIKeys.shared.stadiaMapsAPIKey)")!,
+            profile: "pedestrian",
+            locationManager: locationManager
         )
+
+        // TODO: Example showing delegate
     }
     
     var body: some View {

--- a/apple/DemoApp/Demo/NavigationView.swift
+++ b/apple/DemoApp/Demo/NavigationView.swift
@@ -16,7 +16,8 @@ struct NavigationView: View {
     
     private let initialLocation = CLLocation(latitude: 37.332726,
                                              longitude: -122.031790)
-    
+    private let navigationDelegate = NavigationDelegate()
+
     private var locationProvider: LocationProviding
     @ObservedObject private var ferrostarCore: FerrostarCore
     
@@ -40,8 +41,8 @@ struct NavigationView: View {
             profile: "pedestrian",
             locationProvider: locationProvider
         )
-
-        // TODO: Example showing delegate
+        // NOTE: Not all applications will need a delegate. Read the NavigationDelegate documentation for details.
+        self.ferrostarCore.delegate = navigationDelegate
     }
     
     var body: some View {

--- a/apple/DemoApp/Ferrostar Demo.xcodeproj/project.pbxproj
+++ b/apple/DemoApp/Ferrostar Demo.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		169A1D582B2E8280006CE59E /* FerrostarMapLibreUI in Frameworks */ = {isa = PBXBuildFile; productRef = 169A1D572B2E8280006CE59E /* FerrostarMapLibreUI */; };
 		169B50132B2E46800008EBB7 /* FerrostarCore in Frameworks */ = {isa = PBXBuildFile; productRef = 169B50122B2E46800008EBB7 /* FerrostarCore */; };
 		169B50152B2E46800008EBB7 /* FerrostarMapLibreUI in Frameworks */ = {isa = PBXBuildFile; productRef = 169B50142B2E46800008EBB7 /* FerrostarMapLibreUI */; };
+		E90D97912B8AF507005E43F8 /* Navigation Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90D97902B8AF507005E43F8 /* Navigation Delegate.swift */; };
 		E9505FCA2AD449B30016BF0A /* FerrostarCore in Frameworks */ = {isa = PBXBuildFile; productRef = E9505FC92AD449B30016BF0A /* FerrostarCore */; };
 		E9505FCC2AD449B30016BF0A /* FerrostarMapLibreUI in Frameworks */ = {isa = PBXBuildFile; productRef = E9505FCB2AD449B30016BF0A /* FerrostarMapLibreUI */; };
 /* End PBXBuildFile section */
@@ -34,6 +35,7 @@
 		1663679E2B2F8FB3008BFF1F /* MockLocationData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocationData.swift; sourceTree = "<group>"; };
 		168ECA792B2E8C42007B11DE /* API-Keys.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "API-Keys.plist"; sourceTree = "<group>"; };
 		168ECA7B2B2F6A1E007B11DE /* Ferrostar Demo-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Ferrostar Demo-Info.plist"; sourceTree = "<group>"; };
+		E90D97902B8AF507005E43F8 /* Navigation Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Navigation Delegate.swift"; sourceTree = "<group>"; };
 		E9505FB72AD449700016BF0A /* Ferrostar Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Ferrostar Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9DD18E42B18EE7A00CAF29A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		E9DD18E52B18F4BD00CAF29A /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -66,6 +68,7 @@
 				1663679B2B2F6F79008BFF1F /* Helpers */,
 				1611A5562B2E6E98006B131D /* NavigationView.swift */,
 				1611A5572B2E6E98006B131D /* ConfigurationView.swift */,
+				E90D97902B8AF507005E43F8 /* Navigation Delegate.swift */,
 				1611A5582B2E6E98006B131D /* DemoApp.swift */,
 			);
 			path = Demo;
@@ -196,6 +199,7 @@
 				1663679D2B2F6F85008BFF1F /* APIKeys.swift in Sources */,
 				1663679F2B2F8FB3008BFF1F /* MockLocationData.swift in Sources */,
 				1611A55D2B2E6E98006B131D /* DemoApp.swift in Sources */,
+				E90D97912B8AF507005E43F8 /* Navigation Delegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apple/Sources/FerrostarCore/FerrostarCore.swift
+++ b/apple/Sources/FerrostarCore/FerrostarCore.swift
@@ -191,9 +191,10 @@ public protocol FerrostarCoreDelegate: AnyObject {
                     distanceToNextManeuver <= instruction.triggerDistanceBeforeManeuver
                 })
                 self.state?.distanceToNextManeuver = distanceToNextManeuver
-                self.state?.remainingWaypoints = remainingWaypoints.map({ coord in
+                let clRemainingWaypoints = remainingWaypoints.map({ coord in
                     CLLocationCoordinate2D(geographicCoordinates: coord)
                 })
+                self.state?.remainingWaypoints = clRemainingWaypoints
 
     //                observableState?.spokenInstruction = currentStep.spokenInstruction.last(where: { instruction in
     //                    currentStepRemainingDistance <= instruction.triggerDistanceBeforeManeuver
@@ -208,14 +209,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
                         break
                     }
 
-                    let fallbackAction: CorrectiveAction
-                    if let waypoints = self.state?.remainingWaypoints {
-                        fallbackAction = .getNewRoutes(waypoints: waypoints)
-                    } else {
-                        fallbackAction = .doNothing
-                    }
-
-                    switch (self.delegate?.core(self, correctiveActionForDeviation: deviationFromRouteLine) ?? fallbackAction) {
+                    switch (self.delegate?.core(self, correctiveActionForDeviation: deviationFromRouteLine) ?? .getNewRoutes(waypoints: clRemainingWaypoints)) {
                     case .doNothing:
                         break
                     case .getNewRoutes(let waypoints):

--- a/apple/Sources/FerrostarCore/FerrostarCore.swift
+++ b/apple/Sources/FerrostarCore/FerrostarCore.swift
@@ -36,7 +36,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
     /// Called when the core detects that the user has deviated from the route.
     ///
     /// This hook enables app developers to take the most appropriate corrective action.
-    func core(_ core: FerrostarCore, correctiveActionForDeviation deviationInMeters: Double) -> CorrectiveAction
+    func core(_ core: FerrostarCore, correctiveActionForDeviation deviationInMeters: Double, remainingWaypoints waypoints: [CLLocationCoordinate2D]) -> CorrectiveAction
 
     /// Called when the core has loaded alternate routes.
     ///
@@ -194,7 +194,6 @@ public protocol FerrostarCoreDelegate: AnyObject {
                 let clRemainingWaypoints = remainingWaypoints.map({ coord in
                     CLLocationCoordinate2D(geographicCoordinates: coord)
                 })
-                self.state?.remainingWaypoints = clRemainingWaypoints
 
     //                observableState?.spokenInstruction = currentStep.spokenInstruction.last(where: { instruction in
     //                    currentStepRemainingDistance <= instruction.triggerDistanceBeforeManeuver
@@ -209,7 +208,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
                         break
                     }
 
-                    switch (self.delegate?.core(self, correctiveActionForDeviation: deviationFromRouteLine) ?? .getNewRoutes(waypoints: clRemainingWaypoints)) {
+                    switch (self.delegate?.core(self, correctiveActionForDeviation: deviationFromRouteLine, remainingWaypoints: clRemainingWaypoints) ?? .getNewRoutes(waypoints: clRemainingWaypoints)) {
                     case .doNothing:
                         break
                     case .getNewRoutes(let waypoints):

--- a/apple/Sources/FerrostarCore/FerrostarCore.swift
+++ b/apple/Sources/FerrostarCore/FerrostarCore.swift
@@ -142,34 +142,36 @@ public protocol FerrostarCoreDelegate: AnyObject {
     /// Internal state update.
     ///
     /// You should call this rather than setting properties directly
-    @MainActor
     private func update(newState: UniFFI.TripState, location: CLLocation) {
-        self.tripState = newState
+        DispatchQueue.main.async {
+            self.tripState = newState
 
-        switch (newState) {
-        case .navigating(snappedUserLocation: let snappedLocation, remainingSteps: let remainingSteps, distanceToNextManeuver: let distanceToNextManeuver, deviationFromRouteLine: let deviationFromRouteLine):
-            self.state?.snappedLocation = CLLocation(userLocation: snappedLocation)
-            self.state?.courseOverGround = location.course
-            self.state?.currentStep = remainingSteps.first
-            // TODO: This isn't great; the core should probably just tell us which instruction to display
-            self.state?.visualInstructions = remainingSteps.first?.visualInstructions.last(where: { instruction in
-                distanceToNextManeuver <= instruction.triggerDistanceBeforeManeuver
-            })
-            self.state?.distanceToNextManeuver = distanceToNextManeuver
-            self.state?.deviationFromRouteLine = deviationFromRouteLine
-            // TODO
-//                observableState?.spokenInstruction = currentStep.spokenInstruction.last(where: { instruction in
-//                    currentStepRemainingDistance <= instruction.triggerDistanceBeforeManeuver
-//                })
-        case .complete:
-            // TODO: "You have arrived"?
-            self.state?.visualInstructions = nil
-            self.state?.snappedLocation = location  // We arrived; no more snapping needed
-            self.state?.courseOverGround = location.course
-            self.state?.spokenInstruction = nil
+            switch (newState) {
+            case .navigating(snappedUserLocation: let snappedLocation, remainingSteps: let remainingSteps, distanceToNextManeuver: let distanceToNextManeuver, deviationFromRouteLine: let deviationFromRouteLine):
+                self.state?.snappedLocation = CLLocation(userLocation: snappedLocation)
+                self.state?.courseOverGround = location.course
+                self.state?.currentStep = remainingSteps.first
+                // TODO: This isn't great; the core should probably just tell us which instruction to display
+                self.state?.visualInstructions = remainingSteps.first?.visualInstructions.last(where: { instruction in
+                    distanceToNextManeuver <= instruction.triggerDistanceBeforeManeuver
+                })
+                self.state?.distanceToNextManeuver = distanceToNextManeuver
+                self.state?.deviationFromRouteLine = deviationFromRouteLine
+                // TODO
+    //                observableState?.spokenInstruction = currentStep.spokenInstruction.last(where: { instruction in
+    //                    currentStepRemainingDistance <= instruction.triggerDistanceBeforeManeuver
+    //                })
+            case .complete:
+                // TODO: "You have arrived"?
+                self.state?.visualInstructions = nil
+                self.state?.snappedLocation = location  // We arrived; no more snapping needed
+                self.state?.courseOverGround = location.course
+                self.state?.spokenInstruction = nil
+            }
+
+            self.delegate?.core(self, didUpdateNavigationState: TripState(newState))
+
         }
-
-        self.delegate?.core(self, didUpdateNavigationState: TripState(newState))
     }
 }
 

--- a/apple/Sources/FerrostarCore/ModelWrappers.swift
+++ b/apple/Sources/FerrostarCore/ModelWrappers.swift
@@ -34,13 +34,15 @@ public struct Route {
 
 /// A Swift wrapper around `UniFFI.TripState`.
 public enum TripState {
-    case navigating(snappedUserLocation: CLLocation, remainingSteps: [UniFFI.RouteStep], distanceToNextManeuver: CLLocationDistance, deviation: RouteDeviation)
+    case navigating(snappedUserLocation: CLLocation, remainingSteps: [UniFFI.RouteStep], remainingWaypoints: [CLLocationCoordinate2D], distanceToNextManeuver: CLLocationDistance, deviation: RouteDeviation)
     case complete
 
     init(_ update: UniFFI.TripState) {
         switch (update) {
-        case .navigating(snappedUserLocation: let location, remainingSteps: let remainingSteps, distanceToNextManeuver: let distanceToNextManeuver, deviation: let deviation):
-            self = .navigating(snappedUserLocation: CLLocation(userLocation: location), remainingSteps: remainingSteps, distanceToNextManeuver: distanceToNextManeuver, deviation: deviation)
+        case .navigating(snappedUserLocation: let location, remainingSteps: let remainingSteps, remainingWaypoints: let remainingWaypoints, distanceToNextManeuver: let distanceToNextManeuver, deviation: let deviation):
+            self = .navigating(snappedUserLocation: CLLocation(userLocation: location), remainingSteps: remainingSteps, remainingWaypoints: remainingWaypoints.map({ coord in
+                CLLocationCoordinate2D(geographicCoordinates: coord)
+            }), distanceToNextManeuver: distanceToNextManeuver, deviation: deviation)
         case .complete:
             self = .complete
         }

--- a/apple/Sources/FerrostarCore/ModelWrappers.swift
+++ b/apple/Sources/FerrostarCore/ModelWrappers.swift
@@ -34,13 +34,13 @@ public struct Route {
 
 /// A Swift wrapper around `UniFFI.TripState`.
 public enum TripState {
-    case navigating(snappedUserLocation: CLLocation, remainingSteps: [UniFFI.RouteStep], distanceToNextManeuver: CLLocationDistance, deviationFromRouteLine: CLLocationDistance?)
+    case navigating(snappedUserLocation: CLLocation, remainingSteps: [UniFFI.RouteStep], distanceToNextManeuver: CLLocationDistance, deviation: RouteDeviation)
     case complete
 
     init(_ update: UniFFI.TripState) {
         switch (update) {
-        case .navigating(snappedUserLocation: let location, remainingSteps: let remainingSteps, distanceToNextManeuver: let distanceToNextManeuver, deviationFromRouteLine: let deviationFromRouteLine):
-            self = .navigating(snappedUserLocation: CLLocation(userLocation: location), remainingSteps: remainingSteps, distanceToNextManeuver: distanceToNextManeuver, deviationFromRouteLine: deviationFromRouteLine)
+        case .navigating(snappedUserLocation: let location, remainingSteps: let remainingSteps, distanceToNextManeuver: let distanceToNextManeuver, deviation: let deviation):
+            self = .navigating(snappedUserLocation: CLLocation(userLocation: location), remainingSteps: remainingSteps, distanceToNextManeuver: distanceToNextManeuver, deviation: deviation)
         case .complete:
             self = .complete
         }
@@ -67,6 +67,38 @@ public enum StepAdvanceMode {
             return .distanceToEndOfStep(distance: distance, minimumHorizontalAccuracy: minimumHorizontalAccuracy)
         case .relativeLineStringDistance(minimumHorizontalAccuracy: let minimumHorizontalAccuracy, automaticAdvanceDistance: let automaticAdvanceDistance):
             return .relativeLineStringDistance(minimumHorizontalAccuracy: minimumHorizontalAccuracy, automaticAdvanceDistance: automaticAdvanceDistance)
+        }
+    }
+}
+
+private class DetectorImpl: RouteDeviationDetector {
+    let detectorFunc: (UserLocation, Route, RouteStep) -> RouteDeviation
+
+    init(detectorFunc: @escaping (UserLocation, Route, RouteStep) -> RouteDeviation) {
+        self.detectorFunc = detectorFunc
+    }
+
+    func checkRouteDeviation(location: UniFFI.UserLocation, route: UniFFI.Route, currentRouteStep: UniFFI.RouteStep) -> UniFFI.RouteDeviation {
+        return detectorFunc(location, Route(inner: route), currentRouteStep)
+    }
+}
+
+/// A Swift wrapper around `UniFFI.RouteDeviationTracking`
+public enum RouteDeviationTracking {
+    case none
+
+    case staticThreshold(minimumHorizontalAccuracy: UInt16, maxAcceptableDeviation: Double)
+
+    case custom(detector: (UserLocation, Route, RouteStep) -> RouteDeviation)
+
+    var ffiValue: UniFFI.RouteDeviationTracking {
+        switch self {
+        case .none:
+            return .none
+        case .staticThreshold(minimumHorizontalAccuracy: let minimumHorizontalAccuracy, maxAcceptableDeviation: let maxAcceptableDeviation):
+            return .staticThreshold(minimumHorizontalAccuracy: minimumHorizontalAccuracy, maxAcceptableDeviation: maxAcceptableDeviation)
+        case .custom(detector: let detectorFunc):
+            return .custom(detector: DetectorImpl(detectorFunc: detectorFunc))
         }
     }
 }

--- a/apple/Sources/FerrostarCore/ModelWrappers.swift
+++ b/apple/Sources/FerrostarCore/ModelWrappers.swift
@@ -34,13 +34,13 @@ public struct Route {
 
 /// A Swift wrapper around `UniFFI.TripState`.
 public enum TripState {
-    case navigating(snappedUserLocation: CLLocation, remainingSteps: [UniFFI.RouteStep], distanceToNextManeuver: Double)
+    case navigating(snappedUserLocation: CLLocation, remainingSteps: [UniFFI.RouteStep], distanceToNextManeuver: CLLocationDistance, deviationFromRouteLine: CLLocationDistance?)
     case complete
 
     init(_ update: UniFFI.TripState) {
         switch (update) {
-        case .navigating(snappedUserLocation: let location, remainingSteps: let remainingSteps, distanceToNextManeuver: let distanceToNextManeuver):
-            self = .navigating(snappedUserLocation: CLLocation(userLocation: location), remainingSteps: remainingSteps, distanceToNextManeuver: distanceToNextManeuver)
+        case .navigating(snappedUserLocation: let location, remainingSteps: let remainingSteps, distanceToNextManeuver: let distanceToNextManeuver, deviationFromRouteLine: let deviationFromRouteLine):
+            self = .navigating(snappedUserLocation: CLLocation(userLocation: location), remainingSteps: remainingSteps, distanceToNextManeuver: distanceToNextManeuver, deviationFromRouteLine: deviationFromRouteLine)
         case .complete:
             self = .complete
         }

--- a/apple/Sources/FerrostarCore/ObservableState.swift
+++ b/apple/Sources/FerrostarCore/ObservableState.swift
@@ -15,7 +15,7 @@ public struct NavigationState {
     public internal(set) var visualInstructions: UniFFI.VisualInstruction?
     public internal(set) var spokenInstruction: UniFFI.SpokenInstruction?
     public internal(set) var distanceToNextManeuver: CLLocationDistance?
-    /// Set to true when the core is calculating a new route (ex: due to the user being off route).
+    /// Indicates when the core is calculating a new route (ex: due to the user being off route).
     public internal(set) var isCalculatingNewRoute: Bool = false
 
     init(snappedLocation: CLLocation, heading: CLHeading? = nil, fullRoute: [CLLocationCoordinate2D], steps: [RouteStep]) {

--- a/apple/Sources/FerrostarCore/ObservableState.swift
+++ b/apple/Sources/FerrostarCore/ObservableState.swift
@@ -15,7 +15,6 @@ public struct NavigationState {
     public internal(set) var visualInstructions: UniFFI.VisualInstruction?
     public internal(set) var spokenInstruction: UniFFI.SpokenInstruction?
     public internal(set) var distanceToNextManeuver: CLLocationDistance?
-    public internal(set) var deviationFromRouteLine: CLLocationDistance?
 
     init(snappedLocation: CLLocation, heading: CLHeading? = nil, fullRoute: [CLLocationCoordinate2D], steps: [RouteStep]) {
         self.snappedLocation = snappedLocation

--- a/apple/Sources/FerrostarCore/ObservableState.swift
+++ b/apple/Sources/FerrostarCore/ObservableState.swift
@@ -12,10 +12,11 @@ public struct NavigationState {
     public internal(set) var courseOverGround: CLLocationDirection?
     public internal(set) var fullRouteShape: [CLLocationCoordinate2D]
     public internal(set) var currentStep: UniFFI.RouteStep?
+    public internal(set) var remainingWaypoints: [CLLocationCoordinate2D]?
     public internal(set) var visualInstructions: UniFFI.VisualInstruction?
     public internal(set) var spokenInstruction: UniFFI.SpokenInstruction?
     public internal(set) var distanceToNextManeuver: CLLocationDistance?
-    /// Indicates when the core is calculating a new route (ex: due to the user being off route).
+    /// Indicates when the core is calculating a new route due to the user being off route
     public internal(set) var isCalculatingNewRoute: Bool = false
 
     init(snappedLocation: CLLocation, heading: CLHeading? = nil, fullRoute: [CLLocationCoordinate2D], steps: [RouteStep]) {

--- a/apple/Sources/FerrostarCore/ObservableState.swift
+++ b/apple/Sources/FerrostarCore/ObservableState.swift
@@ -15,6 +15,8 @@ public struct NavigationState {
     public internal(set) var visualInstructions: UniFFI.VisualInstruction?
     public internal(set) var spokenInstruction: UniFFI.SpokenInstruction?
     public internal(set) var distanceToNextManeuver: CLLocationDistance?
+    /// Set to true when the core is calculating a new route (ex: due to the user being off route).
+    public internal(set) var isCalculatingNewRoute: Bool = false
 
     init(snappedLocation: CLLocation, heading: CLHeading? = nil, fullRoute: [CLLocationCoordinate2D], steps: [RouteStep]) {
         self.snappedLocation = snappedLocation

--- a/apple/Sources/FerrostarCore/ObservableState.swift
+++ b/apple/Sources/FerrostarCore/ObservableState.swift
@@ -12,7 +12,6 @@ public struct NavigationState {
     public internal(set) var courseOverGround: CLLocationDirection?
     public internal(set) var fullRouteShape: [CLLocationCoordinate2D]
     public internal(set) var currentStep: UniFFI.RouteStep?
-    public internal(set) var remainingWaypoints: [CLLocationCoordinate2D]?
     public internal(set) var visualInstructions: UniFFI.VisualInstruction?
     public internal(set) var spokenInstruction: UniFFI.SpokenInstruction?
     public internal(set) var distanceToNextManeuver: CLLocationDistance?

--- a/apple/Sources/FerrostarCore/ObservableState.swift
+++ b/apple/Sources/FerrostarCore/ObservableState.swift
@@ -15,6 +15,7 @@ public struct NavigationState {
     public internal(set) var visualInstructions: UniFFI.VisualInstruction?
     public internal(set) var spokenInstruction: UniFFI.SpokenInstruction?
     public internal(set) var distanceToNextManeuver: CLLocationDistance?
+    public internal(set) var deviationFromRouteLine: CLLocationDistance?
 
     init(snappedLocation: CLLocation, heading: CLHeading? = nil, fullRoute: [CLLocationCoordinate2D], steps: [RouteStep]) {
         self.snappedLocation = snappedLocation

--- a/apple/Sources/UniFFI/ferrostar.swift
+++ b/apple/Sources/UniFFI/ferrostar.swift
@@ -425,12 +425,45 @@ private struct FfiConverterTimestamp: FfiConverterRustBuffer {
     }
 }
 
+/**
+ * Manages the navigation lifecycle of a route, reacting to inputs like user location updates
+ * and returning a new state.
+ * If you want to recalculate a new route, you need to create a new navigation controller.
+ *
+ * In the overall architecture, this is a mid-level construct. It wraps some lower
+ * level constructs like the route adapter, but a higher level wrapper handles things
+ * like feeding in user location updates, route recalculation behavior, etc.
+ */
 public protocol NavigationControllerProtocol: AnyObject {
+    /**
+     * Advances navigation to the next step.
+     *
+     * Depending on the advancement strategy, this may be automatic.
+     * For other cases, it is desirable to advance to the next step manually (ex: walking in an
+     * urban tunnel). We leave this decision to the app developer.
+     */
     func advanceToNextStep(state: TripState) -> TripState
+
+    /**
+     * Returns initial trip state as if the user had just started the route with no progress.
+     */
     func getInitialState(location: UserLocation) -> TripState
+
+    /**
+     * Updates the user's current location and updates the navigation state accordingly.
+     */
     func updateUserLocation(location: UserLocation, state: TripState) -> TripState
 }
 
+/**
+ * Manages the navigation lifecycle of a route, reacting to inputs like user location updates
+ * and returning a new state.
+ * If you want to recalculate a new route, you need to create a new navigation controller.
+ *
+ * In the overall architecture, this is a mid-level construct. It wraps some lower
+ * level constructs like the route adapter, but a higher level wrapper handles things
+ * like feeding in user location updates, route recalculation behavior, etc.
+ */
 public class NavigationController:
     NavigationControllerProtocol
 {
@@ -441,6 +474,10 @@ public class NavigationController:
     // make it `required` without making it `public`.
     required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_ferrostar_fn_clone_navigationcontroller(self.pointer, $0) }
     }
 
     public convenience init(route: Route, config: NavigationControllerConfig) {
@@ -456,31 +493,44 @@ public class NavigationController:
         try! rustCall { uniffi_ferrostar_fn_free_navigationcontroller(pointer, $0) }
     }
 
+    /**
+     * Advances navigation to the next step.
+     *
+     * Depending on the advancement strategy, this may be automatic.
+     * For other cases, it is desirable to advance to the next step manually (ex: walking in an
+     * urban tunnel). We leave this decision to the app developer.
+     */
     public func advanceToNextStep(state: TripState) -> TripState {
         return try! FfiConverterTypeTripState.lift(
             try!
                 rustCall {
-                    uniffi_ferrostar_fn_method_navigationcontroller_advance_to_next_step(self.pointer,
+                    uniffi_ferrostar_fn_method_navigationcontroller_advance_to_next_step(self.uniffiClonePointer(),
                                                                                          FfiConverterTypeTripState.lower(state), $0)
                 }
         )
     }
 
+    /**
+     * Returns initial trip state as if the user had just started the route with no progress.
+     */
     public func getInitialState(location: UserLocation) -> TripState {
         return try! FfiConverterTypeTripState.lift(
             try!
                 rustCall {
-                    uniffi_ferrostar_fn_method_navigationcontroller_get_initial_state(self.pointer,
+                    uniffi_ferrostar_fn_method_navigationcontroller_get_initial_state(self.uniffiClonePointer(),
                                                                                       FfiConverterTypeUserLocation.lower(location), $0)
                 }
         )
     }
 
+    /**
+     * Updates the user's current location and updates the navigation state accordingly.
+     */
     public func updateUserLocation(location: UserLocation, state: TripState) -> TripState {
         return try! FfiConverterTypeTripState.lift(
             try!
                 rustCall {
-                    uniffi_ferrostar_fn_method_navigationcontroller_update_user_location(self.pointer,
+                    uniffi_ferrostar_fn_method_navigationcontroller_update_user_location(self.uniffiClonePointer(),
                                                                                          FfiConverterTypeUserLocation.lower(location),
                                                                                          FfiConverterTypeTripState.lower(state), $0)
                 }
@@ -497,7 +547,7 @@ public struct FfiConverterTypeNavigationController: FfiConverter {
     }
 
     public static func lower(_ value: NavigationController) -> UnsafeMutableRawPointer {
-        return value.pointer
+        return value.uniffiClonePointer()
     }
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NavigationController {
@@ -526,11 +576,52 @@ public func FfiConverterTypeNavigationController_lower(_ value: NavigationContro
     return FfiConverterTypeNavigationController.lower(value)
 }
 
+/**
+ * The route adapter bridges between the common core and a routing backend.
+ *
+ * This is essentially the composite of the [RouteRequestGenerator] and [RouteResponseParser]
+ * traits, but it provides one further level of abstraction which is helpful to consumers.
+ * As there is no way to signal compatibility between request generators and response parsers,
+ * the [RouteAdapter] provides convenience constructors which take the guesswork out of it,
+ * while still leaving consumers free to implement one or both halves.
+ *
+ * In the future, we may provide additional methods or conveniences, and this
+ * indirection leaves the design open to such changes without necessarily breaking source
+ * compatibility.
+ * One such possible extension would be the ability to fetch more detailed attributes in real time.
+ * This is supported by the Valhalla stack, among others.
+ *
+ * Ideas  welcome re: how to signal compatibility between request generators and response parsers.
+ * I don't think we can do this in the type system, since one of the reasons for the split design
+ * is modularity, including the possibility of user-provided implementations, and these will not
+ * always be of a "known" type to the Rust side.
+ */
 public protocol RouteAdapterProtocol: AnyObject {
     func generateRequest(userLocation: UserLocation, waypoints: [GeographicCoordinate]) throws -> RouteRequest
+
     func parseResponse(response: Data) throws -> [Route]
 }
 
+/**
+ * The route adapter bridges between the common core and a routing backend.
+ *
+ * This is essentially the composite of the [RouteRequestGenerator] and [RouteResponseParser]
+ * traits, but it provides one further level of abstraction which is helpful to consumers.
+ * As there is no way to signal compatibility between request generators and response parsers,
+ * the [RouteAdapter] provides convenience constructors which take the guesswork out of it,
+ * while still leaving consumers free to implement one or both halves.
+ *
+ * In the future, we may provide additional methods or conveniences, and this
+ * indirection leaves the design open to such changes without necessarily breaking source
+ * compatibility.
+ * One such possible extension would be the ability to fetch more detailed attributes in real time.
+ * This is supported by the Valhalla stack, among others.
+ *
+ * Ideas  welcome re: how to signal compatibility between request generators and response parsers.
+ * I don't think we can do this in the type system, since one of the reasons for the split design
+ * is modularity, including the possibility of user-provided implementations, and these will not
+ * always be of a "known" type to the Rust side.
+ */
 public class RouteAdapter:
     RouteAdapterProtocol
 {
@@ -541,6 +632,10 @@ public class RouteAdapter:
     // make it `required` without making it `public`.
     required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
+    }
+
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_ferrostar_fn_clone_routeadapter(self.pointer, $0) }
     }
 
     public convenience init(requestGenerator: RouteRequestGenerator, responseParser: RouteResponseParser) {
@@ -568,7 +663,7 @@ public class RouteAdapter:
     public func generateRequest(userLocation: UserLocation, waypoints: [GeographicCoordinate]) throws -> RouteRequest {
         return try FfiConverterTypeRouteRequest.lift(
             rustCallWithError(FfiConverterTypeRoutingRequestGenerationError.lift) {
-                uniffi_ferrostar_fn_method_routeadapter_generate_request(self.pointer,
+                uniffi_ferrostar_fn_method_routeadapter_generate_request(self.uniffiClonePointer(),
                                                                          FfiConverterTypeUserLocation.lower(userLocation),
                                                                          FfiConverterSequenceTypeGeographicCoordinate.lower(waypoints), $0)
             }
@@ -578,7 +673,7 @@ public class RouteAdapter:
     public func parseResponse(response: Data) throws -> [Route] {
         return try FfiConverterSequenceTypeRoute.lift(
             rustCallWithError(FfiConverterTypeRoutingResponseParseError.lift) {
-                uniffi_ferrostar_fn_method_routeadapter_parse_response(self.pointer,
+                uniffi_ferrostar_fn_method_routeadapter_parse_response(self.uniffiClonePointer(),
                                                                        FfiConverterData.lower(response), $0)
             }
         )
@@ -594,7 +689,7 @@ public struct FfiConverterTypeRouteAdapter: FfiConverter {
     }
 
     public static func lower(_ value: RouteAdapter) -> UnsafeMutableRawPointer {
-        return value.pointer
+        return value.uniffiClonePointer()
     }
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RouteAdapter {
@@ -623,10 +718,39 @@ public func FfiConverterTypeRouteAdapter_lower(_ value: RouteAdapter) -> UnsafeM
     return FfiConverterTypeRouteAdapter.lower(value)
 }
 
+/**
+ * A trait describing any object capable of generating [RouteRequest]s.
+ *
+ * The interface is intentionally generic. Every routing backend has its own set of
+ * parameters, including a "profile," max travel speed, units of speed and distance, and more.
+ * It is assumed that these properties will be set at construction time or otherwise configured
+ * before use, so that we can keep the public interface as generic as possible.
+ *
+ * Implementations may be either in Rust (most popular engines should eventually have Rust
+ * implementations) or foreign code.
+ */
 public protocol RouteRequestGenerator: AnyObject {
+    /**
+     * Generates a routing backend request given the set of locations.
+     *
+     * While most implementations will treat the locations as an ordered sequence, this is not
+     * guaranteed (ex: an optimized router)..
+     * TODO: Option for whether we should account for course over ground or heading.
+     */
     func generateRequest(userLocation: UserLocation, waypoints: [GeographicCoordinate]) throws -> RouteRequest
 }
 
+/**
+ * A trait describing any object capable of generating [RouteRequest]s.
+ *
+ * The interface is intentionally generic. Every routing backend has its own set of
+ * parameters, including a "profile," max travel speed, units of speed and distance, and more.
+ * It is assumed that these properties will be set at construction time or otherwise configured
+ * before use, so that we can keep the public interface as generic as possible.
+ *
+ * Implementations may be either in Rust (most popular engines should eventually have Rust
+ * implementations) or foreign code.
+ */
 public class RouteRequestGeneratorImpl:
     RouteRequestGenerator
 {
@@ -639,14 +763,25 @@ public class RouteRequestGeneratorImpl:
         self.pointer = pointer
     }
 
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_ferrostar_fn_clone_routerequestgenerator(self.pointer, $0) }
+    }
+
     deinit {
         try! rustCall { uniffi_ferrostar_fn_free_routerequestgenerator(pointer, $0) }
     }
 
+    /**
+     * Generates a routing backend request given the set of locations.
+     *
+     * While most implementations will treat the locations as an ordered sequence, this is not
+     * guaranteed (ex: an optimized router)..
+     * TODO: Option for whether we should account for course over ground or heading.
+     */
     public func generateRequest(userLocation: UserLocation, waypoints: [GeographicCoordinate]) throws -> RouteRequest {
         return try FfiConverterTypeRouteRequest.lift(
             rustCallWithError(FfiConverterTypeRoutingRequestGenerationError.lift) {
-                uniffi_ferrostar_fn_method_routerequestgenerator_generate_request(self.pointer,
+                uniffi_ferrostar_fn_method_routerequestgenerator_generate_request(self.uniffiClonePointer(),
                                                                                   FfiConverterTypeUserLocation.lower(userLocation),
                                                                                   FfiConverterSequenceTypeGeographicCoordinate.lower(waypoints), $0)
             }
@@ -746,7 +881,7 @@ private let uniffiCallbackInterfaceRouteRequestGenerator: ForeignCallback = { (h
     switch method {
     case IDX_CALLBACK_FREE:
         FfiConverterTypeRouteRequestGenerator.handleMap.remove(handle: handle)
-        // Sucessful return
+        // Successful return
         // See docs of ForeignCallback in `uniffi_core/src/ffi/foreigncallbacks.rs`
         return UNIFFI_CALLBACK_SUCCESS
     case 1:
@@ -818,10 +953,24 @@ public func FfiConverterTypeRouteRequestGenerator_lower(_ value: RouteRequestGen
     return FfiConverterTypeRouteRequestGenerator.lower(value)
 }
 
+/**
+ * A generic interface describing any object capable of parsing a response from a routing
+ * backend into one or more [Route]s.
+ */
 public protocol RouteResponseParser: AnyObject {
+    /**
+     * Parses a raw response from the routing backend into a route.
+     *
+     * We use a sequence of octets as a common interchange format.
+     * as this works for all currently conceivable formats (JSON, PBF, etc.).
+     */
     func parseResponse(response: Data) throws -> [Route]
 }
 
+/**
+ * A generic interface describing any object capable of parsing a response from a routing
+ * backend into one or more [Route]s.
+ */
 public class RouteResponseParserImpl:
     RouteResponseParser
 {
@@ -834,14 +983,24 @@ public class RouteResponseParserImpl:
         self.pointer = pointer
     }
 
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_ferrostar_fn_clone_routeresponseparser(self.pointer, $0) }
+    }
+
     deinit {
         try! rustCall { uniffi_ferrostar_fn_free_routeresponseparser(pointer, $0) }
     }
 
+    /**
+     * Parses a raw response from the routing backend into a route.
+     *
+     * We use a sequence of octets as a common interchange format.
+     * as this works for all currently conceivable formats (JSON, PBF, etc.).
+     */
     public func parseResponse(response: Data) throws -> [Route] {
         return try FfiConverterSequenceTypeRoute.lift(
             rustCallWithError(FfiConverterTypeRoutingResponseParseError.lift) {
-                uniffi_ferrostar_fn_method_routeresponseparser_parse_response(self.pointer,
+                uniffi_ferrostar_fn_method_routeresponseparser_parse_response(self.uniffiClonePointer(),
                                                                               FfiConverterData.lower(response), $0)
             }
         )
@@ -874,7 +1033,7 @@ private let uniffiCallbackInterfaceRouteResponseParser: ForeignCallback = { (han
     switch method {
     case IDX_CALLBACK_FREE:
         FfiConverterTypeRouteResponseParser.handleMap.remove(handle: handle)
-        // Sucessful return
+        // Successful return
         // See docs of ForeignCallback in `uniffi_core/src/ffi/foreigncallbacks.rs`
         return UNIFFI_CALLBACK_SUCCESS
     case 1:
@@ -952,7 +1111,10 @@ public struct BoundingBox {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(sw: GeographicCoordinate, ne: GeographicCoordinate) {
+    public init(
+        sw: GeographicCoordinate,
+        ne: GeographicCoordinate
+    ) {
         self.sw = sw
         self.ne = ne
     }
@@ -998,13 +1160,33 @@ public func FfiConverterTypeBoundingBox_lower(_ value: BoundingBox) -> RustBuffe
     return FfiConverterTypeBoundingBox.lower(value)
 }
 
+/**
+ * The direction in which the user/device is observed to be traveling.
+ */
 public struct CourseOverGround {
+    /**
+     * The direction in which the user's device is traveling, measured in clockwise degrees from
+     * true north (N = 0, E = 90, S = 180, W = 270).
+     */
     public var degrees: UInt16
+    /**
+     * The accuracy of the course value, measured in degrees.
+     */
     public var accuracy: UInt16
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(degrees: UInt16, accuracy: UInt16) {
+    public init(
+        /**
+         * The direction in which the user's device is traveling, measured in clockwise degrees from
+         * true north (N = 0, E = 90, S = 180, W = 270).
+         */
+        degrees: UInt16,
+        /**
+            * The accuracy of the course value, measured in degrees.
+            */
+        accuracy: UInt16
+    ) {
         self.degrees = degrees
         self.accuracy = accuracy
     }
@@ -1056,7 +1238,10 @@ public struct GeographicCoordinate {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(lng: Double, lat: Double) {
+    public init(
+        lng: Double,
+        lat: Double
+    ) {
         self.lng = lng
         self.lat = lat
     }
@@ -1108,7 +1293,10 @@ public struct LocationSimulationState {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(currentLocation: GeographicCoordinate, remainingLocations: [GeographicCoordinate]) {
+    public init(
+        currentLocation: GeographicCoordinate,
+        remainingLocations: [GeographicCoordinate]
+    ) {
         self.currentLocation = currentLocation
         self.remainingLocations = remainingLocations
     }
@@ -1159,7 +1347,9 @@ public struct NavigationControllerConfig {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(stepAdvance: StepAdvanceMode) {
+    public init(
+        stepAdvance: StepAdvanceMode)
+    {
         self.stepAdvance = stepAdvance
     }
 }
@@ -1198,16 +1388,44 @@ public func FfiConverterTypeNavigationControllerConfig_lower(_ value: Navigation
     return FfiConverterTypeNavigationControllerConfig.lower(value)
 }
 
+/**
+ * Information describing the series of steps needed to travel between two or more points.
+ *
+ * NOTE: This type is unstable and is still under active development and should be
+ * considered unstable.
+ */
 public struct Route {
     public var geometry: [GeographicCoordinate]
     public var bbox: BoundingBox
+    /**
+     * The total route distance, in meters.
+     */
     public var distance: Double
+    /**
+     * The ordered list of waypoints to visit, including the starting point.
+     * Note that this is distinct from the *geometry* which includes all points visited.
+     * A waypoint represents a start/end point for a route leg.
+     */
     public var waypoints: [GeographicCoordinate]
     public var steps: [RouteStep]
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(geometry: [GeographicCoordinate], bbox: BoundingBox, distance: Double, waypoints: [GeographicCoordinate], steps: [RouteStep]) {
+    public init(
+        geometry: [GeographicCoordinate],
+        bbox: BoundingBox,
+        /**
+            * The total route distance, in meters.
+            */
+        distance: Double,
+        /**
+            * The ordered list of waypoints to visit, including the starting point.
+            * Note that this is distinct from the *geometry* which includes all points visited.
+            * A waypoint represents a start/end point for a route leg.
+            */
+        waypoints: [GeographicCoordinate],
+        steps: [RouteStep]
+    ) {
         self.geometry = geometry
         self.bbox = bbox
         self.distance = distance
@@ -1274,8 +1492,19 @@ public func FfiConverterTypeRoute_lower(_ value: Route) -> RustBuffer {
     return FfiConverterTypeRoute.lower(value)
 }
 
+/**
+ * A maneuver (such as a turn or merge) followed by travel of a certain distance until reaching
+ * the next step.
+ *
+ * NOTE: OSRM specifies this rather precisely as "travel along a single way to the subsequent step"
+ * but we will intentionally define this somewhat looser unless/until it becomes clear something
+
+ */
 public struct RouteStep {
     public var geometry: [GeographicCoordinate]
+    /**
+     * The distance, in meters, to travel along the route after the maneuver to reach the next step.
+     */
     public var distance: Double
     public var roadName: String?
     public var instruction: String
@@ -1284,7 +1513,17 @@ public struct RouteStep {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(geometry: [GeographicCoordinate], distance: Double, roadName: String?, instruction: String, visualInstructions: [VisualInstruction], spokenInstructions: [SpokenInstruction]) {
+    public init(
+        geometry: [GeographicCoordinate],
+        /**
+            * The distance, in meters, to travel along the route after the maneuver to reach the next step.
+            */
+        distance: Double,
+        roadName: String?,
+        instruction: String,
+        visualInstructions: [VisualInstruction],
+        spokenInstructions: [SpokenInstruction]
+    ) {
         self.geometry = geometry
         self.distance = distance
         self.roadName = roadName
@@ -1359,13 +1598,35 @@ public func FfiConverterTypeRouteStep_lower(_ value: RouteStep) -> RustBuffer {
 }
 
 public struct SpokenInstruction {
+    /**
+     * Plain-text instruction which can be synthesized with a TTS engine.
+     */
     public var text: String
+    /**
+     * Speech Synthesis Markup Language, which should be preferred by clients capable of understanding it.
+     */
     public var ssml: String?
+    /**
+     * How far (in meters) from the upcoming maneuver the instruction should start being displayed
+     */
     public var triggerDistanceBeforeManeuver: Double
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(text: String, ssml: String?, triggerDistanceBeforeManeuver: Double) {
+    public init(
+        /**
+         * Plain-text instruction which can be synthesized with a TTS engine.
+         */
+        text: String,
+        /**
+            * Speech Synthesis Markup Language, which should be preferred by clients capable of understanding it.
+            */
+        ssml: String?,
+        /**
+            * How far (in meters) from the upcoming maneuver the instruction should start being displayed
+            */
+        triggerDistanceBeforeManeuver: Double
+    ) {
         self.text = text
         self.ssml = ssml
         self.triggerDistanceBeforeManeuver = triggerDistanceBeforeManeuver
@@ -1418,15 +1679,32 @@ public func FfiConverterTypeSpokenInstruction_lower(_ value: SpokenInstruction) 
     return FfiConverterTypeSpokenInstruction.lower(value)
 }
 
+/**
+ * The location of the user that is navigating.
+ *
+ * In addition to coordinates, this includes estimated accuracy and course information,
+ * which can influence navigation logic and UI.
+ */
 public struct UserLocation {
     public var coordinates: GeographicCoordinate
+    /**
+     * The estimated accuracy of the coordinate (in meters)
+     */
     public var horizontalAccuracy: Double
     public var courseOverGround: CourseOverGround?
     public var timestamp: Date
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(coordinates: GeographicCoordinate, horizontalAccuracy: Double, courseOverGround: CourseOverGround?, timestamp: Date) {
+    public init(
+        coordinates: GeographicCoordinate,
+        /**
+            * The estimated accuracy of the coordinate (in meters)
+            */
+        horizontalAccuracy: Double,
+        courseOverGround: CourseOverGround?,
+        timestamp: Date
+    ) {
         self.coordinates = coordinates
         self.horizontalAccuracy = horizontalAccuracy
         self.courseOverGround = courseOverGround
@@ -1489,11 +1767,21 @@ public func FfiConverterTypeUserLocation_lower(_ value: UserLocation) -> RustBuf
 public struct VisualInstruction {
     public var primaryContent: VisualInstructionContent
     public var secondaryContent: VisualInstructionContent?
+    /**
+     * How far (in meters) from the upcoming maneuver the instruction should start being displayed
+     */
     public var triggerDistanceBeforeManeuver: Double
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(primaryContent: VisualInstructionContent, secondaryContent: VisualInstructionContent?, triggerDistanceBeforeManeuver: Double) {
+    public init(
+        primaryContent: VisualInstructionContent,
+        secondaryContent: VisualInstructionContent?,
+        /**
+            * How far (in meters) from the upcoming maneuver the instruction should start being displayed
+            */
+        triggerDistanceBeforeManeuver: Double
+    ) {
         self.primaryContent = primaryContent
         self.secondaryContent = secondaryContent
         self.triggerDistanceBeforeManeuver = triggerDistanceBeforeManeuver
@@ -1554,7 +1842,12 @@ public struct VisualInstructionContent {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(text: String, maneuverType: ManeuverType?, maneuverModifier: ManeuverModifier?, roundaboutExitDegrees: UInt16?) {
+    public init(
+        text: String,
+        maneuverType: ManeuverType?,
+        maneuverModifier: ManeuverModifier?,
+        roundaboutExitDegrees: UInt16?
+    ) {
         self.text = text
         self.maneuverType = maneuverType
         self.maneuverModifier = maneuverModifier
@@ -1616,6 +1909,9 @@ public func FfiConverterTypeVisualInstructionContent_lower(_ value: VisualInstru
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * Specifies additional information about a [ManeuverType]
+ */
 public enum ManeuverModifier {
     case uTurn
     case sharpRight
@@ -1694,6 +1990,11 @@ extension ManeuverModifier: Equatable, Hashable {}
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * Indicates the type of maneuver to perform.
+ *
+ * Frequently used in conjunction with [ManeuverModifier].
+ */
 public enum ManeuverType {
     case turn
     case newName
@@ -1819,7 +2120,9 @@ public func FfiConverterTypeManeuverType_lower(_ value: ManeuverType) -> RustBuf
 extension ManeuverType: Equatable, Hashable {}
 
 public enum ModelError {
-    case PolylineGenerationError(error: String)
+    case PolylineGenerationError(
+        error: String
+    )
 
     fileprivate static func uniffiErrorHandler(_ error: RustBuffer) throws -> Error {
         return try FfiConverterTypeModelError.lift(error)
@@ -1855,8 +2158,15 @@ extension ModelError: Error {}
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * A route request generated by a [RouteRequestGenerator].
+ */
 public enum RouteRequest {
-    case httpPost(url: String, headers: [String: String], body: Data)
+    case httpPost(
+        url: String,
+        headers: [String: String],
+        body: Data
+    )
 }
 
 public struct FfiConverterTypeRouteRequest: FfiConverterRustBuffer {
@@ -1939,7 +2249,9 @@ extension RoutingRequestGenerationError: Equatable, Hashable {}
 extension RoutingRequestGenerationError: Error {}
 
 public enum RoutingResponseParseError {
-    case ParseError(error: String)
+    case ParseError(
+        error: String
+    )
     case UnknownError
 
     fileprivate static func uniffiErrorHandler(_ error: RustBuffer) throws -> Error {
@@ -1979,7 +2291,9 @@ extension RoutingResponseParseError: Equatable, Hashable {}
 extension RoutingResponseParseError: Error {}
 
 public enum SimulationError {
-    case PolylineError(error: String)
+    case PolylineError(
+        error: String
+    )
     case NotEnoughPoints
 
     fileprivate static func uniffiErrorHandler(_ error: RustBuffer) throws -> Error {
@@ -2021,6 +2335,9 @@ extension SimulationError: Error {}
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 public enum SimulationSpeed {
+    /**
+     * Jumps directly to the next location without any interpolation
+     */
     case jumpToNextLocation
 }
 
@@ -2057,9 +2374,40 @@ extension SimulationSpeed: Equatable, Hashable {}
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 public enum StepAdvanceMode {
+    /**
+     * Never advances to the next step automatically
+     */
     case manual
-    case distanceToEndOfStep(distance: UInt16, minimumHorizontalAccuracy: UInt16)
-    case relativeLineStringDistance(minimumHorizontalAccuracy: UInt16, automaticAdvanceDistance: UInt16?)
+    /**
+     * Automatically advances when the user's location is close enough to the end of the step
+     */
+    case distanceToEndOfStep(
+        /**
+         * Distance to the last waypoint in the step, measured in meters, at which to advance.
+         */
+        distance: UInt16,
+        /**
+            * The minimum required horizontal accuracy of the user location.
+            * Values larger than this cannot trigger a step advance.
+            */
+        minimumHorizontalAccuracy: UInt16
+    )
+    /**
+     * Automatically advances when the user's distance to the *next* step's linestring  is less
+     * than the distance to the current step's linestring.
+     */
+    case relativeLineStringDistance(
+        /**
+         * The minimum required horizontal accuracy of the user location.
+         * Values larger than this cannot trigger a step advance.
+         */
+        minimumHorizontalAccuracy: UInt16,
+        /**
+            * At this (optional) distance, navigation should advance to the next step regardless
+            * of which LineString appears closer.
+            */
+        automaticAdvanceDistance: UInt16?
+    )
 }
 
 public struct FfiConverterTypeStepAdvanceMode: FfiConverterRustBuffer {
@@ -2114,8 +2462,27 @@ extension StepAdvanceMode: Equatable, Hashable {}
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * Internal state of the navigation controller.
+ */
 public enum TripState {
-    case navigating(snappedUserLocation: UserLocation, remainingSteps: [RouteStep], distanceToNextManeuver: Double, deviationFromRouteLine: Double?)
+    case navigating(
+        snappedUserLocation: UserLocation,
+        /**
+            * The ordered list of steps that remain in the trip.
+            * The step at the front of the list is always the current step.
+            * We currently assume that you cannot move backward to a previous step.
+            */
+        remainingSteps: [RouteStep],
+        /**
+            * The distance to the next maneuver, in meters.
+            */
+        distanceToNextManeuver: Double,
+        /**
+            * The deviation of the user from the expected route line.
+            */
+        deviationFromRouteLine: Double?
+    )
     case complete
 }
 
@@ -2443,6 +2810,16 @@ private struct FfiConverterDictionaryStringString: FfiConverterRustBuffer {
     }
 }
 
+/**
+ * Returns the next simulation state based on the desired strategy.
+ * Results of this can be thought of like a stream from a generator function.
+ *
+ * This function is intended to be called once/second.
+ * However, the caller may vary speed to purposefully replay at a faster rate
+ * (ex: calling 3x per second will be a triple speed simulation).
+ *
+ * When there are now more locations to visit, returns the same state forever.
+ */
 public func advanceLocationSimulation(state: LocationSimulationState, speed: SimulationSpeed) -> LocationSimulationState {
     return try! FfiConverterTypeLocationSimulationState.lift(
         try! rustCall {
@@ -2475,6 +2852,11 @@ public func createValhallaRequestGenerator(endpointUrl: String, profile: String)
     )
 }
 
+/**
+ * Helper function for getting the route as an encoded polyline.
+ *
+ * Mostly used for debugging.
+ */
 public func getRoutePolyline(route: Route, precision: UInt32) throws -> String {
     return try FfiConverterString.lift(
         rustCallWithError(FfiConverterTypeModelError.lift) {
@@ -2533,55 +2915,55 @@ private var initializationResult: InitializationResult {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
-    if uniffi_ferrostar_checksum_func_advance_location_simulation() != 31818 {
+    if uniffi_ferrostar_checksum_func_advance_location_simulation() != 44291 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_func_create_osrm_response_parser() != 37676 {
+    if uniffi_ferrostar_checksum_func_create_osrm_response_parser() != 10648 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_func_create_valhalla_request_generator() != 42515 {
+    if uniffi_ferrostar_checksum_func_create_valhalla_request_generator() != 14703 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_func_get_route_polyline() != 7053 {
+    if uniffi_ferrostar_checksum_func_get_route_polyline() != 53320 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_func_location_simulation_from_coordinates() != 32668 {
+    if uniffi_ferrostar_checksum_func_location_simulation_from_coordinates() != 36441 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_func_location_simulation_from_polyline() != 33402 {
+    if uniffi_ferrostar_checksum_func_location_simulation_from_polyline() != 51577 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_func_location_simulation_from_route() != 52353 {
+    if uniffi_ferrostar_checksum_func_location_simulation_from_route() != 1344 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_method_navigationcontroller_advance_to_next_step() != 5714 {
+    if uniffi_ferrostar_checksum_method_navigationcontroller_advance_to_next_step() != 50206 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_method_navigationcontroller_get_initial_state() != 22778 {
+    if uniffi_ferrostar_checksum_method_navigationcontroller_get_initial_state() != 48874 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_method_navigationcontroller_update_user_location() != 19022 {
+    if uniffi_ferrostar_checksum_method_navigationcontroller_update_user_location() != 60529 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_method_routeadapter_generate_request() != 35986 {
+    if uniffi_ferrostar_checksum_method_routeadapter_generate_request() != 39525 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_method_routeadapter_parse_response() != 29808 {
+    if uniffi_ferrostar_checksum_method_routeadapter_parse_response() != 39819 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_method_routerequestgenerator_generate_request() != 34771 {
+    if uniffi_ferrostar_checksum_method_routerequestgenerator_generate_request() != 837 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_method_routeresponseparser_parse_response() != 30875 {
+    if uniffi_ferrostar_checksum_method_routeresponseparser_parse_response() != 38851 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_constructor_navigationcontroller_new() != 26294 {
+    if uniffi_ferrostar_checksum_constructor_navigationcontroller_new() != 29000 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_constructor_routeadapter_new() != 22742 {
+    if uniffi_ferrostar_checksum_constructor_routeadapter_new() != 15081 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_constructor_routeadapter_new_valhalla_http() != 34303 {
+    if uniffi_ferrostar_checksum_constructor_routeadapter_new_valhalla_http() != 24553 {
         return InitializationResult.apiChecksumMismatch
     }
 

--- a/apple/Sources/UniFFI/ferrostar.swift
+++ b/apple/Sources/UniFFI/ferrostar.swift
@@ -945,8 +945,7 @@ public protocol RouteRequestGenerator: AnyObject {
      * Generates a routing backend request given the set of locations.
      *
      * While most implementations will treat the locations as an ordered sequence, this is not
-     * guaranteed (ex: an optimized router)..
-     * TODO: Option for whether we should account for course over ground or heading.
+     * guaranteed (ex: an optimized router).
      */
     func generateRequest(userLocation: UserLocation, waypoints: [GeographicCoordinate]) throws -> RouteRequest
 }
@@ -986,8 +985,7 @@ public class RouteRequestGeneratorImpl:
      * Generates a routing backend request given the set of locations.
      *
      * While most implementations will treat the locations as an ordered sequence, this is not
-     * guaranteed (ex: an optimized router)..
-     * TODO: Option for whether we should account for course over ground or heading.
+     * guaranteed (ex: an optimized router).
      */
     public func generateRequest(userLocation: UserLocation, waypoints: [GeographicCoordinate]) throws -> RouteRequest {
         return try FfiConverterTypeRouteRequest.lift(
@@ -2750,6 +2748,9 @@ public enum TripState {
             * The distance to the next maneuver, in meters.
             */
         distanceToNextManeuver: Double,
+        /**
+            * The route deviation status: is the user following the route or not?
+            */
         deviation: RouteDeviation
     )
     case complete
@@ -3202,7 +3203,7 @@ private var initializationResult: InitializationResult {
     if uniffi_ferrostar_checksum_method_routedeviationdetector_check_route_deviation() != 17675 {
         return InitializationResult.apiChecksumMismatch
     }
-    if uniffi_ferrostar_checksum_method_routerequestgenerator_generate_request() != 837 {
+    if uniffi_ferrostar_checksum_method_routerequestgenerator_generate_request() != 33758 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_ferrostar_checksum_method_routeresponseparser_parse_response() != 38851 {

--- a/apple/Tests/FerrostarCoreTests/FerrostarCoreTests.swift
+++ b/apple/Tests/FerrostarCoreTests/FerrostarCoreTests.swift
@@ -74,7 +74,7 @@ final class FerrostarCoreTests: XCTestCase {
         assertSnapshot(of: routes, as: .dump)
     }
 
-    func testCustomOffRouteHandler() async throws {
+    func testCustomRouteDeviationHandler() async throws {
         let routeDeviationCallbackExp = expectation(description: "The delegate should receive a callback that the user has deviated from the route")
         routeDeviationCallbackExp.expectedFulfillmentCount = 1
 

--- a/apple/Tests/FerrostarCoreTests/FerrostarCoreTests.swift
+++ b/apple/Tests/FerrostarCoreTests/FerrostarCoreTests.swift
@@ -97,19 +97,15 @@ final class FerrostarCoreTests: XCTestCase {
                 self.loadedAltRoutesExp = loadedAltRoutesExp
             }
 
-            func core(_ core: FerrostarCore, locationManagerFailedWithError error: Error) {
-                // Do nothing
-            }
-
-            func core(_ core: FerrostarCore, correctiveActionForDeviation deviationInMeters: Double) -> CorrectiveAction {
+            func core(_ core: FerrostarCore, correctiveActionForDeviation deviationInMeters: Double, remainingWaypoints waypoints: [CLLocationCoordinate2D]) -> CorrectiveAction {
                 XCTAssertEqual(deviationInMeters, 42)
                 self.routeDeviationCallbackExp.fulfill()
-                return .getNewRoutes(waypoints: [CLLocationCoordinate2D(latitude: 60.5349908, longitude: -149.5485806)])
+                return .getNewRoutes(waypoints: waypoints)
             }
 
-            func core(_ core: FerrostarCore, loadedAlternateRoutes: [Route]) {
+            func core(_ core: FerrostarCore, loadedAlternateRoutes routes: [Route]) {
                 XCTAssert(core.state?.isCalculatingNewRoute == true)  // We are still calculating until this method completes
-                XCTAssert(!loadedAlternateRoutes.isEmpty)
+                XCTAssert(!routes.isEmpty)
                 self.loadedAltRoutesExp.fulfill()
             }
         }

--- a/apple/Tests/FerrostarCoreTests/ValhallaCoreTests.swift
+++ b/apple/Tests/FerrostarCoreTests/ValhallaCoreTests.swift
@@ -8,12 +8,11 @@ import XCTest
 import SnapshotTesting
 
 final class ValhallaCoreTests: XCTestCase {
-    @MainActor
     func testValhallaRouteParsing() async throws {
         let mockSession = MockURLSession()
         mockSession.registerMock(forURL: valhallaEndpointUrl, withData: sampleRouteData, andResponse: successfulJSONResponse)
 
-        let core = FerrostarCore(valhallaEndpointUrl: valhallaEndpointUrl, profile: "auto", locationManager: SimulatedLocationProvider(), networkSession: mockSession)
+        let core = FerrostarCore(valhallaEndpointUrl: valhallaEndpointUrl, profile: "auto", locationProvider: SimulatedLocationProvider(), networkSession: mockSession)
         let routes = try await core.getRoutes(initialLocation: CLLocation(latitude: 60.5347155, longitude: -149.543469), waypoints: [CLLocationCoordinate2D(latitude: 60.5349908, longitude: -149.5485806)])
 
         assertSnapshot(of: routes, as: .dump)

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -22,9 +22,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "approx"
@@ -240,9 +240,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.0"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.0"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -482,9 +482,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "insta"
-version = "1.34.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc"
+checksum = "7c985c1bef99cf13c58fade470483d81a2bfe846ebde60ed28cc2dddec2df9e2"
 dependencies = [
  "console",
  "lazy_static",
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "scopeguard"
@@ -816,27 +816,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -919,9 +919,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
  "smawk",
  "unicode-linebreak",
@@ -1201,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1216,45 +1216,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "yaml-rust"

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -184,12 +184,6 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
@@ -217,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
 dependencies = [
  "serde",
 ]
@@ -246,9 +240,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -256,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
@@ -268,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -280,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -320,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "encode_unicode"
@@ -413,11 +407,11 @@ dependencies = [
 
 [[package]]
 name = "geographiclib-rs"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea804e7bd3c6a4ca6a01edfa35231557a8a81d4d3f3e1e2b650d028c42592be"
+checksum = "e6e5ed84f8089c70234b0a8e0aedb6dc733671612ddc0d37c6066052f9781960"
 dependencies = [
- "lazy_static",
+ "libm",
 ]
 
 [[package]]
@@ -601,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -665,7 +659,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.2",
+ "bitflags",
  "lazy_static",
  "num-traits",
  "rand",
@@ -732,15 +726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,7 +763,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -928,9 +913,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
@@ -945,13 +930,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys",
 ]
@@ -969,18 +953,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -15,15 +15,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,15 +239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,19 +383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "windows",
-]
-
-[[package]]
 name = "geo"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,9 +439,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
 dependencies = [
  "log",
  "plain",
@@ -593,29 +562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "loom"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
-dependencies = [
- "cfg-if",
- "generator",
- "pin-utils",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,16 +600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,37 +616,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "oneshot"
+name = "oneshot-uniffi"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6640c6bda7731b1fdbab747981a0f896dd1fedaf9f4a53fa237a04a84431f4"
-dependencies = [
- "loom",
-]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+checksum = "6c548d5c78976f6955d72d0ced18c48ca07030f7a1d4024529fedd7c1c01b29c"
 
 [[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plain"
@@ -756,7 +671,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.2",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -826,44 +741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata 0.4.3",
- "regex-syntax 0.8.2",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.8.2",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,12 +786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,12 +804,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,18 +811,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1005,15 +870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "similar"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +886,12 @@ name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "spade"
@@ -1095,6 +957,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,83 +988,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
-dependencies = [
- "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -1216,9 +1018,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
 name = "uniffi"
-version = "0.25.2"
-source = "git+https://github.com/mozilla/uniffi-rs/?rev=fbc6631953a889c7af6e5f1af94de9242589b75b#fbc6631953a889c7af6e5f1af94de9242589b75b"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
 dependencies = [
  "anyhow",
  "camino",
@@ -1238,8 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.25.2"
-source = "git+https://github.com/mozilla/uniffi-rs/?rev=fbc6631953a889c7af6e5f1af94de9242589b75b#fbc6631953a889c7af6e5f1af94de9242589b75b"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab31006ab9c9c6870739f0e74235729d1478d82e73571b8f53c25aa176d67535"
 dependencies = [
  "anyhow",
  "askama",
@@ -1253,6 +1069,7 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
+ "textwrap",
  "toml",
  "uniffi_meta",
  "uniffi_testing",
@@ -1261,8 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.25.2"
-source = "git+https://github.com/mozilla/uniffi-rs/?rev=fbc6631953a889c7af6e5f1af94de9242589b75b#fbc6631953a889c7af6e5f1af94de9242589b75b"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
 dependencies = [
  "anyhow",
  "camino",
@@ -1271,8 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.25.2"
-source = "git+https://github.com/mozilla/uniffi-rs/?rev=fbc6631953a889c7af6e5f1af94de9242589b75b#fbc6631953a889c7af6e5f1af94de9242589b75b"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
 dependencies = [
  "quote",
  "syn",
@@ -1280,23 +1099,25 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.25.2"
-source = "git+https://github.com/mozilla/uniffi-rs/?rev=fbc6631953a889c7af6e5f1af94de9242589b75b#fbc6631953a889c7af6e5f1af94de9242589b75b"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d6e8db3f4e558faf0e25ac4b5bd775567973a4e18809f1123e74de52a853692"
 dependencies = [
  "anyhow",
  "bytes",
  "camino",
  "log",
  "once_cell",
- "oneshot",
+ "oneshot-uniffi",
  "paste",
  "static_assertions",
 ]
 
 [[package]]
 name = "uniffi_macros"
-version = "0.25.2"
-source = "git+https://github.com/mozilla/uniffi-rs/?rev=fbc6631953a889c7af6e5f1af94de9242589b75b#fbc6631953a889c7af6e5f1af94de9242589b75b"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
 dependencies = [
  "bincode",
  "camino",
@@ -1313,8 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.25.2"
-source = "git+https://github.com/mozilla/uniffi-rs/?rev=fbc6631953a889c7af6e5f1af94de9242589b75b#fbc6631953a889c7af6e5f1af94de9242589b75b"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f64a99e905671738d9d293f9cce58708ce1af8e13ea29f9d6b6925114fc2e85"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1324,8 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.25.2"
-source = "git+https://github.com/mozilla/uniffi-rs/?rev=fbc6631953a889c7af6e5f1af94de9242589b75b#fbc6631953a889c7af6e5f1af94de9242589b75b"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdca5719a22edf34c8239cc6ac9e3906d7ebc2a3e8a5e6ece4c3dffc312a4251"
 dependencies = [
  "anyhow",
  "camino",
@@ -1336,10 +1159,12 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.25.2"
-source = "git+https://github.com/mozilla/uniffi-rs/?rev=fbc6631953a889c7af6e5f1af94de9242589b75b#fbc6631953a889c7af6e5f1af94de9242589b75b"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
 dependencies = [
  "anyhow",
+ "textwrap",
  "uniffi_meta",
  "uniffi_testing",
  "weedle2",
@@ -1350,12 +1175,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -1380,41 +1199,11 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "weedle2"
-version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs/?rev=fbc6631953a889c7af6e5f1af94de9242589b75b#fbc6631953a889c7af6e5f1af94de9242589b75b"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -36,43 +36,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "approx"
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.12.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0fc7dcf8bd4ead96b1d36b41df47c14beedf7b0301fc543d8f2384e66a2ec0"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -117,9 +117,9 @@ checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "askama_parser"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c268a96e01a4c47c8c5c2472aaa570707e006a875ea63e819f75474ceedaf7b4"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
 dependencies = [
  "nom",
 ]
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
@@ -151,9 +151,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2139706359229bfa8f19142ac1155b4b80beafb7a60471ac5dd109d4a19778"
+checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
 dependencies = [
  "serde",
 ]
@@ -190,9 +190,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "byteorder"
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
+checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
 dependencies = [
  "serde",
 ]
@@ -246,9 +246,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -292,14 +292,14 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -332,12 +332,12 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "lazy_static"
@@ -523,9 +523,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -541,9 +541,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -563,9 +563,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "mime"
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oneshot-uniffi"
@@ -650,9 +650,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -665,7 +665,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
  "rand",
@@ -685,9 +685,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -774,15 +774,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "scopeguard"
@@ -831,27 +831,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
 name = "siphasher"
@@ -883,9 +883,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smawk"
@@ -895,9 +895,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "spade"
-version = "2.5.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd774eb23cff002036706e6ea83c3f4ab4c80dad89da76fe16d49f77ab71682f"
+checksum = "61addf9117b11d1f5b4bf6fe94242ba25f59d2d4b2080544b771bd647024fd00"
 dependencies = [
  "hashbrown",
  "num-traits",
@@ -934,9 +934,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -945,15 +945,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -969,18 +969,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1208,135 +1208,69 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "yaml-rust"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,4 +15,4 @@ lto = "thin"
 opt-level = "s"
 
 [workspace.dependencies]
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "fbc6631953a889c7af6e5f1af94de9242589b75b" }
+uniffi = "0.26.1"

--- a/common/build-ios.sh
+++ b/common/build-ios.sh
@@ -33,6 +33,7 @@ fat_simulator_lib_dir="target/ios-simulator-fat/release"
 generate_ffi() {
   echo "Generating framework module mapping and FFI bindings"
   cargo run -p uniffi-bindgen generate --library target/aarch64-apple-ios/release/lib$1.dylib --language swift --out-dir target/uniffi-xcframework-staging
+  mkdir -p ../apple/Sources/UniFFI/
   mv target/uniffi-xcframework-staging/*.swift ../apple/Sources/UniFFI/
   mv target/uniffi-xcframework-staging/$1FFI.modulemap target/uniffi-xcframework-staging/module.modulemap  # Convention requires this have a specific name
 }

--- a/common/ferrostar/Cargo.toml
+++ b/common/ferrostar/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Ian Wagner <ian@stadiamaps.com>", "Luke Seelenbinder <luke@stadiamap
 license = "BSD-3-Clause"
 repository = "https://github.com/stadiamaps/ferrostar"
 readme = "README.md"
-description = "The common core of Ferrostar, a modern mobile navigation SDK."
-keywords = ["navigation", "routing", "osrm"]
+description = "The core of modern turn-by-turn navigation."
+keywords = ["navigation", "routing", "valhalla", "osrm"]
 categories = ["science::geo"]
 edition = "2021"
 

--- a/common/ferrostar/proptest-regressions/algorithms.txt
+++ b/common/ferrostar/proptest-regressions/algorithms.txt
@@ -1,0 +1,12 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc e830f216364740386e849cf6a4874725c10ae0aeb155fe9a3c01a21c1868a197 # shrinks to x1 = 0.0, y1 = 0.0, x2 = 0.0, y2 = 0.0, x3 = 0.0, y3 = 0.0, has_next_step = true, distance = 0, minimum_horizontal_accuracy = 0, excess_inaccuracy = 0.0, automatic_advance_distance = None
+cc 4cf168ed167545f9b4b305549366a172eeb019901a89ab8f5cea84540df78987 # shrinks to x1 = 0.0, y1 = 0.0, x2 = 0.0, y2 = -0.0
+cc 1b4c40e1180426c77236313e68f0adbb9e7549819920bf38e5a19c69ef7afdf7 # shrinks to x1 = 1.223530337324287e-308, y1 = -0.0, x2 = -1.4734502574081931e29, y2 = 0.0
+cc d553bd94070bed8e00cdb0dd89db23e378f33051161a8013b956007488f2116e # shrinks to x1 = 1.4807726584113844e222, y1 = 7.616422804810974e-309, x2 = 0.0, y2 = -1.1133474666002946e254
+cc 08a3370b3e481e130a11a6a81deed2d5a2d30341a7edeadb7e18517cf638897f # shrinks to x1 = 1.126875786678146e-308, y1 = 0.0, x2 = 5.235085749133708e-29, y2 = -0.0
+cc 9343327e3112d7e3337bda8d95349a10f7882025f43fa76201929eba8deaa87d # shrinks to x1 = 0.0003739224474886329, y1 = 2.15972600670539e-309, x2 = 0.0, y2 = 3.234338053641099e-10

--- a/common/ferrostar/proptest-regressions/deviation_detection.txt
+++ b/common/ferrostar/proptest-regressions/deviation_detection.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d19dfb8bb824e1998c294918ba29b381a618582acf362e3d02a1d0dfe895905b # shrinks to x1 = 0.0, y1 = 0.0, x2 = 0.0, y2 = 0.0

--- a/common/ferrostar/proptest-regressions/deviation_detection.txt
+++ b/common/ferrostar/proptest-regressions/deviation_detection.txt
@@ -5,3 +5,7 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc d19dfb8bb824e1998c294918ba29b381a618582acf362e3d02a1d0dfe895905b # shrinks to x1 = 0.0, y1 = 0.0, x2 = 0.0, y2 = 0.0
+cc 08b20ce6b7b9499cd1f5af1ae15367d83ac5cbc09fadb8fa770409488b07b221 # shrinks to x1 = 0.0, y1 = 4.233089928589958e162, x2 = 0.0, y2 = 0.0, x3 = 0.0, y3 = 0.0, minimum_horizontal_accuracy = 0, horizontal_accuracy = 0.0, max_acceptable_deviation = 0.0
+cc 95479b0b7c128061cc6df61a29d7fbe49d764e2b9aba59dafed3ba0275ddedb1 # shrinks to x1 = -0.0, y1 = 0.0, x2 = 0.0, y2 = -1.4717756057562962e265, x3 = 0.0, y3 = 0.0, minimum_horizontal_accuracy = 0, horizontal_accuracy = 0.0, max_acceptable_deviation = -1.335008194259936e-309
+cc 41c5ca5f4d7617534b9442c23630813e94d092cd3146f8efe62e631508432eaf # shrinks to x1 = 0.0, y1 = 0.0, x2 = 0.0, y2 = -1.458929417498442e62, x3 = 0.0, y3 = 0.0, minimum_horizontal_accuracy = 0, horizontal_accuracy = 0.0, max_acceptable_deviation = -2.7106463905954037e138
+cc 4db52b6397185441487a1bb53b328248213c2ccdbe2e71cff963ac2be6627d51 # shrinks to x1 = 3.533686378944801e119, y1 = -0.0, x2 = 0.0, y2 = -5.457510912428616e-15, x3 = 0.0, y3 = 2.1562926009690472e64, minimum_horizontal_accuracy = 0, horizontal_accuracy = 0.0, max_acceptable_deviation = 0.0

--- a/common/ferrostar/src/algorithms.rs
+++ b/common/ferrostar/src/algorithms.rs
@@ -1,5 +1,8 @@
 use crate::models::{GeographicCoordinate, RouteStep, UserLocation};
-use geo::{Closest, ClosestPoint, EuclideanDistance, HaversineDistance, HaversineLength, LineLocatePoint, LineString, Point};
+use geo::{
+    Closest, ClosestPoint, EuclideanDistance, HaversineDistance, HaversineLength, LineLocatePoint,
+    LineString, Point,
+};
 
 use crate::navigation_controller::models::{
     StepAdvanceMode, StepAdvanceStatus,
@@ -8,9 +11,10 @@ use crate::navigation_controller::models::{
 
 #[cfg(test)]
 use {
-    crate::navigation_controller::test_helpers::gen_dummy_route_step, proptest::prelude::*,
-    std::time::SystemTime,
+    crate::navigation_controller::test_helpers::gen_dummy_route_step,
     geo::{coord, point},
+    proptest::prelude::*,
+    std::time::SystemTime,
 };
 
 /// Snaps a user location to the closest point on a route line.
@@ -34,15 +38,19 @@ fn snap_point_to_line(point: &Point, line: &LineString) -> Option<Point> {
     match line.closest_point(point) {
         Closest::Intersection(snapped) | Closest::SinglePoint(snapped) => {
             let (x, y) = (snapped.x(), snapped.y());
-            if x.is_nan() || x.is_subnormal() || x.is_infinite() || y.is_nan() || y.is_subnormal() || y.is_infinite() {
+            if x.is_nan()
+                || x.is_subnormal()
+                || x.is_infinite()
+                || y.is_nan()
+                || y.is_subnormal()
+                || y.is_infinite()
+            {
                 None
             } else {
                 Some(snapped)
             }
-        },
-        Closest::Indeterminate => {
-            None
-        },
+        }
+        Closest::Indeterminate => None,
     }
 }
 
@@ -171,8 +179,8 @@ pub fn should_advance_to_next_step(
 /// including dropping a completed step.
 /// This function is safe and idempotent in the case that it is accidentally
 /// invoked with no remaining steps.
-pub fn advance_step(remaining_steps: &[RouteStep]) -> StepAdvanceStatus {
-    // NOTE: The first item is the *current* step and we want the *next* step.
+pub(crate) fn advance_step(remaining_steps: &[RouteStep]) -> StepAdvanceStatus {
+    // NOTE: The first item is the *current* step, and we want the *next* step.
     match remaining_steps.get(1) {
         Some(new_step) => Advanced {
             step: new_step.clone(),

--- a/common/ferrostar/src/deviation_detection.rs
+++ b/common/ferrostar/src/deviation_detection.rs
@@ -1,0 +1,96 @@
+use crate::models::{Route, RouteStep, UserLocation};
+use crate::navigation_controller::algorithms::deviation_from_line;
+use geo::Point;
+use std::sync::Arc;
+
+#[derive(Clone, uniffi::Enum)]
+pub enum RouteDeviationTracking {
+    /// No checks will be done, and we assume the user is always following the route.
+    None,
+    StaticThreshold {
+        /// The minimum required horizontal accuracy of the user location, in meters.
+        /// Values larger than this will not trigger route deviation warnings.
+        minimum_horizontal_accuracy: u16,
+        /// The maximum acceptable deviation from the route line, in meters.
+        ///
+        /// If the distance between the reported location and the expected route line
+        /// is greater than this threshold, it will be flagged as an off route condition.
+        max_acceptable_deviation: f64,
+    },
+    // TODO: Standard variants that account for mode of travel. For example, `DefaultFor(modeOfTravel: ModeOfTravel)` with sensible defaults for walking, driving, cycling, etc.
+    Custom {
+        detector: Arc<dyn RouteDeviationDetector>,
+    },
+}
+
+impl RouteDeviationTracking {
+    pub(crate) fn check_route_deviation(
+        &self,
+        location: UserLocation,
+        route: &Route,
+        current_route_step: &RouteStep,
+    ) -> RouteDeviation {
+        match self {
+            RouteDeviationTracking::None => RouteDeviation::NoDeviation,
+            RouteDeviationTracking::StaticThreshold {
+                minimum_horizontal_accuracy,
+                max_acceptable_deviation,
+            } => {
+                if location.horizontal_accuracy < *minimum_horizontal_accuracy as f64 {
+                    // Check if the deviation from the route line is within tolerance,
+                    // after sanity checking that the positioning signal is within accuracy tolerance.
+                    deviation_from_line(
+                        &Point::from(location),
+                        &current_route_step.get_linestring(),
+                    )
+                    .map_or(RouteDeviation::NoDeviation, |deviation| {
+                        if deviation > *max_acceptable_deviation {
+                            RouteDeviation::OffRoute {
+                                deviation_from_route_line: deviation,
+                            }
+                        } else {
+                            RouteDeviation::NoDeviation
+                        }
+                    })
+                } else {
+                    RouteDeviation::NoDeviation
+                }
+            }
+            RouteDeviationTracking::Custom { detector } => {
+                detector.check_route_deviation(location, route.clone(), current_route_step.clone())
+            }
+        }
+    }
+}
+
+/// Status information that describes whether the user is proceeding according to the route or not.
+///
+/// Note that the name is intentionally a bit generic to allow for expansion of other states.
+/// For example, we could conceivably add a "wrong way" status in the future.
+#[derive(Debug, Copy, Clone, PartialEq, uniffi::Enum)]
+pub enum RouteDeviation {
+    /// The user is proceeding on course within the expected tolerances; everything is normal.
+    NoDeviation,
+    /// The user is off the expected route.
+    OffRoute {
+        /// The deviation from the route line, in meters.
+        deviation_from_route_line: f64,
+    },
+}
+
+#[uniffi::export(with_foreign)]
+pub trait RouteDeviationDetector: Send + Sync {
+    /// Determines whether the user is following the route correctly or not.
+    ///
+    /// NOTE: This function is merely for reporting the tracking status based on available information.
+    /// A return value indicating that the user is off route does not necessarily mean
+    /// that a new route will be recalculated immediately.
+    fn check_route_deviation(
+        &self,
+        location: UserLocation,
+        route: Route,
+        current_route_step: RouteStep,
+    ) -> RouteDeviation;
+}
+
+// TODO: Tests!

--- a/common/ferrostar/src/deviation_detection.rs
+++ b/common/ferrostar/src/deviation_detection.rs
@@ -1,7 +1,17 @@
 use crate::models::{Route, RouteStep, UserLocation};
-use crate::navigation_controller::algorithms::deviation_from_line;
+use crate::algorithms::deviation_from_line;
 use geo::Point;
 use std::sync::Arc;
+
+#[cfg(test)]
+use {
+    crate::{
+        models::GeographicCoordinate,
+        navigation_controller::test_helpers::{gen_dummy_route_step, gen_route_from_steps},
+    },
+    proptest::proptest,
+    std::time::SystemTime,
+};
 
 #[derive(Clone, uniffi::Enum)]
 pub enum RouteDeviationTracking {
@@ -24,6 +34,7 @@ pub enum RouteDeviationTracking {
 }
 
 impl RouteDeviationTracking {
+    #[must_use]
     pub(crate) fn check_route_deviation(
         &self,
         location: UserLocation,
@@ -85,6 +96,7 @@ pub trait RouteDeviationDetector: Send + Sync {
     /// NOTE: This function is merely for reporting the tracking status based on available information.
     /// A return value indicating that the user is off route does not necessarily mean
     /// that a new route will be recalculated immediately.
+    #[must_use]
     fn check_route_deviation(
         &self,
         location: UserLocation,
@@ -93,4 +105,236 @@ pub trait RouteDeviationDetector: Send + Sync {
     ) -> RouteDeviation;
 }
 
-// TODO: Tests!
+#[cfg(test)]
+proptest! {
+    /// Tests [RouteDeviationTracking::None] behavior,
+    /// which never reports that the user is off route, even when they obviously are.
+    #[test]
+    fn no_deviation_tracking(
+        x1 in -180f64..180f64, y1 in -90f64..90f64,
+        x2 in -180f64..180f64, y2 in -90f64..90f64,
+        x3 in -180f64..180f64, y3 in -90f64..90f64,
+    ) {
+        let tracking = RouteDeviationTracking::None;
+        let current_route_step = gen_dummy_route_step(x1, y1, x2, y2);
+        let route = gen_route_from_steps(vec![current_route_step.clone()]);
+
+        // Set the user location to the start of the route step.
+        // This is clearly on the route.
+        let user_location_on_route = UserLocation {
+            coordinates: GeographicCoordinate {
+                lng: x1,
+                lat: y1,
+            },
+            horizontal_accuracy: 0.0,
+            course_over_ground: None,
+            timestamp: SystemTime::now(),
+        };
+        assert_eq!(
+            tracking.check_route_deviation(user_location_on_route, &route, &current_route_step),
+            RouteDeviation::NoDeviation,
+        );
+
+        // Set the user location to a random value.
+        // This may be well off route, but we don't care in this mode.
+        let user_location_random = UserLocation {
+            coordinates: GeographicCoordinate {
+                lng: x3,
+                lat: y3,
+            },
+            horizontal_accuracy: 0.0,
+            course_over_ground: None,
+            timestamp: SystemTime::now(),
+        };
+        assert_eq!(
+            tracking.check_route_deviation(user_location_random, &route, &current_route_step),
+            RouteDeviation::NoDeviation,
+        );
+    }
+
+    /// Implements the same behavior as [RouteDeviationTracking::None]
+    /// with user-supplied code.
+    #[test]
+    fn custom_no_deviation_mode(
+        x1 in -180f64..180f64, y1 in -90f64..90f64,
+        x2 in -180f64..180f64, y2 in -90f64..90f64,
+        x3 in -180f64..180f64, y3 in -90f64..90f64,
+    ) {
+        struct NeverDetector {}
+
+        impl RouteDeviationDetector for NeverDetector {
+            fn check_route_deviation(
+                &self,
+                _location: UserLocation,
+                _route: Route,
+                _current_route_step: RouteStep,
+            ) -> RouteDeviation {
+                return RouteDeviation::NoDeviation
+            }
+        }
+
+        let tracking = RouteDeviationTracking::Custom {
+            detector: Arc::new(NeverDetector {})
+        };
+        let current_route_step = gen_dummy_route_step(x1, y1, x2, y2);
+        let route = gen_route_from_steps(vec![current_route_step.clone()]);
+
+        // Set the user location to the start of the route step.
+        // This is clearly on the route.
+        let user_location_on_route = UserLocation {
+            coordinates: GeographicCoordinate {
+                lng: x1,
+                lat: y1,
+            },
+            horizontal_accuracy: 0.0,
+            course_over_ground: None,
+            timestamp: SystemTime::now(),
+        };
+        assert_eq!(
+            tracking.check_route_deviation(user_location_on_route, &route, &current_route_step),
+            RouteDeviation::NoDeviation,
+        );
+
+        // Set the user location to a random value.
+        // This may be well off route, but we don't care in this mode.
+        let user_location_random = UserLocation {
+            coordinates: GeographicCoordinate {
+                lng: x3,
+                lat: y3,
+            },
+            horizontal_accuracy: 0.0,
+            course_over_ground: None,
+            timestamp: SystemTime::now(),
+        };
+        assert_eq!(
+            tracking.check_route_deviation(user_location_random, &route, &current_route_step),
+            RouteDeviation::NoDeviation,
+        );
+    }
+
+    /// Custom behavior claiming that the user is always off the route.
+    #[test]
+    fn custom_always_off_route(
+        x1 in -180f64..180f64, y1 in -90f64..90f64,
+        x2 in -180f64..180f64, y2 in -90f64..90f64,
+        x3 in -180f64..180f64, y3 in -90f64..90f64,
+    ) {
+        struct NeverDetector {}
+
+        impl RouteDeviationDetector for NeverDetector {
+            fn check_route_deviation(
+                &self,
+                _location: UserLocation,
+                _route: Route,
+                _current_route_step: RouteStep,
+            ) -> RouteDeviation {
+                return RouteDeviation::OffRoute {
+                    deviation_from_route_line: 7.0
+                }
+            }
+        }
+
+        let tracking = RouteDeviationTracking::Custom {
+            detector: Arc::new(NeverDetector {})
+        };
+        let current_route_step = gen_dummy_route_step(x1, y1, x2, y2);
+        let route = gen_route_from_steps(vec![current_route_step.clone()]);
+
+        // Set the user location to the start of the route step.
+        // This is clearly on the route.
+        let user_location_on_route = UserLocation {
+            coordinates: GeographicCoordinate {
+                lng: x1,
+                lat: y1,
+            },
+            horizontal_accuracy: 0.0,
+            course_over_ground: None,
+            timestamp: SystemTime::now(),
+        };
+        assert_eq!(
+            tracking.check_route_deviation(user_location_on_route, &route, &current_route_step),
+            RouteDeviation::OffRoute {
+                deviation_from_route_line: 7.0
+            },
+        );
+
+        // Set the user location to a random value.
+        // This may be well off route, but we don't care in this mode.
+        let user_location_random = UserLocation {
+            coordinates: GeographicCoordinate {
+                lng: x3,
+                lat: y3,
+            },
+            horizontal_accuracy: 0.0,
+            course_over_ground: None,
+            timestamp: SystemTime::now(),
+        };
+        assert_eq!(
+            tracking.check_route_deviation(user_location_random, &route, &current_route_step),
+            RouteDeviation::OffRoute {
+                deviation_from_route_line: 7.0
+            },
+        );
+    }
+
+    /// Tests [RouteDeviationTracking::StaticThreshold] behavior,
+    /// using [crate::algorithms::deviation_from_line]
+    #[test]
+    fn static_threshold_oracle_test(
+        x1 in -180f64..180f64, y1 in -90f64..90f64,
+        x2 in -180f64..180f64, y2 in -90f64..90f64,
+        x3 in -180f64..180f64, y3 in -90f64..90f64,
+        minimum_horizontal_accuracy in 1u16..100u16,
+        max_acceptable_deviation in 1f64..100f64,
+    ) {
+        let tracking = RouteDeviationTracking::StaticThreshold {
+            minimum_horizontal_accuracy,
+            max_acceptable_deviation
+        };
+        let current_route_step = gen_dummy_route_step(x1, y1, x2, y2);
+        let route = gen_route_from_steps(vec![current_route_step.clone()]);
+
+        // Set the user location to the start of the route step.
+        // This is clearly on the route.
+        let user_location_on_route = UserLocation {
+            coordinates: GeographicCoordinate {
+                lng: x1,
+                lat: y1,
+            },
+            // TODO: Test different accuracy values
+            horizontal_accuracy: 0.0,
+            course_over_ground: None,
+            timestamp: SystemTime::now(),
+        };
+        assert_eq!(
+            tracking.check_route_deviation(user_location_on_route, &route, &current_route_step),
+            RouteDeviation::NoDeviation,
+        );
+
+        // Set the user location to a random value.
+        // This may be well off route. Check the deviation_from_line helper
+        // as an oracle.
+        let coordinates = GeographicCoordinate {
+            lng: x3,
+            lat: y3,
+        };
+        let user_location_random = UserLocation {
+            coordinates,
+            horizontal_accuracy: 0.0,
+            course_over_ground: None,
+            timestamp: SystemTime::now(),
+        };
+        let deviation = deviation_from_line(&Point::from(coordinates), &current_route_step.get_linestring());
+        match tracking.check_route_deviation(user_location_random, &route, &current_route_step) {
+            RouteDeviation::NoDeviation => {
+                assert!(deviation.unwrap() <= max_acceptable_deviation)
+            }
+            RouteDeviation::OffRoute{ deviation_from_route_line } => {
+                assert_eq!(
+                    deviation_from_route_line,
+                    deviation.unwrap(),
+                );
+            }
+        }
+    }
+}

--- a/common/ferrostar/src/lib.rs
+++ b/common/ferrostar/src/lib.rs
@@ -1,3 +1,12 @@
+//! # Ferrostar
+//!
+//! Ferrostar is a modern SDK for building turn-by-turn navigation applications.
+//!
+//! See the [README on GitHub](https://github.com/stadiamaps/ferrostar) for the moment,
+//! as this is still under extremely active development,
+//! and proper documentation is still in flux.
+
+pub mod deviation_detection;
 pub mod models;
 pub mod navigation_controller;
 pub mod routing_adapters;

--- a/common/ferrostar/src/lib.rs
+++ b/common/ferrostar/src/lib.rs
@@ -6,12 +6,12 @@
 //! as this is still under extremely active development,
 //! and proper documentation is still in flux.
 
+pub mod algorithms;
 pub mod deviation_detection;
 pub mod models;
 pub mod navigation_controller;
 pub mod routing_adapters;
 pub mod simulation;
-pub mod algorithms;
 
 use crate::routing_adapters::osrm::OsrmResponseParser;
 use crate::routing_adapters::valhalla::ValhallaHttpRequestGenerator;

--- a/common/ferrostar/src/lib.rs
+++ b/common/ferrostar/src/lib.rs
@@ -11,6 +11,7 @@ pub mod models;
 pub mod navigation_controller;
 pub mod routing_adapters;
 pub mod simulation;
+pub mod algorithms;
 
 use crate::routing_adapters::osrm::OsrmResponseParser;
 use crate::routing_adapters::valhalla::ValhallaHttpRequestGenerator;

--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -235,8 +235,8 @@ mod tests {
 
     #[test]
     fn test_polyline_encode() {
-        let sw = GeographicCoordinate {lng: 0.0, lat: 0.0};
-        let ne = GeographicCoordinate {lng: 1.0, lat: 1.0};
+        let sw = GeographicCoordinate { lng: 0.0, lat: 0.0 };
+        let ne = GeographicCoordinate { lng: 1.0, lat: 1.0 };
         let route = Route {
             geometry: vec![sw, ne],
             bbox: BoundingBox { sw, ne },

--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -98,7 +98,7 @@ impl From<UserLocation> for Point {
 ///
 /// NOTE: This type is unstable and is still under active development and should be
 /// considered unstable.
-#[derive(Debug, uniffi::Record)]
+#[derive(Clone, Debug, uniffi::Record)]
 #[cfg_attr(test, derive(Serialize))]
 pub struct Route {
     pub geometry: Vec<GeographicCoordinate>,

--- a/common/ferrostar/src/navigation_controller/algorithms.rs
+++ b/common/ferrostar/src/navigation_controller/algorithms.rs
@@ -36,6 +36,10 @@ fn snap_point_to_line(point: &Point, line: &LineString) -> Option<Point> {
     }
 }
 
+pub fn deviation_from_line(point: &Point, line: &LineString) -> Option<f64> {
+    snap_point_to_line(point, line).map(|snapped| snapped.haversine_distance(point))
+}
+
 fn is_close_enough_to_end_of_step(
     current_position: &Point,
     current_step_linestring: &LineString,

--- a/common/ferrostar/src/navigation_controller/mod.rs
+++ b/common/ferrostar/src/navigation_controller/mod.rs
@@ -4,8 +4,11 @@ pub mod models;
 pub(crate) mod test_helpers;
 
 use crate::{
-    algorithms::{snap_user_location_to_line, advance_step, distance_to_end_of_step, should_advance_to_next_step},
-    models::{Route, UserLocation}
+    algorithms::{
+        advance_step, distance_to_end_of_step, should_advance_to_next_step,
+        snap_user_location_to_line,
+    },
+    models::{Route, UserLocation},
 };
 use models::*;
 

--- a/common/ferrostar/src/navigation_controller/mod.rs
+++ b/common/ferrostar/src/navigation_controller/mod.rs
@@ -1,11 +1,12 @@
-pub mod algorithms;
 pub mod models;
 
-use crate::models::{Route, UserLocation};
-use crate::navigation_controller::algorithms::{
-    advance_step, distance_to_end_of_step, should_advance_to_next_step,
+#[cfg(test)]
+pub(crate) mod test_helpers;
+
+use crate::{
+    algorithms::{snap_user_location_to_line, advance_step, distance_to_end_of_step, should_advance_to_next_step},
+    models::{Route, UserLocation}
 };
-use algorithms::snap_user_location_to_line;
 use models::*;
 
 /// Manages the navigation lifecycle of a route, reacting to inputs like user location updates

--- a/common/ferrostar/src/navigation_controller/mod.rs
+++ b/common/ferrostar/src/navigation_controller/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     models::{Route, UserLocation},
 };
+use geo::{HaversineDistance, Point};
 use models::*;
 
 /// Manages the navigation lifecycle of a route, reacting to inputs like user location updates
@@ -54,6 +55,8 @@ impl NavigationController {
         TripState::Navigating {
             snapped_user_location,
             remaining_steps: remaining_steps.clone(),
+            // Skip the first waypoint, as it is the current one
+            remaining_waypoints: self.route.waypoints.iter().skip(1).copied().collect(),
             distance_to_next_maneuver,
             deviation,
         }
@@ -63,15 +66,17 @@ impl NavigationController {
     ///
     /// Depending on the advancement strategy, this may be automatic.
     /// For other cases, it is desirable to advance to the next step manually (ex: walking in an
-    /// urban tunnel). We leave this decision to the app developer.
+    /// urban tunnel). We leave this decision to the app developer and provide this as a convenience.
     pub fn advance_to_next_step(&self, state: &TripState) -> TripState {
         match state {
             TripState::Navigating {
                 snapped_user_location,
                 ref remaining_steps,
+                ref remaining_waypoints,
                 deviation,
                 ..
             } => {
+                // FIXME: This logic is mostly duplicated below
                 let update = advance_step(remaining_steps);
                 match update {
                     StepAdvanceStatus::Advanced {
@@ -82,12 +87,37 @@ impl NavigationController {
                         let mut remaining_steps = remaining_steps.clone();
                         remaining_steps.remove(0);
 
+                        // Update remaining waypoints
+                        let should_advance_waypoint = if let Some(waypoint) =
+                            remaining_waypoints.first()
+                        {
+                            let current_location: Point = snapped_user_location.coordinates.into();
+                            let next_waypoint: Point = (*waypoint).into();
+                            // TODO: This is just a hard-coded threshold for the time being.
+                            // More sophisticated behavior will take some time and use cases, so punting on this for now.
+                            current_location.haversine_distance(&next_waypoint) < 100.0
+                        } else {
+                            false
+                        };
+
+                        let remaining_waypoints = if should_advance_waypoint {
+                            let mut remaining_waypoints = remaining_waypoints.clone();
+                            remaining_waypoints.remove(0);
+                            remaining_waypoints
+                        } else {
+                            remaining_waypoints.clone()
+                        };
+
                         let distance_to_next_maneuver =
                             distance_to_end_of_step(&(*snapped_user_location).into(), &linestring);
+
                         TripState::Navigating {
                             snapped_user_location: *snapped_user_location,
                             remaining_steps,
+                            remaining_waypoints,
                             distance_to_next_maneuver,
+                            // NOTE: We *can't* run deviation calculations in this method,
+                            // as it requires a non-snapped user location.
                             deviation: *deviation,
                         }
                     }
@@ -105,6 +135,8 @@ impl NavigationController {
         match state {
             TripState::Navigating {
                 ref remaining_steps,
+                ref remaining_waypoints,
+                deviation,
                 ..
             } => {
                 let Some(current_step) = remaining_steps.first() else {
@@ -116,57 +148,60 @@ impl NavigationController {
                 //
 
                 // Find the nearest point on the route line
-                let mut current_step_linestring = current_step.get_linestring();
+                let current_step_linestring = current_step.get_linestring();
                 let snapped_user_location =
                     snap_user_location_to_line(location, &current_step_linestring);
+                let distance_to_next_maneuver = distance_to_end_of_step(
+                    &snapped_user_location.into(),
+                    &current_step_linestring,
+                );
+                let intermediate_state = TripState::Navigating {
+                    snapped_user_location,
+                    remaining_steps: remaining_steps.clone(),
+                    remaining_waypoints: remaining_waypoints.clone(),
+                    distance_to_next_maneuver,
+                    deviation: *deviation,
+                };
 
-                // If on track, update the set of remaining waypoints, remaining steps (drop from the list), and update current step.
-                let mut remaining_steps = remaining_steps.clone();
-                let current_step = if should_advance_to_next_step(
+                match if should_advance_to_next_step(
                     &current_step_linestring,
                     remaining_steps.get(1),
                     &location,
                     self.config.step_advance,
                 ) {
                     // Advance to the next step
-                    let update = advance_step(&remaining_steps);
-                    match update {
-                        StepAdvanceStatus::Advanced { step, linestring } => {
-                            // Apply the updates
-                            // TODO: Figure out an elegant way to factor this out as it appears in two places
-                            remaining_steps.remove(0);
-                            current_step_linestring = linestring;
-
-                            Some(step.clone())
-                        }
-                        StepAdvanceStatus::EndOfRoute => {
-                            return TripState::Complete;
-                        }
-                    }
+                    self.advance_to_next_step(&intermediate_state)
                 } else {
-                    Some(current_step.clone())
-                };
-
-                if let Some(step) = current_step {
-                    let distance_to_next_maneuver = distance_to_end_of_step(
-                        &snapped_user_location.into(),
-                        &current_step_linestring,
-                    );
-
-                    let deviation = self.config.route_deviation_tracking.check_route_deviation(
-                        location,
-                        &self.route,
-                        &step,
-                    );
-
+                    // Do not advance
+                    intermediate_state
+                } {
                     TripState::Navigating {
                         snapped_user_location,
                         remaining_steps,
+                        remaining_waypoints,
                         distance_to_next_maneuver,
-                        deviation,
+                        deviation: _,
+                    } => {
+                        // Recalculate deviation. This happens later, as the current step may have changed.
+                        // The distance to the next maneuver will be updated by advance_to_next_step if needed.
+                        let current_step = remaining_steps
+                            .first()
+                            .expect("Invalid state: navigating with zero remaining steps.");
+                        let deviation = self.config.route_deviation_tracking.check_route_deviation(
+                            location,
+                            &self.route,
+                            current_step,
+                        );
+
+                        TripState::Navigating {
+                            snapped_user_location,
+                            remaining_steps,
+                            remaining_waypoints,
+                            distance_to_next_maneuver,
+                            deviation,
+                        }
                     }
-                } else {
-                    TripState::Complete
+                    TripState::Complete => TripState::Complete,
                 }
             }
             // Terminal state

--- a/common/ferrostar/src/navigation_controller/mod.rs
+++ b/common/ferrostar/src/navigation_controller/mod.rs
@@ -8,7 +8,6 @@ use crate::navigation_controller::algorithms::{
 use algorithms::snap_user_location_to_line;
 use geo::Point;
 use models::*;
-use std::sync::Arc;
 
 /// Manages the navigation lifecycle of a route, reacting to inputs like user location updates
 /// and returning a new state.
@@ -26,8 +25,8 @@ pub struct NavigationController {
 #[uniffi::export]
 impl NavigationController {
     #[uniffi::constructor]
-    pub fn new(route: Route, config: NavigationControllerConfig) -> Arc<Self> {
-        Arc::new(Self { config, route })
+    pub fn new(route: Route, config: NavigationControllerConfig) -> Self {
+        Self { config, route }
     }
 
     /// Returns initial trip state as if the user had just started the route with no progress.

--- a/common/ferrostar/src/navigation_controller/models.rs
+++ b/common/ferrostar/src/navigation_controller/models.rs
@@ -1,5 +1,5 @@
 use crate::deviation_detection::{RouteDeviation, RouteDeviationTracking};
-use crate::models::{RouteStep, UserLocation};
+use crate::models::{GeographicCoordinate, RouteStep, UserLocation};
 use geo::LineString;
 
 /// Internal state of the navigation controller.
@@ -8,9 +8,19 @@ pub enum TripState {
     Navigating {
         snapped_user_location: UserLocation,
         /// The ordered list of steps that remain in the trip.
+        ///
         /// The step at the front of the list is always the current step.
         /// We currently assume that you cannot move backward to a previous step.
         remaining_steps: Vec<RouteStep>,
+        /// Remaining waypoints to visit on the route.
+        ///
+        /// The waypoint at the front of the list is always the *next* waypoint "goal."
+        /// Unlike the current step, there is no value in tracking the "current" waypoint,
+        /// as the main use of waypoints is recalculation when the user deviates from the route.
+        /// (In most use cases, a route will have only two waypoints, but more complex use cases
+        /// may have multiple intervening points that are visited along the route.)
+        /// This list is updated as the user advances through the route.
+        remaining_waypoints: Vec<GeographicCoordinate>,
         /// The distance to the next maneuver, in meters.
         distance_to_next_maneuver: f64,
         /// The route deviation status: is the user following the route or not?

--- a/common/ferrostar/src/navigation_controller/models.rs
+++ b/common/ferrostar/src/navigation_controller/models.rs
@@ -10,8 +10,10 @@ pub enum TripState {
         /// The step at the front of the list is always the current step.
         /// We currently assume that you cannot move backward to a previous step.
         remaining_steps: Vec<RouteStep>,
+        /// The distance to the next maneuver, in meters.
         distance_to_next_maneuver: f64,
-        // TODO: Communicate off-route and other state info
+        /// The deviation of the user from the expected route line.
+        deviation_from_route_line: Option<f64>,
     },
     Complete,
 }

--- a/common/ferrostar/src/navigation_controller/models.rs
+++ b/common/ferrostar/src/navigation_controller/models.rs
@@ -13,6 +13,7 @@ pub enum TripState {
         remaining_steps: Vec<RouteStep>,
         /// The distance to the next maneuver, in meters.
         distance_to_next_maneuver: f64,
+        /// The route deviation status: is the user following the route or not?
         deviation: RouteDeviation,
     },
     Complete,

--- a/common/ferrostar/src/navigation_controller/models.rs
+++ b/common/ferrostar/src/navigation_controller/models.rs
@@ -1,3 +1,4 @@
+use crate::deviation_detection::{RouteDeviation, RouteDeviationTracking};
 use crate::models::{RouteStep, UserLocation};
 use geo::LineString;
 
@@ -12,17 +13,18 @@ pub enum TripState {
         remaining_steps: Vec<RouteStep>,
         /// The distance to the next maneuver, in meters.
         distance_to_next_maneuver: f64,
-        /// The deviation of the user from the expected route line.
-        deviation_from_route_line: Option<f64>,
+        deviation: RouteDeviation,
     },
     Complete,
 }
 
 pub enum StepAdvanceStatus {
+    /// Navigation has advanced, and the information on the next step is embedded.
     Advanced {
         step: RouteStep,
         linestring: LineString,
     },
+    /// Navigation has reached the end of the route.
     EndOfRoute,
 }
 
@@ -34,14 +36,14 @@ pub enum StepAdvanceMode {
     DistanceToEndOfStep {
         /// Distance to the last waypoint in the step, measured in meters, at which to advance.
         distance: u16,
-        /// The minimum required horizontal accuracy of the user location.
+        /// The minimum required horizontal accuracy of the user location, in meters.
         /// Values larger than this cannot trigger a step advance.
         minimum_horizontal_accuracy: u16,
     },
     /// Automatically advances when the user's distance to the *next* step's linestring  is less
     /// than the distance to the current step's linestring.
     RelativeLineStringDistance {
-        /// The minimum required horizontal accuracy of the user location.
+        /// The minimum required horizontal accuracy of the user location, in meters.
         /// Values larger than this cannot trigger a step advance.
         minimum_horizontal_accuracy: u16,
         /// At this (optional) distance, navigation should advance to the next step regardless
@@ -50,7 +52,8 @@ pub enum StepAdvanceMode {
     },
 }
 
-#[derive(Debug, Copy, Clone, uniffi::Record)]
+#[derive(Clone, uniffi::Record)]
 pub struct NavigationControllerConfig {
     pub step_advance: StepAdvanceMode,
+    pub route_deviation_tracking: RouteDeviationTracking,
 }

--- a/common/ferrostar/src/navigation_controller/test_helpers.rs
+++ b/common/ferrostar/src/navigation_controller/test_helpers.rs
@@ -1,0 +1,53 @@
+use crate::models::{BoundingBox, GeographicCoordinate, Route, RouteStep};
+use geo::{BoundingRect, LineString, Point};
+
+pub fn gen_dummy_route_step(
+    start_lng: f64,
+    start_lat: f64,
+    end_lng: f64,
+    end_lat: f64,
+) -> RouteStep {
+    RouteStep {
+        geometry: vec![
+            GeographicCoordinate {
+                lng: start_lng,
+                lat: start_lat,
+            },
+            GeographicCoordinate {
+                lng: end_lng,
+                lat: end_lat,
+            },
+        ],
+        distance: 0.0,
+        road_name: None,
+        instruction: "".to_string(),
+        visual_instructions: vec![],
+        spoken_instructions: vec![],
+    }
+}
+
+pub fn gen_route_from_steps(steps: Vec<RouteStep>) -> Route {
+    let geometry: Vec<_> = steps
+        .iter()
+        .flat_map(|step| step.geometry.clone())
+        .collect();
+    let linestring = LineString::from_iter(geometry.iter().map(|point| Point::from(*point)));
+    let distance = steps.iter().fold(0.0, |acc, step| acc + step.distance);
+    let bbox = linestring.bounding_rect().unwrap();
+
+    Route {
+        geometry,
+        bbox: BoundingBox {
+            sw: GeographicCoordinate::from(bbox.min()),
+            ne: GeographicCoordinate::from(bbox.max()),
+        },
+        distance,
+        waypoints: vec![
+            // This method cannot be used outside the test configuration,
+            // so unwraps are OK.
+            steps.first().unwrap().geometry.first().cloned().unwrap(),
+            steps.last().unwrap().geometry.last().cloned().unwrap(),
+        ],
+        steps,
+    }
+}

--- a/common/ferrostar/src/routing_adapters/mod.rs
+++ b/common/ferrostar/src/routing_adapters/mod.rs
@@ -31,7 +31,7 @@ pub enum RouteRequest {
 ///
 /// Implementations may be either in Rust (most popular engines should eventually have Rust
 /// implementations) or foreign code.
-#[uniffi::export]
+#[uniffi::export(with_foreign)]
 pub trait RouteRequestGenerator: Send + Sync {
     /// Generates a routing backend request given the set of locations.
     ///
@@ -49,7 +49,7 @@ pub trait RouteRequestGenerator: Send + Sync {
 
 /// A generic interface describing any object capable of parsing a response from a routing
 /// backend into one or more [Route]s.
-#[uniffi::export]
+#[uniffi::export(with_foreign)]
 pub trait RouteResponseParser: Send + Sync {
     /// Parses a raw response from the routing backend into a route.
     ///

--- a/common/ferrostar/src/routing_adapters/mod.rs
+++ b/common/ferrostar/src/routing_adapters/mod.rs
@@ -88,15 +88,15 @@ impl RouteAdapter {
     pub fn new(
         request_generator: Arc<dyn RouteRequestGenerator>,
         response_parser: Arc<dyn RouteResponseParser>,
-    ) -> Arc<Self> {
-        Arc::new(Self {
+    ) -> Self {
+        Self {
             request_generator,
             response_parser,
-        })
+        }
     }
 
     #[uniffi::constructor]
-    pub fn new_valhalla_http(endpoint_url: String, profile: String) -> Arc<Self> {
+    pub fn new_valhalla_http(endpoint_url: String, profile: String) -> Self {
         let request_generator = create_valhalla_request_generator(endpoint_url, profile);
         let response_parser = create_osrm_response_parser(6);
         Self::new(request_generator, response_parser)

--- a/common/ferrostar/src/routing_adapters/mod.rs
+++ b/common/ferrostar/src/routing_adapters/mod.rs
@@ -36,7 +36,7 @@ pub trait RouteRequestGenerator: Send + Sync {
     /// Generates a routing backend request given the set of locations.
     ///
     /// While most implementations will treat the locations as an ordered sequence, this is not
-    /// guaranteed (ex: an optimized router)..
+    /// guaranteed (ex: an optimized router).
     /// TODO: Option for whether we should account for course over ground or heading.
     fn generate_request(
         &self,

--- a/common/ferrostar/src/routing_adapters/mod.rs
+++ b/common/ferrostar/src/routing_adapters/mod.rs
@@ -37,7 +37,8 @@ pub trait RouteRequestGenerator: Send + Sync {
     ///
     /// While most implementations will treat the locations as an ordered sequence, this is not
     /// guaranteed (ex: an optimized router).
-    /// TODO: Option for whether we should account for course over ground or heading.
+    // TODO: Arbitrary options; how can we make this generic???
+    // TODO: Option for whether we should account for course over ground or heading.
     fn generate_request(
         &self,
         user_location: UserLocation,

--- a/common/ferrostar/src/routing_adapters/osrm/models.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/models.rs
@@ -1,4 +1,4 @@
-//! OSRM models from the API spec: http://project-osrm.org/docs/v5.5.1/api/
+//! OSRM models from the API spec: <http://project-osrm.org/docs/v5.5.1/api/>
 //!
 //! Note that in some cases we optionally allow for extensions that have been made to the spec
 //! by others which are now pseudo-standardized (ex: Mapbox). We omit some fields which are not

--- a/common/ferrostar/tests/navigation_controller.rs
+++ b/common/ferrostar/tests/navigation_controller.rs
@@ -1,5 +1,6 @@
 extern crate ferrostar;
 
+use ferrostar::deviation_detection::RouteDeviationTracking;
 use ferrostar::models::{Route, UserLocation};
 use ferrostar::navigation_controller::models::{
     NavigationControllerConfig, StepAdvanceMode, TripState,
@@ -38,6 +39,7 @@ fn same_location_results_in_identical_state() {
         route,
         NavigationControllerConfig {
             step_advance: StepAdvanceMode::Manual,
+            route_deviation_tracking: RouteDeviationTracking::None,
         },
     );
 
@@ -71,6 +73,7 @@ fn simple_route_state_machine_manual_advance() {
         route,
         NavigationControllerConfig {
             step_advance: StepAdvanceMode::Manual,
+            route_deviation_tracking: RouteDeviationTracking::None,
         },
     );
 
@@ -143,6 +146,7 @@ fn simple_route_state_machine_advances_with_location_change() {
                 distance: 0,
                 minimum_horizontal_accuracy: 0,
             },
+            route_deviation_tracking: RouteDeviationTracking::None,
         },
     );
 

--- a/common/ferrostar/tests/navigation_controller.rs
+++ b/common/ferrostar/tests/navigation_controller.rs
@@ -10,6 +10,7 @@ use ferrostar::routing_adapters::osrm::OsrmResponseParser;
 use ferrostar::routing_adapters::RouteResponseParser;
 use std::time::SystemTime;
 
+// A route with two steps
 const TWO_STEP_RESPONSE: &str = r#"{"routes":[{"weight_name":"auto","weight":56.002,"duration":11.488,"distance":284,"legs":[{"via_waypoints":[],"annotation":{"maxspeed":[{"speed":89,"unit":"km/h"},{"speed":89,"unit":"km/h"},{"speed":89,"unit":"km/h"},{"speed":89,"unit":"km/h"},{"speed":89,"unit":"km/h"},{"speed":89,"unit":"km/h"},{"speed":89,"unit":"km/h"},{"speed":89,"unit":"km/h"},{"speed":89,"unit":"km/h"}],"speed":[24.7,24.7,24.7,24.7,24.7,24.7,24.7,24.7,24.7],"distance":[23.6,14.9,9.6,13.2,25,28.1,38.1,41.6,90],"duration":[0.956,0.603,0.387,0.535,1.011,1.135,1.539,1.683,3.641]},"admins":[{"iso_3166_1_alpha3":"USA","iso_3166_1":"US"}],"weight":56.002,"duration":11.488,"steps":[{"intersections":[{"bearings":[288],"entry":[true],"admin_index":0,"out":0,"geometry_index":0,"location":[-149.543469,60.534716]}],"speedLimitUnit":"mph","maneuver":{"type":"depart","instruction":"Drive west on AK 1/Seward Highway.","bearing_after":288,"bearing_before":0,"location":[-149.543469,60.534716]},"speedLimitSign":"mutcd","name":"Seward Highway","duration":11.488,"distance":284,"driving_side":"right","weight":56.002,"mode":"driving","ref":"AK 1","geometry":"wzvmrBxalf|GcCrX}A|Nu@jI}@pMkBtZ{@x^_Afj@Inn@`@veB"},{"intersections":[{"bearings":[89],"entry":[true],"in":0,"admin_index":0,"geometry_index":9,"location":[-149.548581,60.534991]}],"speedLimitUnit":"mph","maneuver":{"type":"arrive","instruction":"You have arrived at your destination.","bearing_after":0,"bearing_before":269,"location":[-149.548581,60.534991]},"speedLimitSign":"mutcd","name":"Seward Highway","duration":0,"distance":0,"driving_side":"right","weight":0,"mode":"driving","ref":"AK 1","geometry":"}kwmrBhavf|G??"}],"distance":284,"summary":"AK 1"}],"geometry":"wzvmrBxalf|GcCrX}A|Nu@jI}@pMkBtZ{@x^_Afj@Inn@`@veB"}],"waypoints":[{"distance":0,"name":"AK 1","location":[-149.543469,60.534715]},{"distance":0,"name":"AK 1","location":[-149.548581,60.534991]}],"code":"Ok"}"#;
 
 /// Gets a route with two steps.
@@ -154,6 +155,7 @@ fn simple_route_state_machine_advances_with_location_change() {
     let initial_state = controller.get_initial_state(initial_user_location);
     let TripState::Navigating {
         remaining_steps: initial_remaining_steps,
+        remaining_waypoints: initial_remaining_waypoints,
         ..
     } = initial_state.clone()
     else {
@@ -162,11 +164,13 @@ fn simple_route_state_machine_advances_with_location_change() {
 
     // The current step should change when we jump to the end location
     let TripState::Navigating {
-        remaining_steps, ..
+        remaining_steps, remaining_waypoints, ..
     } = controller.update_user_location(user_location_end_of_first_step, &initial_state)
     else {
         panic!("Expected state to be navigating");
     };
 
     assert_ne!(remaining_steps, initial_remaining_steps);
+    // In this case, the final step is the arrival point
+    assert_eq!(remaining_waypoints.len(), 0);
 }

--- a/common/ferrostar/tests/navigation_controller.rs
+++ b/common/ferrostar/tests/navigation_controller.rs
@@ -155,12 +155,13 @@ fn simple_route_state_machine_advances_with_location_change() {
     let initial_state = controller.get_initial_state(initial_user_location);
     let TripState::Navigating {
         remaining_steps: initial_remaining_steps,
-        remaining_waypoints: initial_remaining_waypoints,
+        remaining_waypoints,
         ..
     } = initial_state.clone()
     else {
         panic!("Expected state to be navigating");
     };
+    assert_eq!(remaining_waypoints.len(), 1);
 
     // The current step should change when we jump to the end location
     let TripState::Navigating {


### PR DESCRIPTION
Closes #8 #50 and #55.

This is a first pass at route deviation tracking (aka "off route detection"). What is meant by a first pass? Before merging, the following should be true:

* We have a way for developers to choose from several methods for detecting deviations from the expected route
  - [X] None (cases where we simply don't care)
  - [X] Using static thresholds (for minimal positioning accuracy, and a distance in meters beyond which the user is considered off the route). This logic must be a reasonable first pass, but can change later.
  - [X] Ability to pass in custom code. This interface should be a reasonable first pass that covers all currently known use cases.
  - OUT OF SCOPE: "Presets" tuned with sane defaults for common modes of travel (this can come later).
* All code paths are tested
  - [x] Static thresholds with an emprical check against the algorithms in the crate; basic internal consistency check
  - [x] Static thresholds with some simple test cases
  - [x] Custom implementation written in Rust (thoroughly tested)
  - [x] Custom implementation written in Swift (light integration testing)
  - [x] Custom implementation written in Kotlin (light integration testing)
- [x] Discussion + decision on the balance between the framework and library approach to _recalculation_. I'm leaning toward the library approach in this case, but let's discuss on our review call
  - [x] Dogfooding: Integration of a "standard" approach to recalculation in both sample apps