### PR TITLE
Fix breaking out from navigation camera on iOS

### DIFF
--- a/apple/DemoApp/Demo/DemoNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoNavigationView.swift
@@ -32,6 +32,7 @@ struct DemoNavigationView: View {
     }
 
     @State private var camera: MapViewCamera = .center(initialLocation.coordinate, zoom: 14)
+    @State private var snappedCamera = true
 
     init() {
         let simulated = SimulatedLocationProvider(location: initialLocation)
@@ -67,7 +68,7 @@ struct DemoNavigationView: View {
                 navigationState: ferrostarCore.state,
                 camera: $camera,
                 snappedZoom: .constant(18),
-                useSnappedCamera: .constant(true)
+                useSnappedCamera: $snappedCamera
             ) {
                 let source = ShapeSource(identifier: "userLocation") {
                     // Demonstrate how to add a dynamic overlay;

--- a/apple/Sources/FerrostarMapLibreUI/Views/NavigationMapView.swift
+++ b/apple/Sources/FerrostarMapLibreUI/Views/NavigationMapView.swift
@@ -118,8 +118,8 @@ public struct NavigationMapView: View {
         .gesture(
             DragGesture()
                 .onChanged { gesture in
-                    guard gesture.velocity.width > breakwayVelocity
-                        || gesture.velocity.height > breakwayVelocity
+                    guard abs(gesture.velocity.width) > breakwayVelocity
+                        || abs(gesture.velocity.height) > breakwayVelocity
                     else {
                         return
                     }


### PR DESCRIPTION
Two small changes to fix breaking out from the navigation camera on iOS:

1. Use a binding for the snapped instead of a constant to allow user to break from navigation camera.

It could be that this was done intentional to not allow breaking out from the navigation at all when using the `DemoNavigationView`. If so, feel free to ignore. The behavior looks quite buggy right now though because even if the user tries to move the map during navigation it will try to snap back to the user location.

2. Drag gesture velocity can be negative. So we should check the absolute value of the gesture velocity against the `breakwayVelocity`.