### PR TITLE
Use camelCase in web implementations

### DIFF
--- a/common/ferrostar/src/deviation_detection.rs
+++ b/common/ferrostar/src/deviation_detection.rs
@@ -44,6 +44,7 @@ pub enum RouteDeviationTracking {
     /// No checks will be done, and we assume the user is always following the route.
     None,
     /// Detects deviation from the route using a configurable static distance threshold from the route line.
+    #[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
     StaticThreshold {
         /// The minimum required horizontal accuracy of the user location, in meters.
         /// Values larger than this will not trigger route deviation warnings.
@@ -115,6 +116,7 @@ pub enum RouteDeviation {
     /// The user is proceeding on course within the expected tolerances; everything is normal.
     NoDeviation,
     /// The user is off the expected route.
+    #[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
     OffRoute {
         /// The deviation from the route line, in meters.
         deviation_from_route_line: f64,

--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -183,6 +183,7 @@ pub struct Speed {
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(any(feature = "wasm-bindgen", test), derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
 pub struct UserLocation {
     pub coordinates: GeographicCoordinate,
     /// The estimated accuracy of the coordinate (in meters)
@@ -236,6 +237,7 @@ fn get_route_polyline(route: &Route, precision: u32) -> Result<String, ModelErro
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(any(feature = "wasm-bindgen", test), derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
 pub struct RouteStep {
     pub geometry: Vec<GeographicCoordinate>,
     /// The distance, in meters, to travel along the route after the maneuver to reach the next step.
@@ -311,6 +313,7 @@ impl RouteStep {
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(any(feature = "wasm-bindgen", test), derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
 pub struct SpokenInstruction {
     /// Plain-text instruction which can be synthesized with a TTS engine.
     pub text: String,
@@ -387,6 +390,7 @@ pub enum ManeuverModifier {
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(any(feature = "wasm-bindgen", test), derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
 pub struct VisualInstructionContent {
     /// The text to display.
     pub text: String,
@@ -406,6 +410,7 @@ pub struct VisualInstructionContent {
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(any(feature = "wasm-bindgen", test), derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
 pub struct VisualInstruction {
     /// The primary instruction content.
     ///

--- a/common/ferrostar/src/navigation_controller/mod.rs
+++ b/common/ferrostar/src/navigation_controller/mod.rs
@@ -272,6 +272,7 @@ impl JsNavigationController {
         )))
     }
 
+    #[wasm_bindgen(js_name = getInitialState)]
     pub fn get_initial_state(&self, location: JsValue) -> Result<JsValue, JsValue> {
         let location: UserLocation = serde_wasm_bindgen::from_value(location)?;
 
@@ -286,6 +287,7 @@ impl JsNavigationController {
             .map_err(|e| JsValue::from_str(&format!("{:?}", e)))
     }
 
+    #[wasm_bindgen(js_name = updateUserLocation)]
     pub fn update_user_location(
         &self,
         location: JsValue,

--- a/common/ferrostar/src/navigation_controller/models.rs
+++ b/common/ferrostar/src/navigation_controller/models.rs
@@ -28,6 +28,7 @@ pub struct TripProgress {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 #[cfg_attr(feature = "wasm-bindgen", derive(Serialize, Deserialize))]
 pub enum TripState {
+    #[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
     Navigating {
         snapped_user_location: UserLocation,
         /// The ordered list of steps that remain in the trip.
@@ -81,6 +82,7 @@ pub enum StepAdvanceMode {
     /// You can use this to implement custom behaviors in external code.
     Manual,
     /// Automatically advances when the user's location is close enough to the end of the step
+    #[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
     DistanceToEndOfStep {
         /// Distance to the last waypoint in the step, measured in meters, at which to advance.
         distance: u16,
@@ -90,6 +92,7 @@ pub enum StepAdvanceMode {
     },
     /// Automatically advances when the user's distance to the *next* step's linestring  is less
     /// than the distance to the current step's linestring.
+    #[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
     RelativeLineStringDistance {
         /// The minimum required horizontal accuracy of the user location, in meters.
         /// Values larger than this cannot trigger a step advance.
@@ -103,6 +106,7 @@ pub enum StepAdvanceMode {
 #[derive(Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm-bindgen", derive(Deserialize))]
+#[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
 pub struct NavigationControllerConfig {
     pub step_advance: StepAdvanceMode,
     pub route_deviation_tracking: RouteDeviationTracking,

--- a/common/ferrostar/src/routing_adapters/mod.rs
+++ b/common/ferrostar/src/routing_adapters/mod.rs
@@ -186,7 +186,7 @@ impl RouteAdapter {
 pub struct JsRouteAdapter(RouteAdapter);
 
 #[cfg(feature = "wasm-bindgen")]
-#[ wasm_bindgen(js_class = RouteAdapter)]
+#[wasm_bindgen(js_class = RouteAdapter)]
 impl JsRouteAdapter {
     /// Creates a new RouteAdapter with a Valhalla HTTP request generator and an OSRM response parser.
     /// At the moment, this is the only supported combination.
@@ -202,6 +202,7 @@ impl JsRouteAdapter {
         // TODO: We should have a better error handling strategy here. Same for the other methods.
     }
 
+    #[wasm_bindgen(js_name = generateRequest)]
     pub fn generate_request(
         &self,
         user_location: JsValue,
@@ -226,6 +227,7 @@ impl JsRouteAdapter {
         }
     }
 
+    #[wasm_bindgen(js_name = parseResponse)]
     pub fn parse_response(&self, response: Vec<u8>) -> Result<JsValue, JsValue> {
         match self.0.parse_response(response.into()) {
             Ok(routes) => serde_wasm_bindgen::to_value(&routes).map_err(JsValue::from),

--- a/web/index.html
+++ b/web/index.html
@@ -29,18 +29,18 @@
     <script type="module">
       import { SimulatedLocationProvider, BrowserLocationProvider } from "/src/location.ts";
 
-      // FIXME: type + should be camelCase
+      // TODO: type + use TypeScript enum
       const config = {
-        step_advance: {
+        stepAdvance: {
           RelativeLineStringDistance: {
-            minimum_horizontal_accuracy: 25,
-            automatic_advance_distance: 10,
+            minimumHorizontalAccuracy: 25,
+            automaticAdvanceDistance: 10,
           },
         },
-        route_deviation_tracking: {
+        routeDeviationTracking: {
           StaticThreshold: {
-            minimum_horizontal_accuracy: 25,
-            max_acceptable_deviation: 10.0,
+            minimumHorizontalAccuracy: 25,
+            maxAcceptableDeviation: 10.0,
           },
         },
       };
@@ -79,8 +79,8 @@
         simulateNavigationButton.addEventListener("click", async () => {
           const initialSimulatedLocation = {
             coordinates: { lat: 37.807770999999995, lng: -122.41970699999999 },
-            horizontal_accuracy: 6.0,
-            course_over_ground: null,
+            horizontalAccuracy: 6.0,
+            courseOverGround: null,
             // TODO: find a better way to create the timestamp?
             timestamp: {
               secs_since_epoch: Math.floor(Date.now() / 1000),

--- a/web/src/ferrostar-core.ts
+++ b/web/src/ferrostar-core.ts
@@ -73,15 +73,18 @@ class FerrostarCore extends LitElement {
   // TODO: type
   async getRoutes(initialLocation: any, waypoints: any) {
     await init();
+
     this.routeAdapter = new RouteAdapter(this.valhallaEndpointUrl, this.profile);
 
     const body = this.routeAdapter.generateRequest(initialLocation, waypoints).get("body");
+
     // FIXME: assert httpClient is not null
     const response = await this.httpClient!(this.valhallaEndpointUrl, {
       method: "POST",
       // FIXME: assert body is not null
       body: new Uint8Array(body).buffer,
     });
+
     const responseData = new Uint8Array(await response.arrayBuffer());
     const routes = this.routeAdapter.parseResponse(responseData);
 
@@ -97,8 +100,8 @@ class FerrostarCore extends LitElement {
       ? this.locationProvider.lastLocation
       : {
           coordinates: route.geometry[0],
-          horizontal_accuracy: 0.0,
-          course_over_ground: null,
+          horizontalAccuracy: 0.0,
+          courseOverGround: null,
           // TODO: find a better way to create the timestamp?
           timestamp: {
             secs_since_epoch: Math.floor(Date.now() / 1000),

--- a/web/src/ferrostar-core.ts
+++ b/web/src/ferrostar-core.ts
@@ -75,7 +75,7 @@ class FerrostarCore extends LitElement {
     await init();
     this.routeAdapter = new RouteAdapter(this.valhallaEndpointUrl, this.profile);
 
-    const body = this.routeAdapter.generate_request(initialLocation, waypoints).get("body");
+    const body = this.routeAdapter.generateRequest(initialLocation, waypoints).get("body");
     // FIXME: assert httpClient is not null
     const response = await this.httpClient!(this.valhallaEndpointUrl, {
       method: "POST",
@@ -83,7 +83,7 @@ class FerrostarCore extends LitElement {
       body: new Uint8Array(body).buffer,
     });
     const responseData = new Uint8Array(await response.arrayBuffer());
-    const routes = this.routeAdapter.parse_response(responseData);
+    const routes = this.routeAdapter.parseResponse(responseData);
 
     return routes;
   }
@@ -107,8 +107,7 @@ class FerrostarCore extends LitElement {
           speed: null,
         };
 
-    // FIXME: should be camelCase
-    const initialTripState = this.navigationController.get_initial_state(startingLocation);
+    const initialTripState = this.navigationController.getInitialState(startingLocation);
     this.handleStateUpdate(initialTripState, startingLocation);
 
     const polyline = L.polyline(route.geometry, { color: "red" }).addTo(this.map!);


### PR DESCRIPTION
This PR should come earlier, or bigger: In the beginning I was going to add TypeScript types to the structs, but wasm-bindgen is [cumbersome](https://github.com/rustwasm/wasm-bindgen/issues/2407) [and](https://rustwasm.github.io/wasm-bindgen/reference/attributes/on-rust-exports/typescript_custom_section.html) [difficult](https://rustwasm.github.io/wasm-bindgen/reference/attributes/on-js-imports/typescript_type.html) in this regard, so I plan to postpone types until UI is perfected. And the only thing left to do with this PR is to replace names with camelCase.