### PR TITLE
Clean up most of the nits from the last PR

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,8 +21,7 @@ jobs:
       - run: >-
           cargo hack check --rust-version --workspace --all-targets
           --ignore-private
-        with:
-          manifest-path: common/Cargo.toml
+        working-directory: common
 
   semver-checks:
     runs-on: macos-14
@@ -31,7 +30,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
-        working-directory: common
+        with:
+          manifest-path: common/Cargo.toml
 
   build:
     runs-on: macos-14

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,11 @@
 name: Rust (Common)
-
 on:
   push:
-    branches: [ "*" ]
+    branches:
+      - '*'
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,9 +18,12 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
-      - run: cargo hack check --rust-version --workspace --all-targets --ignore-private
-        working-directory: common
-        
+      - run: >-
+          cargo hack check --rust-version --workspace --all-targets
+          --ignore-private
+        with:
+          manifest-path: common/Cargo.toml
+
   semver-checks:
     runs-on: macos-14
     steps:
@@ -32,10 +36,10 @@ jobs:
   build:
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v4
-    - name: Cargo Build
-      run: cargo build --verbose
-      working-directory: common
-    - name: Run tests
-      run: cargo test --verbose
-      working-directory: common
+      - uses: actions/checkout@v4
+      - name: Cargo Build
+        run: cargo build --verbose
+        working-directory: common
+      - name: Run tests
+        run: cargo test --verbose
+        working-directory: common

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,10 +10,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  msrv:
     runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+      - run: cargo hack check --rust-version --workspace --all-targets --ignore-private
+        working-directory: common
+        
+  semver-checks:
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        working-directory: common
 
+  build:
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - name: Cargo Build

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/FerrostarCore.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/FerrostarCore.kt
@@ -55,6 +55,7 @@ sealed class CorrectiveAction {
     class GetNewRoutes(val waypoints: List<GeographicCoordinate>): CorrectiveAction()
 }
 
