### PR TITLE
Use a minimal Vite serving allow list

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   server: {
     fs: {
-      // Allow serving files from one level up to the project root
+      // Allow serving the wasm module
       allow: [".", "../common/ferrostar/pkg"],
     },
   },

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -4,7 +4,7 @@ export default defineConfig({
   server: {
     fs: {
       // Allow serving files from one level up to the project root
-      allow: [".."],
+      allow: [".", "../common/ferrostar/pkg"],
     },
   },
 });


### PR DESCRIPTION
This change restricts Vite to only access the necessary files (specifically, the wasm-bindgen NPM package) rather than the entire repository.