### PR TITLE
feat: keep screen alive convenience for android

### DIFF
--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/runtime/KeepScreenOnDisposableEffect.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/runtime/KeepScreenOnDisposableEffect.kt
@@ -1,0 +1,40 @@
+package com.stadiamaps.ferrostar.composeui.runtime
+
+import android.app.Activity
+import android.view.Window
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
+
+/** Get the Window for the current scene (Activity). */
+@Composable
+fun window(): Window? {
+  val context = LocalContext.current
+  return (context as? Activity)?.window ?: return null
+}
+
+/** Get the WindowInsetsController for the provided window. */
+@Composable
+fun windowInsetsController(window: Window): WindowInsetsControllerCompat {
+  return WindowCompat.getInsetsController(window, window.decorView)
+}
+
+/**
+ * A Composable that keeps the screen on while the hosting Composable is in the view hierarchy.
+ * OnDispose, the flag is cleared and the screen will return to its normal behavior.
+ *
+ * See [WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON]
+ */
+@Composable
+fun KeepScreenOnDisposableEffect() {
+  val window = window() ?: return
+
+  DisposableEffect(Unit) {
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+    onDispose { window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) }
+  }
+}

--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/runtime/KeepScreenOnDisposableEffect.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/runtime/KeepScreenOnDisposableEffect.kt
@@ -23,8 +23,8 @@ fun windowInsetsController(window: Window): WindowInsetsControllerCompat {
 }
 
 /**
- * A Composable that keeps the screen on while the hosting Composable is in the view hierarchy.
- * On dispose, the flag is cleared and the screen will return to its normal behavior.
+ * A Composable that keeps the screen on while the hosting Composable is in the view hierarchy. On
+ * dispose, the flag is cleared and the screen will return to its normal behavior.
  *
  * See [WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON]
  */

--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/runtime/KeepScreenOnDisposableEffect.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/runtime/KeepScreenOnDisposableEffect.kt
@@ -24,7 +24,7 @@ fun windowInsetsController(window: Window): WindowInsetsControllerCompat {
 
 /**
  * A Composable that keeps the screen on while the hosting Composable is in the view hierarchy.
- * OnDispose, the flag is cleared and the screen will return to its normal behavior.
+ * On dispose, the flag is cleared and the screen will return to its normal behavior.
  *
  * See [WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON]
  */

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoNavigationScene.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoNavigationScene.kt
@@ -40,7 +40,7 @@ fun DemoNavigationScene(
     locationProvider: SimulatedLocationProvider = AppModule.locationProvider,
     core: FerrostarCore = AppModule.ferrostarCore
 ) {
-  // Keeps the screen at consistent brightness on while this Composable is in the view hierarchy.
+  // Keeps the screen on at a consistent brightness while this Composable is in the view hierarchy.
   // This is typically a good idea for scenes hosting navigation trips or a NavigationView.
   KeepScreenOnDisposableEffect()
 

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoNavigationScene.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoNavigationScene.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.maplibre.compose.symbols.Circle
+import com.stadiamaps.ferrostar.composeui.runtime.KeepScreenOnDisposableEffect
 import com.stadiamaps.ferrostar.core.FerrostarCore
 import com.stadiamaps.ferrostar.core.NavigationViewModel
 import com.stadiamaps.ferrostar.core.SimulatedLocationProvider
@@ -39,6 +40,10 @@ fun DemoNavigationScene(
     locationProvider: SimulatedLocationProvider = AppModule.locationProvider,
     core: FerrostarCore = AppModule.ferrostarCore
 ) {
+  // Keeps the screen at consistent brightness on while this Composable is in the view hierarchy.
+  // This is typically a good idea for scenes hosting navigation trips or a NavigationView.
+  KeepScreenOnDisposableEffect()
+
   var viewModel by remember { mutableStateOf<NavigationViewModel?>(null) }
 
   // Get location permissions.

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/runtime/AutoHideSystemUIDisposableEffect.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/runtime/AutoHideSystemUIDisposableEffect.kt
@@ -1,29 +1,14 @@
 package com.stadiamaps.ferrostar.maplibreui.runtime
 
-import android.app.Activity
 import android.graphics.Color
-import android.view.Window
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
-
-/** Get the Window for the current scene (Activity). */
-@Composable
-fun window(): Window? {
-  val context = LocalContext.current
-  return (context as? Activity)?.window ?: return null
-}
-
-/** Get the WindowInsetsController for the provided window. */
-@Composable
-fun windowInsetsController(window: Window): WindowInsetsControllerCompat {
-  return WindowCompat.getInsetsController(window, window.decorView)
-}
+import com.stadiamaps.ferrostar.composeui.runtime.window
+import com.stadiamaps.ferrostar.composeui.runtime.windowInsetsController
 
 /**
  * A Composable effect that automatically hides the system UI (status bar and navigation bar) when


### PR DESCRIPTION
- Adds keep screen alive disposable effect (and adds it to demo app)
- Revises hide system ui module path (file name mismatch).