### PR TITLE
.gitattributes: Added gitattributes to exclude demo files from stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 android/demo-app/** -linguist-detectable
 
 apple/DemoApp/** -linguist-detectable
+
+apple/Sources/UniFFI/** -linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Exclude demo apps from language stats
+# Exclude demo apps and generated code from language stats
 
 android/demo-app/** -linguist-detectable
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Exclude demo apps from language stats
+
+android/demo-app/** -linguist-detectable
+
+apple/DemoApp/** -linguist-detectable


### PR DESCRIPTION
I found out about this project from the Developer Voices podcast episode Ian appeared in! 

[In this episode](https://youtu.be/WL0jY51PQR8?si=HX-dg90cdPVdsCd9&t=2210), Ian mentions: 

Ian: "(...) Part of it is demo apps! (...) Kotlin is a very verbose language"

So I wanted to check if these demo apps were excluded from [Linguist's](https://github.com/github-linguist/linguist) analysis and I found out that they weren't!.

I added the `.gitattributes` file (following the [Documentation](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md). And I decided to run it locally just to make sure.

Spoiler alert: It didn't make _much_ of a difference, but it is "something". Plus, it could always be expanded upon! 

Before `.gitattributes`:

```shell
46.19%  371237     Swift
25.48%  204772     Kotlin
25.23%  202768     Rust
2.18%   17490      TypeScript
0.48%   3880       Shell
0.42%   3348       HTML
0.03%   225        CSS
0.01%   55         JavaScript
```

After `.gitattributes`:
```shell
46.32%  358590     Swift
26.19%  202768     Rust
24.26%  187817     Kotlin
2.26%   17490      TypeScript
0.50%   3880       Shell
0.43%   3348       HTML
0.03%   225        CSS
0.01%   55         JavaScript
```

Kotlin sure is verbose!

I hope this helps.

PS: Just wanted to say you guys are doing amazing work and this is very exciting!!! I am a big fan of maps and mapping software!

Sidenote: AFAIK, there are _some_ differences between "Raw" linguist and the one Github uses on their website. Plus, considering that the difference is small, it might be hard to notice it in the stat section (if at all).  