### PR TITLE
Prevent auto lock screen while navigating on iOS

### DIFF
--- a/apple/DemoApp/Demo/DemoNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoNavigationView.swift
@@ -196,11 +196,14 @@ struct DemoNavigationView: View {
             route: route,
             config: config
         )
+
+        preventAutoLock()
     }
 
     func stopNavigation() {
         ferrostarCore.stopNavigation()
         camera = .center(initialLocation.coordinate, zoom: 14)
+        allowAutoLock()
     }
 
     var locationLabel: String {
@@ -209,6 +212,14 @@ struct DemoNavigationView: View {
         }
 
         return "±\(Int(userLocation.horizontalAccuracy))m accuracy"
+    }
+
+    private func preventAutoLock() {
+        UIApplication.shared.isIdleTimerDisabled = true
+    }
+
+    private func allowAutoLock() {
+        UIApplication.shared.isIdleTimerDisabled = false
     }
 }
 

--- a/guide/src/ios-getting-started.md
+++ b/guide/src/ios-getting-started.md
@@ -150,6 +150,19 @@ DynamicallyOrientingNavigationView(
     useSnappedCamera: .constant(true))
 ```
 
+## Preventing the screen from sleeping
+
+If you’re navigating, you probably don’t want the screen to go to sleep.
+You can prevent this by setting the `isIdleTimerDisabled` property on the `UIApplication.shared` object.
+
+```swift
+UIApplication.shared.isIdleTimerDisabled = true
+
+// Don't forget to re-enable it when you're done!
+UIApplication.shared.isIdleTimerDisabled = false
+```
+
+Refer to the [Apple documentation](https://developer.apple.com/documentation/uikit/uiapplication/1623070-isidletimerdisabled) for more information.
 
 ## Demo app
 


### PR DESCRIPTION
We certainly wouldn't want the phone to automatically lock the screen during navigation.

But I'm not so sure this should be added directly to the core, instead of the demo app. However, core itself comes with such behavior that may be unexpected, so I'll just add this to the demo app, leaving the choice to downstream developers and users.