### PR TITLE
Fix dark mode background color in iOS InstructionsView

### DIFF
--- a/apple/Sources/FerrostarSwiftUI/Theme/InstructionRowTheme.swift
+++ b/apple/Sources/FerrostarSwiftUI/Theme/InstructionRowTheme.swift
@@ -15,6 +15,9 @@ public protocol InstructionRowTheme {
 
     /// The color of the icon.
     var iconTintColor: Color { get }
+    
+    /// The color of the background.
+    var backgroundColor: Color { get }
 }
 
 public struct DefaultInstructionRowTheme: InstructionRowTheme, Equatable, Hashable {
@@ -23,6 +26,7 @@ public struct DefaultInstructionRowTheme: InstructionRowTheme, Equatable, Hashab
     public var instructionColor: Color = .secondary
     public var instructionFont: Font = .title2
     public var iconTintColor: Color = .primary
+    public var backgroundColor: Color = Color(.systemBackground)
 
     public init() {
         // No action. Create your own theme or modify this inline if you want to customize
@@ -35,6 +39,7 @@ public struct DefaultSecondaryInstructionRowTheme: InstructionRowTheme, Equatabl
     public var instructionColor: Color = .secondary
     public var instructionFont: Font = .subheadline
     public var iconTintColor: Color = .primary
+    public var backgroundColor: Color = Color(.secondarySystemBackground)
 
     public init() {
         // No action. Create your own theme or modify this inline if you want to customize

--- a/apple/Sources/FerrostarSwiftUI/Theme/InstructionRowTheme.swift
+++ b/apple/Sources/FerrostarSwiftUI/Theme/InstructionRowTheme.swift
@@ -15,7 +15,7 @@ public protocol InstructionRowTheme {
 
     /// The color of the icon.
     var iconTintColor: Color { get }
-    
+
     /// The color of the background.
     var backgroundColor: Color { get }
 }
@@ -26,7 +26,7 @@ public struct DefaultInstructionRowTheme: InstructionRowTheme, Equatable, Hashab
     public var instructionColor: Color = .secondary
     public var instructionFont: Font = .title2
     public var iconTintColor: Color = .primary
-    public var backgroundColor: Color = Color(.systemBackground)
+    public var backgroundColor: Color = .init(.systemBackground)
 
     public init() {
         // No action. Create your own theme or modify this inline if you want to customize
@@ -39,7 +39,7 @@ public struct DefaultSecondaryInstructionRowTheme: InstructionRowTheme, Equatabl
     public var instructionColor: Color = .secondary
     public var instructionFont: Font = .subheadline
     public var iconTintColor: Color = .primary
-    public var backgroundColor: Color = Color(.secondarySystemBackground)
+    public var backgroundColor: Color = .init(.secondarySystemBackground)
 
     public init() {
         // No action. Create your own theme or modify this inline if you want to customize

--- a/apple/Sources/FerrostarSwiftUI/Views/InstructionsView.swift
+++ b/apple/Sources/FerrostarSwiftUI/Views/InstructionsView.swift
@@ -77,7 +77,7 @@ public struct InstructionsView: View {
                 pillControl(isActive: showPillControl)
             }
         }
-        .background(Color.white)
+        .background(secondaryRowTheme.backgroundColor)
         .clipShape(.rect(cornerRadius: 12))
         .padding()
         .shadow(radius: 12)

--- a/apple/Sources/FerrostarSwiftUI/Views/InstructionsView.swift
+++ b/apple/Sources/FerrostarSwiftUI/Views/InstructionsView.swift
@@ -77,7 +77,7 @@ public struct InstructionsView: View {
                 pillControl(isActive: showPillControl)
             }
         }
-        .background(secondaryRowTheme.backgroundColor)
+        .background(primaryRowTheme.backgroundColor)
         .clipShape(.rect(cornerRadius: 12))
         .padding()
         .shadow(radius: 12)


### PR DESCRIPTION
In dark mode, the background of the InstructionsView remains white, making the text invisible.
![screenshot](https://github.com/stadiamaps/ferrostar/assets/7774491/75ecccf3-c070-4af0-8c67-951dd69221c5)

This adds `backgroundColor` to `InstructionRowTheme` and uses it in `InstructionsView` to render instruction cards in dark mode correctly.