### PR TITLE
Add auto commit action to avoid the case of forgetting to regen bindings

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -39,6 +39,8 @@ jobs:
 
     - name: Commit changed files (it is easy to forget about ferrostar.swift)
       uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        file_pattern: 'apple/Sources/UniFFI/*'
 
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -37,6 +37,9 @@ jobs:
       run: ./build-ios.sh --release
       working-directory: common
 
+    - name: Commit changed files (it is easy to forget about ferrostar.swift)
+      uses: stefanzweifel/git-auto-commit-action@v5
+
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
I noticed that the last release contained a small change to a comment which resulted in the binding source changing. Due to the way SPM works, we have to commit these, so I think it's best to just have CI auto-commit on branches for you to save the trouble ;)