### PR TITLE
Clear the TTS queue when stopping navigation

### DIFF
--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/FerrostarCore.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/FerrostarCore.kt
@@ -297,6 +297,7 @@ class FerrostarCore(
     _navigationController = null
     _state.value = NavigationState()
     _queuedUtteranceIds.clear()
+    spokenInstructionObserver?.stopAndClearQueue()
   }
 
   /**

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/Speech.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/Speech.kt
@@ -14,6 +14,9 @@ interface SpokenInstructionObserver {
    */
   fun onSpokenInstructionTrigger(spokenInstruction: SpokenInstruction)
 
+  /** Stops speech and clears the queue of spoken utterances. */
+  fun stopAndClearQueue()
+
   var isMuted: Boolean
 }
 
@@ -120,6 +123,10 @@ class AndroidTtsObserver(
     }
 
     statusObserver?.onTtsInitialized(tts, status)
+  }
+
+  override fun stopAndClearQueue() {
+    tts?.stop()
   }
 
   /**

--- a/apple/Sources/FerrostarCore/FerrostarCore.swift
+++ b/apple/Sources/FerrostarCore/FerrostarCore.swift
@@ -262,6 +262,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
         state = nil
         queuedUtteranceIDs.removeAll()
         locationProvider.stopUpdating()
+        spokenInstructionObserver?.stopAndClearQueue()
     }
 
     /// Internal state update.

--- a/apple/Sources/FerrostarCore/Speech.swift
+++ b/apple/Sources/FerrostarCore/Speech.swift
@@ -10,6 +10,9 @@ public protocol SpokenInstructionObserver {
     /// for the same instruction during a navigation session.
     func spokenInstructionTriggered(_ instruction: SpokenInstruction)
 
+    /// Stops speech and clears the queue of spoken utterances.
+    func stopAndClearQueue()
+
     var isMuted: Bool { get set }
 }
 
@@ -43,5 +46,9 @@ public class AVSpeechSpokenInstructionObserver: SpokenInstructionObserver {
         }
 
         synthesizer.speak(utterance)
+    }
+
+    public func stopAndClearQueue() {
+        synthesizer.stopSpeaking(at: .immediate)
     }
 }


### PR DESCRIPTION
This closes #117 since `stopNavigation` is called as part of the rerouting process.