+// TODO: Think of a better (more specialized) name for this interface; something about rerouting? The term "delegate" is imported from the Apple ecosystem and will be super confusing to a Kotlin dev.
 interface FerrostarCoreDelegate {
     /**
      * Called when the core has loaded alternative routes.
@@ -231,6 +232,8 @@ class FerrostarCore(
                                             routes
                                         )
                                     } else if (routes.count() > 1 && config != null) {
+                                        // Default behavior when there is no user-defined behavior:
+                                        // accept the first route, as this is what most users want when they go off route.
                                         startNavigation(routes.first(), config)
                                     }
                                 } finally {

--- a/apple/DemoApp/Demo/Navigation Delegate.swift
+++ b/apple/DemoApp/Demo/Navigation Delegate.swift
@@ -24,10 +24,12 @@ class NavigationDelegate: FerrostarCoreDelegate {
         if core.state?.isCalculatingNewRoute ?? false,
            let route = routes.first {
             do {
+                // Most implementations will probably reuse existing configs (the default implementation does),
+                // but we provide devs with flexibility here.
+                let config = NavigationControllerConfig(stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 32, automaticAdvanceDistance: 10), routeDeviationTracking: .staticThreshold(minimumHorizontalAccuracy: 25, maxAcceptableDeviation: 20))
                 try core.startNavigation(
                     route: route,
-                    stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 32, automaticAdvanceDistance: 10),
-                    routeDeviationTracking: .staticThreshold(minimumHorizontalAccuracy: 25, maxAcceptableDeviation: 20))
+                    config: config)
             } catch {
                 // Users of the framework my develop their own responses here, such as notifying the user if appropriate
             }

--- a/apple/DemoApp/Demo/NavigationView.swift
+++ b/apple/DemoApp/Demo/NavigationView.swift
@@ -173,13 +173,18 @@ struct NavigationView: View {
             return
         }
         
+        // Configure the navigation session.
+        // You have a lot of flexibility here based on your use case
+        let config = NavigationControllerConfig(
+            stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 32, automaticAdvanceDistance: 10),
+            routeDeviationTracking: .staticThreshold(minimumHorizontalAccuracy: 25, maxAcceptableDeviation: 20))
+
         // Starts the navigation state machine.
         // It's worth having a look through the parameters,
         // as most of the configuration happens here.
         try ferrostarCore.startNavigation(
             route: route,
-            stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 32, automaticAdvanceDistance: 10),
-            routeDeviationTracking: .staticThreshold(minimumHorizontalAccuracy: 25, maxAcceptableDeviation: 20))
+            config: config)
 
         if let simulated = locationProvider as? SimulatedLocationProvider {
             try simulated.startSimulating(route: route)

--- a/apple/Sources/FerrostarCore/ModelWrappers.swift
+++ b/apple/Sources/FerrostarCore/ModelWrappers.swift
@@ -104,3 +104,12 @@ public enum RouteDeviationTracking {
         }
     }
 }
+
+/// A Swift wrapper around `UniFFI.NavigationControllerConfig`.
+public struct NavigationControllerConfig {
+    public init(stepAdvance: StepAdvanceMode, routeDeviationTracking: RouteDeviationTracking) {
+        ffiValue = UniFFI.NavigationControllerConfig(stepAdvance: stepAdvance.ffiValue, routeDeviationTracking: routeDeviationTracking.ffiValue)
+    }
+
+    var ffiValue: UniFFI.NavigationControllerConfig
+}

--- a/apple/Tests/FerrostarCoreTests/FerrostarCoreTests.swift
+++ b/apple/Tests/FerrostarCoreTests/FerrostarCoreTests.swift
@@ -6,6 +6,7 @@ import struct FerrostarCore.Route
 import protocol FerrostarCore.FerrostarCoreDelegate
 import enum FerrostarCore.CorrectiveAction
 import class FerrostarCore.FerrostarCore
+import struct FerrostarCore.NavigationControllerConfig
 import UniFFI
 import XCTest
 import SnapshotTesting
@@ -116,10 +117,12 @@ final class FerrostarCoreTests: XCTestCase {
         let routes = try await core.getRoutes(initialLocation: CLLocation(latitude: 60.5347155, longitude: -149.543469), waypoints: [CLLocationCoordinate2D(latitude: 60.5349908, longitude: -149.5485806)])
 
         locationProvider.lastLocation = CLLocation(latitude: 0, longitude: 0)
-        try core.startNavigation(route: routes.first!, stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 16, automaticAdvanceDistance: 16), routeDeviationTracking: .custom(detector: { userLocation, route, step in
+        let config = NavigationControllerConfig(stepAdvance: .relativeLineStringDistance(minimumHorizontalAccuracy: 16, automaticAdvanceDistance: 16), routeDeviationTracking: .custom(detector: { userLocation, route, step in
             // Pretend that the user is always off route
             .offRoute(deviationFromRouteLine: 42)
         }))
+
+        try core.startNavigation(route: routes.first!, config: config)
 
         await fulfillment(of: [routeDeviationCallbackExp], timeout: 1.0)
         await fulfillment(of: [loadedAltRoutesExp], timeout: 1.0)

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -135,15 +135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,12 +288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
-
-[[package]]
 name = "earcutr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4841b40fdbccd4b7042bd6195e4de91da54af34c50632e371bcbfcdfb558b873"
+checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
 dependencies = [
  "earcutr",
  "float_next_after",
@@ -395,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567495020b114f1ce9bed679b29975aa0bfae06ac22beacd5cfde5dabe7b05d6"
+checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
 dependencies = [
  "approx",
  "num-traits",
@@ -444,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -463,14 +448,11 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "atomic-polyfill",
  "hash32",
- "rustc_version",
- "spin",
  "stable_deref_trait",
 ]
 
@@ -538,16 +520,6 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -739,22 +711,13 @@ checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
 
 [[package]]
 name = "rstar"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73111312eb7a2287d229f06c00ff35b51ddee180f017ab6dec1f69d62ac098d6"
+checksum = "133315eb94c7b1e8d0cb097e5a710d850263372fd028fff18969de708afc7008"
 dependencies = [
  "heapless",
  "num-traits",
  "smallvec",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
 ]
 
 [[package]]
@@ -787,12 +750,6 @@ name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
@@ -891,15 +848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,9 +867,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -930,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,6 +6,13 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+authors = ["Ian Wagner <ian@stadiamaps.com>", "Jacob Fielding <jacob@rallista.app>", "Luke Seelenbinder <luke@stadiamaps.com>"]
+license = "BSD-3-Clause"
+edition = "2021"
+repository = "https://github.com/stadiamaps/ferrostar"
+rust-version = "1.74.0"
+
 [profile.dev.package]
 insta.opt-level = 3
 similar.opt-level = 3

--- a/common/ferrostar/Cargo.toml
+++ b/common/ferrostar/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "ferrostar"
 version = "0.0.18"
-authors = ["Ian Wagner <ian@stadiamaps.com>", "Jacob Fielding <jacob@rallista.app>", "Luke Seelenbinder <luke@stadiamaps.com>"]
-license = "BSD-3-Clause"
-repository = "https://github.com/stadiamaps/ferrostar"
 readme = "README.md"
 description = "The core of modern turn-by-turn navigation."
 keywords = ["navigation", "routing", "valhalla", "osrm"]
 categories = ["science::geo"]
-edition = "2021"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-geo = "0.27.0"
+geo = "0.28.0"
 polyline = "0.10.0"
 serde = { version = "1.0.162", features = ["derive"] }
 serde_json = "1.0.96"

--- a/common/ferrostar/Cargo.toml
+++ b/common/ferrostar/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ferrostar"
 version = "0.0.18"
-authors = ["Ian Wagner <ian@stadiamaps.com>", "Luke Seelenbinder <luke@stadiamaps.com>"]
+authors = ["Ian Wagner <ian@stadiamaps.com>", "Jacob Fielding <jacob@rallista.app>", "Luke Seelenbinder <luke@stadiamaps.com>"]
 license = "BSD-3-Clause"
 repository = "https://github.com/stadiamaps/ferrostar"
 readme = "README.md"

--- a/common/uniffi-bindgen/Cargo.toml
+++ b/common/uniffi-bindgen/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "uniffi-bindgen"
 version = "0.1.0"
-license = "BSD-3-Clause"
-edition = "2021"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Worth noting that I made a breaking API change to the `startNavigation` method as well. It now matches the Kotlin interface. It arguably isn't as Swifty, but I think this is probably a better API than accepting half a dozen parameters in 6 months. Moving the config to a separate object which can change, evolve new convenience initializers, etc. seems better.

Also closes #60 and closes #58