### PR TITLE
Publicly mutable `activityType` for changing modes.

### DIFF
--- a/apple/Sources/FerrostarCore/Location.swift
+++ b/apple/Sources/FerrostarCore/Location.swift
@@ -24,6 +24,12 @@ public class CoreLocationProvider: NSObject, ObservableObject {
 
     private let locationManager: CLLocationManager
 
+    /// The activity type of the inner CLLocationManager
+    public var activityType: CLActivityType {
+        get { locationManager.activityType }
+        set { locationManager.activityType = newValue }
+    }
+
     /// Creates a location provider backed by an internal `CLLocationManager`
     /// using the stated activity type.
     ///


### PR DESCRIPTION
If the application routes with one mode, then the user changes modes
later, we can now update the activityType without having to create and
start updating a new CoreLocationManager.
