### PR TITLE
Fixed iOS ci extract folder and useLocal

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -61,6 +61,13 @@ jobs:
       run: xcodebuild -scheme "${{ matrix.scheme }}" build -configuration Debug -skipMacroValidation \
         CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcbeautify && exit ${PIPESTATUS[0]}
       working-directory: apple/DemoApp
+      
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v4
+      with:
+        name: Package.swift
+        path: Package.swift
+        retention-days: 5
 
   test:
     runs-on: macos-13
@@ -97,3 +104,10 @@ jobs:
 
     - name: Test ${{ matrix.scheme }} on ${{ matrix.destination }}
       run: xcodebuild -scheme ${{ matrix.scheme }} test -skipMacroValidation -destination '${{ matrix.destination }}' | xcbeautify && exit ${PIPESTATUS[0]}
+
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v4
+      with:
+        name: Package.swift
+        path: Package.swift
+        retention-days: 5

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -48,7 +48,8 @@ jobs:
         name: libferrostar-rs.xcframework.zip
 
     - name: Unzip libferrostar-rs.xcframework
-      run: unzip common/libferrostar-rs.xcframework.zip
+      run: unzip libferrostar-rs.xcframework.zip
+      working-directory: common
 
     - name: Install xcbeautify
       run: brew install xcbeautify
@@ -88,7 +89,8 @@ jobs:
         name: libferrostar-rs.xcframework.zip
 
     - name: Unzip libferrostar-rs.xcframework
-      run: unzip common/libferrostar-rs.xcframework.zip
+      run: unzip libferrostar-rs.xcframework.zip
+      working-directory: common
 
     - name: Install xcbeautify
       run: brew install xcbeautify

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -85,10 +85,10 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: common
-        name: common/libferrostar-rs.xcframework.zip
+        name: libferrostar-rs.xcframework.zip
 
     - name: Unzip libferrostar-rs.xcframework
-      run: unzip libferrostar-rs.xcframework.zip
+      run: unzip common/libferrostar-rs.xcframework.zip
 
     - name: Install xcbeautify
       run: brew install xcbeautify

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -65,7 +65,7 @@ jobs:
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v4
       with:
-        name: Package.swift
+        name: Demo-Package.swift
         path: Package.swift
         retention-days: 5
 
@@ -108,6 +108,6 @@ jobs:
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v4
       with:
-        name: Package.swift
+        name: Library-Package.swift
         path: Package.swift
         retention-days: 5

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -14,9 +14,6 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
 
-    - name: Configure Package.swift for local development
-      run: sed -i '' 's/let useLocalFramework = false/let useLocalFramework = true/' Package.swift
-
     - name: Build iOS XCFramework
       run: ./build-ios.sh --release
       working-directory: common
@@ -41,13 +38,17 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
 
+    - name: Configure Package.swift for local development
+      run: sed -i '' 's/let useLocalFramework = false/let useLocalFramework = true/' Package.swift
+
     - name: Download libferrostar-rs.xcframework.
       uses: actions/download-artifact@v4
       with:
+        path: common
         name: libferrostar-rs.xcframework.zip
 
     - name: Unzip libferrostar-rs.xcframework
-      run: unzip libferrostar-rs.xcframework.zip
+      run: unzip common/libferrostar-rs.xcframework.zip
 
     - name: Install xcbeautify
       run: brew install xcbeautify
@@ -77,10 +78,14 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
 
+    - name: Configure Package.swift for local development
+      run: sed -i '' 's/let useLocalFramework = false/let useLocalFramework = true/' Package.swift
+
     - name: Download libferrostar-rs.xcframework.
       uses: actions/download-artifact@v4
       with:
-        name: libferrostar-rs.xcframework.zip
+        path: common
+        name: common/libferrostar-rs.xcframework.zip
 
     - name: Unzip libferrostar-rs.xcframework
       run: unzip libferrostar-rs.xcframework.zip


### PR DESCRIPTION
- Revised sed call to ensure build and test tasks run with local artifact.
- Corrects folder for local package.
- adds `Package.swift` artifact upload for verification.