### PR TITLE
Android packaging + fixes and ios speech

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -42,6 +42,9 @@ jobs:
       working-directory: android
       
     - name: Build with Gradle
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./gradlew build
       working-directory: android
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -118,7 +118,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.2'
+        xcode-version: '15.3'
 
     - name: Install xcbeautify
       run: brew install xcbeautify

--- a/android/MapLibreUI/build.gradle
+++ b/android/MapLibreUI/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0'
 
-    implementation 'io.github.rallista:maplibre-compose:0.0.3'
+    api 'io.github.rallista:maplibre-compose:0.0.5'
 
     implementation project(':core')
     implementation project(':compose-ui')

--- a/android/MapLibreUI/src/main/java/com/stadiamaps/ferrostar/maplibreui/BorderedPolyline.kt
+++ b/android/MapLibreUI/src/main/java/com/stadiamaps/ferrostar/maplibreui/BorderedPolyline.kt
@@ -2,7 +2,7 @@ package com.stadiamaps.ferrostar.maplibreui
 
 import androidx.compose.runtime.Composable
 import com.mapbox.mapboxsdk.geometry.LatLng
-import org.ramani.compose.Polyline
+import com.maplibre.compose.symbols.Polyline
 
 @Composable
 fun BorderedPolyline(

--- a/android/MapLibreUI/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
+++ b/android/MapLibreUI/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
@@ -3,54 +3,66 @@ package com.stadiamaps.ferrostar.maplibreui
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import com.mapbox.mapboxsdk.geometry.LatLng
+import com.maplibre.compose.MapView
+import com.maplibre.compose.StaticLocationEngine
+import com.maplibre.compose.camera.CameraPitch
+import com.maplibre.compose.camera.MapViewCamera
+import com.maplibre.compose.ramani.LocationPriority
+import com.maplibre.compose.ramani.LocationRequestProperties
+import com.maplibre.compose.ramani.MapLibreComposable
 import com.stadiamaps.ferrostar.composeui.BannerInstructionView
+import com.stadiamaps.ferrostar.core.NavigationUiState
 import com.stadiamaps.ferrostar.core.NavigationViewModel
-import org.ramani.compose.CameraMotionType
-import org.ramani.compose.CameraPosition
-import org.ramani.compose.Circle
-import org.ramani.compose.MapLibre
+import com.stadiamaps.ferrostar.core.toAndroidLocation
 import uniffi.ferrostar.VisualInstruction
 
 @Composable
 fun NavigationMapView(
     styleUrl: String,
     viewModel: NavigationViewModel,
+    locationRequestProperties: LocationRequestProperties =
+        LocationRequestProperties.Builder()
+            .priority(LocationPriority.PRIORITY_HIGH_ACCURACY)
+            .interval(1000L)
+            .fastestInterval(0L)
+            .displacement(0F)
+            .maxWaitTime(1000L)
+            .build(),
     bannerContentBuilder: @Composable (VisualInstruction, Double?) -> Unit =
         { instruction, distanceToNextManeuver ->
           BannerInstructionView(instruction, distanceToNextManeuver)
-        }
+        },
+    content: @Composable @MapLibreComposable() ((State<NavigationUiState>) -> Unit)? = null
 ) {
   val uiState = viewModel.uiState.collectAsState()
+  val locationEngine = remember { StaticLocationEngine() }
+  locationEngine.lastLocation = uiState.value.snappedLocation.toAndroidLocation()
+  val camera = rememberSaveable { mutableStateOf(MapViewCamera()) }
+  // FIXME: Pitch is not being propagated
+  camera.value = MapViewCamera.TrackingUserLocationWithBearing(18.0, CameraPitch.Fixed(45.0))
 
   Box {
-    MapLibre(
+    MapView(
         modifier = Modifier.fillMaxSize(),
         styleUrl = styleUrl,
-        cameraPosition =
-            CameraPosition(
-                target =
-                    LatLng(
-                        uiState.value.snappedLocation.coordinates.lat,
-                        uiState.value.snappedLocation.coordinates.lng),
-                zoom = 18.0,
-                tilt = 45.0,
-                bearing = uiState.value.snappedLocation.courseOverGround?.degrees?.toDouble(),
-                motionType = CameraMotionType.EASE)) {
-          BorderedPolyline(
-              points = uiState.value.routeGeometry.map { LatLng(it.lat, it.lng) }, zIndex = 1)
-          Circle(
-              center =
-                  LatLng(
-                      uiState.value.snappedLocation.coordinates.lat,
-                      uiState.value.snappedLocation.coordinates.lng),
-              radius = 10f,
-              color = "Blue",
-              zIndex = 2,
-          )
-        }
+        camera = camera,
+        locationRequestProperties = locationRequestProperties,
+        locationEngine = locationEngine,
+    ) {
+      BorderedPolyline(
+          points = uiState.value.routeGeometry.map { LatLng(it.lat, it.lng) }, zIndex = 0)
+
+      if (content != null) {
+        content(uiState)
+      }
+    }
 
     uiState.value.visualInstruction?.let {
       bannerContentBuilder(it, uiState.value.distanceToNextManeuver)

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/Speech.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/Speech.kt
@@ -63,7 +63,7 @@ class AndroidTtsObserver(
     set(value) {
       field = value
 
-      if (tts?.isSpeaking == true) {
+      if (value && tts?.isSpeaking == true) {
         tts?.stop()
       }
     }

--- a/android/demo-app/build.gradle
+++ b/android/demo-app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
     implementation 'androidx.activity:activity-compose:1.8.2'
 
-    implementation platform('androidx.compose:compose-bom:2024.02.00')
+    implementation platform('androidx.compose:compose-bom:2024.03.00')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
@@ -63,6 +63,8 @@ dependencies {
     implementation project(':core')
     implementation project(':MapLibreUI')
 
+    implementation 'io.github.rallista:maplibre-compose:0.0.5'
+
     implementation platform("com.squareup.okhttp3:okhttp-bom:4.10.0")
     implementation 'com.squareup.okhttp3:okhttp'
 
@@ -70,7 +72,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
-    androidTestImplementation platform('androidx.compose:compose-bom:2024.02.00')
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.03.00')
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
 
     debugImplementation 'androidx.compose.ui:ui-tooling'

--- a/android/demo-app/src/main/AndroidManifest.xml
+++ b/android/demo-app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/apple/DemoApp/Demo/DemoNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoNavigationView.swift
@@ -15,6 +15,7 @@ private let initialLocation = CLLocation(latitude: 37.332726,
 
 struct DemoNavigationView: View {
     private let navigationDelegate = NavigationDelegate()
+    private let spokenInstructionObserver = AVSpeechSpokenInstructionObserver(isMuted: false)
 
     private var locationProvider: LocationProviding
     @ObservedObject private var ferrostarCore: FerrostarCore
@@ -45,6 +46,14 @@ struct DemoNavigationView: View {
         )
         // NOTE: Not all applications will need a delegate. Read the NavigationDelegate documentation for details.
         ferrostarCore.delegate = navigationDelegate
+
+        // Initialize text-to-speech; note that this is NOT automatic.
+        // You must set a spokenInstructionObserver.
+        // Fortunately, this is pretty easy with the provided class
+        // backed by AVSpeechSynthesizer.
+        // You can customize the instance it further as needed,
+        // or replace with your own.
+        ferrostarCore.spokenInstructionObserver = spokenInstructionObserver
     }
 
     var body: some View {

--- a/apple/Sources/FerrostarCore/Speech.swift
+++ b/apple/Sources/FerrostarCore/Speech.swift
@@ -1,0 +1,46 @@
+import AVFoundation
+import FerrostarCoreFFI
+import Foundation
+
+public protocol SpokenInstructionObserver {
+    /// Handles spoken instructions as they are triggered.
+    ///
+    /// As long as it is used with the supplied ``FerrostarCore`` class,
+    /// implementors may assume this function will never be called twice
+    /// for the same instruction during a navigation session.
+    func spokenInstructionTriggered(_ instruction: SpokenInstruction)
+
+    var isMuted: Bool { get set }
+}
+
+public class AVSpeechSpokenInstructionObserver: SpokenInstructionObserver {
+    public var isMuted: Bool {
+        didSet {
+            if isMuted, synthesizer.isSpeaking {
+                synthesizer.stopSpeaking(at: .immediate)
+            }
+        }
+    }
+    public let synthesizer = AVSpeechSynthesizer()
+
+    public init(isMuted: Bool) {
+        self.isMuted = isMuted
+    }
+
+    public func spokenInstructionTriggered(_ instruction: FerrostarCoreFFI.SpokenInstruction) {
+        guard !isMuted else {
+            return
+        }
+
+        let utterance: AVSpeechUtterance = if #available(iOS 16.0, *),
+                                              let ssml = instruction.ssml,
+                                              let ssmlUtterance = AVSpeechUtterance(ssmlRepresentation: ssml)
+        {
+            ssmlUtterance
+        } else {
+            AVSpeechUtterance(string: instruction.text)
+        }
+
+        synthesizer.speak(utterance)
+    }
+}

--- a/apple/Sources/FerrostarCore/Speech.swift
+++ b/apple/Sources/FerrostarCore/Speech.swift
@@ -21,6 +21,7 @@ public class AVSpeechSpokenInstructionObserver: SpokenInstructionObserver {
             }
         }
     }
+
     public let synthesizer = AVSpeechSynthesizer()
 
     public init(isMuted: Bool) {

--- a/common/ferrostar/src/routing_adapters/valhalla.rs
+++ b/common/ferrostar/src/routing_adapters/valhalla.rs
@@ -79,6 +79,7 @@ impl RouteRequestGenerator for ValhallaHttpRequestGenerator {
                     ]
                 },
                 "banner_instructions": true,
+                "voice_instructions": true,
                 "costing": &self.profile,
                 "locations": locations,
             });


### PR DESCRIPTION
* Upgrades to latest MapLibre Compose plugin from Rallista
  - Support for location tracking
  - Ports the location engine from iOS to enable piping processed updates from Ferrostar -> MapLibre
  - This SHOULD enable packaging on Android again
* Adds location tracking (defaults) to Android, basically matching iOS now (though there are some issues with it like the puck showing up UNDER the polyline)
* The Android map view is now composable; you can add your own layers using the provided composables on top of the base map view!
* Adds speech protocol to Swift + AVSpeechSynthesizer integration
* Requests voice instructions from Valhalla servers (note that this relies on server support; it's a pretty new feature)