### PR TITLE
Clean up location interfaces

### DIFF
--- a/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/FerrostarCoreTest.kt
+++ b/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/FerrostarCoreTest.kt
@@ -287,7 +287,7 @@ class FerrostarCoreTest {
                         kind = WaypointKind.BREAK)))
 
     locationProvider.lastLocation =
-        SimulatedLocation(GeographicCoordinate(0.0, 0.0), 6.0, null, Instant.now())
+        UserLocation(GeographicCoordinate(0.0, 0.0), 6.0, null, Instant.now())
     core.startNavigation(
         routes.first(),
         NavigationControllerConfig(

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
@@ -23,10 +23,10 @@ data class NavigationUiState(
 
 class NavigationViewModel(
     stateFlow: StateFlow<FerrostarCoreState>,
-    initialUserLocation: Location,
+    initialUserLocation: UserLocation,
     private val routeGeometry: List<GeographicCoordinate>,
 ) : ViewModel() {
-  private var lastLocation: UserLocation = initialUserLocation.userLocation()
+  private var lastLocation: UserLocation = initialUserLocation
 
   val uiState =
       stateFlow
@@ -45,7 +45,7 @@ class NavigationViewModel(
           .stateIn(
               scope = viewModelScope,
               started = SharingStarted.WhileSubscribed(),
-              initialValue = uiState(stateFlow.value, initialUserLocation.userLocation()))
+              initialValue = uiState(stateFlow.value, initialUserLocation))
 
   private fun uiState(coreState: FerrostarCoreState, location: UserLocation) =
       NavigationUiState(

--- a/android/core/src/test/java/com/stadiamaps/ferrostar/core/SimulatedLocationProviderTest.kt
+++ b/android/core/src/test/java/com/stadiamaps/ferrostar/core/SimulatedLocationProviderTest.kt
@@ -7,6 +7,8 @@ import java.util.concurrent.TimeUnit
 import org.junit.Assert.*
 import org.junit.Test
 import uniffi.ferrostar.GeographicCoordinate
+import uniffi.ferrostar.Heading
+import uniffi.ferrostar.UserLocation
 
 class SimulatedLocationProviderTest {
   @Test
@@ -20,7 +22,7 @@ class SimulatedLocationProviderTest {
   @Test
   fun `set location`() {
     val locationProvider = SimulatedLocationProvider()
-    val location = SimulatedLocation(GeographicCoordinate(42.02, 24.0), 12.0, null, Instant.now())
+    val location = UserLocation(GeographicCoordinate(42.02, 24.0), 12.0, null, Instant.now())
 
     locationProvider.lastLocation = location
 
@@ -31,17 +33,17 @@ class SimulatedLocationProviderTest {
   fun `test listener events`() {
     val latch = CountDownLatch(1)
     val locationProvider = SimulatedLocationProvider()
-    val location = SimulatedLocation(GeographicCoordinate(42.02, 24.0), 12.0, null, Instant.now())
+    val location = UserLocation(GeographicCoordinate(42.02, 24.0), 12.0, null, Instant.now())
 
     val listener =
         object : LocationUpdateListener {
-          override fun onLocationUpdated(location: Location) {
+          override fun onLocationUpdated(location: UserLocation) {
             assertEquals(location, location)
 
             latch.countDown()
           }
 
-          override fun onHeadingUpdated(heading: Float) {
+          override fun onHeadingUpdated(heading: Heading) {
             fail("Unexpected heading update")
           }
         }

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/MainActivity.kt
@@ -24,7 +24,6 @@ import com.stadiamaps.ferrostar.core.CorrectiveAction
 import com.stadiamaps.ferrostar.core.FerrostarCore
 import com.stadiamaps.ferrostar.core.NavigationViewModel
 import com.stadiamaps.ferrostar.core.RouteDeviationHandler
-import com.stadiamaps.ferrostar.core.SimulatedLocation
 import com.stadiamaps.ferrostar.core.SimulatedLocationProvider
 import com.stadiamaps.ferrostar.maplibreui.NavigationMapView
 import com.stadiamaps.ferrostar.ui.theme.FerrostarTheme
@@ -42,6 +41,7 @@ import uniffi.ferrostar.NavigationControllerConfig
 import uniffi.ferrostar.RouteDeviationTracking
 import uniffi.ferrostar.SimulationSpeed
 import uniffi.ferrostar.StepAdvanceMode
+import uniffi.ferrostar.UserLocation
 import uniffi.ferrostar.Waypoint
 import uniffi.ferrostar.WaypointKind
 import uniffi.ferrostar.advanceLocationSimulation
@@ -49,7 +49,7 @@ import uniffi.ferrostar.locationSimulationFromRoute
 
 class MainActivity : ComponentActivity() {
   private val initialSimulatedLocation =
-      SimulatedLocation(
+      UserLocation(
           GeographicCoordinate(37.807770999999995, -122.41970699999999), 6.0, null, Instant.now())
   private val locationProvider = SimulatedLocationProvider()
   private val httpClient = OkHttpClient.Builder().callTimeout(Duration.ofSeconds(15)).build()
@@ -97,7 +97,7 @@ class MainActivity : ComponentActivity() {
         launch(Dispatchers.IO) {
           val routes =
               core.getRoutes(
-                  initialSimulatedLocation.userLocation(),
+                  initialSimulatedLocation,
                   listOf(
                       Waypoint(
                           coordinate = GeographicCoordinate(37.807587, -122.428411),
@@ -121,7 +121,7 @@ class MainActivity : ComponentActivity() {
             simulationState =
                 advanceLocationSimulation(simulationState, SimulationSpeed.JUMP_TO_NEXT_LOCATION)
             locationProvider.lastLocation =
-                SimulatedLocation(simulationState.currentLocation, 6.0, null, Instant.now())
+                UserLocation(simulationState.currentLocation, 6.0, null, Instant.now())
           }
         }
       }

--- a/apple/Sources/UniFFI/ferrostar.swift
+++ b/apple/Sources/UniFFI/ferrostar.swift
@@ -1965,6 +1965,9 @@ public func FfiConverterTypeSpokenInstruction_lower(_ value: SpokenInstruction) 
  *
  * In addition to coordinates, this includes estimated accuracy and course information,
  * which can influence navigation logic and UI.
+ *
+ * NOTE: Heading is absent on purpose.
+ * Heading updates are not related to a change in the user's location.
  */
 public struct UserLocation {
     public var coordinates: GeographicCoordinate

--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -123,6 +123,9 @@ impl CourseOverGround {
 ///
 /// In addition to coordinates, this includes estimated accuracy and course information,
 /// which can influence navigation logic and UI.
+///
+/// NOTE: Heading is absent on purpose.
+/// Heading updates are not related to a change in the user's location.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, uniffi::Record)]
 pub struct UserLocation {
     pub coordinates: GeographicCoordinate,


### PR DESCRIPTION
Switches to using Ferrostar types everywhere. This lets us ditch a separate type on Android, sidesteps a whole problem of whether to link in Android deps (didn't want to anyways), and generally a bunch of minor improvements / clarifications