### PR TITLE
Correct a bad package name in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ Run the `ktfmtFormat` gradle action before committing to ensure consistent forma
 
 ### Common Core
 
-Run `cargo test -p ferrostar-core` from within the `common` directory to run tests.
+Run `cargo test -p ferrostar` from within the `common` directory to run tests.
 
 ### Web
 


### PR DESCRIPTION
It appears that the Rust core package name was changed some time ago. Since CI does not use this command for testing, we were not aware of this issue until now.