### PR TITLE
Web cleanup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let binaryTarget: Target
 let maplibreSwiftUIDSLPackage: Package.Dependency
-let useLocalFramework = true
+let useLocalFramework = false
 let useLocalMapLibreSwiftUIDSL = false
 
 if useLocalFramework {

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let binaryTarget: Target
 let maplibreSwiftUIDSLPackage: Package.Dependency
-let useLocalFramework = false
+let useLocalFramework = true
 let useLocalMapLibreSwiftUIDSL = false
 
 if useLocalFramework {
@@ -16,7 +16,7 @@ if useLocalFramework {
         path: "./common/target/ios/libferrostar-rs.xcframework"
     )
 } else {
-    let releaseTag = "0.10.1"
+    let releaseTag = "0.11.0"
     let releaseChecksum = "cc959191f3d066f628264c103e5ea0c3544664ffd0e61907e082d7f1a4d8c5d2"
     binaryTarget = .binaryTarget(
         name: "FerrostarCoreRS",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,5 +12,5 @@ plugins {
 
 allprojects {
     group = "com.stadiamaps.ferrostar"
-    version = "0.10.1"
+    version = "0.11.0"
 }

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -337,7 +337,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "ferrostar"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "assert-json-diff",
  "geo",

--- a/common/ferrostar/Cargo.toml
+++ b/common/ferrostar/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "ferrostar"
-version = "0.10.1"
+version = "0.11.0"
 readme = "README.md"
 description = "The core of modern turn-by-turn navigation."
 keywords = ["navigation", "routing", "valhalla", "osrm"]

--- a/guide/src/ios-getting-started.md
+++ b/guide/src/ios-getting-started.md
@@ -10,6 +10,12 @@ Apple has some helpful [documentation](https://developer.apple.com/documentation
 You can search for the repository via its URL:
 `https://github.com/stadiamaps/ferrostar`.
 
+Unless you are sure you know what you’re doing, you should use a tag (rather than a branch)
+and update along with releases.
+Since auto-generated bindings have to be checked in to source control
+(due to how SPM works),
+it’s possible to have intra-release breakage if you track `master`.
+
 ## Configure location services
 
 To access the user’s real location,

--- a/guide/src/web-getting-started.md
+++ b/guide/src/web-getting-started.md
@@ -88,6 +88,7 @@ Here are the most important ones:
 - `customStyles`: Custom CSS to load (the component uses a scoped shadow DOM; use this to load external styles).
 - `useVoiceGuidance`: Enable voice guidance (default: `false`).
 - `geolocateOnLoad`: Geolocate the user on load and zoom the map to their location (default: `true`; you probably want this unless you are simulating locations for testing).
+- `customStyles`: Styles which will apply inside the component (ex: for MapLibre plugins).
 
 If you haven’t worked with web components before,
 one quick thing to understand is that the only thing you can configure

--- a/guide/src/web-getting-started.md
+++ b/guide/src/web-getting-started.md
@@ -82,10 +82,12 @@ Here are the most important ones:
 - `valhallaEndpointUrl`: The Valhalla routing endpoint to use. You can use any reasonably up-to-date Valhalla server, including your own. See [vendors](./vendor.md#routing) for a list of known compatible vendors.
 - `httpClient`: You can set your own fetch-compatible HTTP client to make requests to the routing API (ex: Valhalla).
 - `costingOptions`: You can set the costing options for the route provider (ex: Valhalla JSON options).
-- `useIntegratedSearchBox`: Ferrostar web includes a search box powered by Stadia Maps, but you can disable this and replace with your own.
-- `useVoiceGuidance`: Enable or disable voice guidance.
-
-NOTE: `useIntegratedSearchBox` and `useVoiceGuidance` are disabled by default. Set them to any value to enable them.
+- `configureMap`: Configures the map on first load. This lets you customize the UI, add MapLibre map controls, etc. on load.
+- `onNavigationStart`: Callback when navigation starts.
+- `onNavigationStop`: Callback when navigation ends.
+- `customStyles`: Custom CSS to load (the component uses a scoped shadow DOM; use this to load external styles).
+- `useVoiceGuidance`: Enable voice guidance (default: `false`).
+- `geolocateOnLoad`: Geolocate the user on load and zoom the map to their location (default: `true`; you probably want this unless you are simulating locations for testing).
 
 If you haven’t worked with web components before,
 one quick thing to understand is that the only thing you can configure
@@ -114,7 +116,8 @@ In Vue, you can write “markup” in your components like this!
   profile="bicycle"
   :center="{lng: -122.42, lat: 37.81}"
   :zoom=18
-  :useIntegratedSearchBox=true
+  :useVoiceGuidance=true
+  :geolocateOnLoad=true
 ></ferrostar-web>
 ```
 

--- a/web/index.html
+++ b/web/index.html
@@ -49,6 +49,7 @@
             maxAcceptableDeviation: 10.0,
           },
         },
+        snappedLocationCourseFiltering: "Raw"
       };
 
       async function onload() {

--- a/web/index.html
+++ b/web/index.html
@@ -32,6 +32,8 @@
 
     <script type="module">
       import { FerrostarMap, SimulatedLocationProvider, BrowserLocationProvider } from "@stadiamaps/ferrostar-webcomponents";
+      import {MapLibreSearchControl} from "@stadiamaps/maplibre-search-box";
+      import searchBoxStyle from "@stadiamaps/maplibre-search-box/dist/style.css?inline";
 
       // TODO: type + use TypeScript enum
       const config = {
@@ -50,11 +52,29 @@
       };
 
       async function onload() {
+        const searchBox = new MapLibreSearchControl({
+          onResultSelected: async (feature) => {
+            await ferrostar.startNavigationFromSearch(feature.geometry.coordinates);
+          },
+        });
+
         const ferrostar = document.getElementById("ferrostar");
 
         ferrostar.center = {lng: -122.42, lat: 37.81};
         ferrostar.zoom = 18;
         ferrostar.costingOptions = { bicycle: { use_roads: 0.2 } };
+        ferrostar.customStyles = searchBoxStyle;
+        ferrostar.geolocateOnLoad = false;
+
+        ferrostar.configureMap = (map) => {
+          map.addControl(searchBox, "top-left");
+        };
+        ferrostar.onNavigationStart = (map) => {
+          map.removeControl(searchBox);
+        };
+        ferrostar.onNavigationStop = (map) => {
+          map.addControl(searchBox, "top-left");
+        };
 
         const simulateNavigationButton = document.getElementById("simulate");
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@stadiamaps/ferrostar-webcomponents",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stadiamaps/ferrostar-webcomponents",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@stadiamaps/ferrostar": "file:../common/ferrostar/pkg",
-        "@stadiamaps/maplibre-search-box": "^1.0.1",
         "lit": "^3.1.4",
         "maplibre-gl": "^4.5.0",
         "vite-plugin-dts": "^4.0.3"
       },
       "devDependencies": {
+        "@stadiamaps/maplibre-search-box": "^1.1.0",
         "typescript": "^5.2.2",
         "vite": "^5.4.1",
         "vite-plugin-top-level-await": "^1.4.4",
@@ -25,7 +25,7 @@
     },
     "../common/ferrostar/pkg": {
       "name": "@stadiamaps/ferrostar",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "BSD-3-Clause"
     },
     "node_modules/@ampproject/remapping": {
@@ -1042,9 +1042,10 @@
       }
     },
     "node_modules/@stadiamaps/api": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@stadiamaps/api/-/api-1.0.10.tgz",
-      "integrity": "sha512-5FDea55gcNu8dJpwBWW+RwB3yOw9JBsiDVHHUUXMHvJCQblcSD5+J38Uan74Nxzm+63seB0BDUBadXCNCY6wDQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@stadiamaps/api/-/api-5.0.0.tgz",
+      "integrity": "sha512-qYHLzmyy0dTh0p+hZByqwa8BYP9OIzsJLQPos9UkIyE5N03ymz8ym2TzuGDuhXSjFMGvEhW02cZPSIouLm1ycQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0"
@@ -1055,12 +1056,13 @@
       "link": true
     },
     "node_modules/@stadiamaps/maplibre-search-box": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stadiamaps/maplibre-search-box/-/maplibre-search-box-1.0.1.tgz",
-      "integrity": "sha512-gv7ZqHqEK9gtKOsC85yPKdwBTa5A7FsQksaoXSIR7kfHOjv0ajF1/8UaSxmlPyWD4EoEJ4x4+Pq/kUmPRlmgEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@stadiamaps/maplibre-search-box/-/maplibre-search-box-1.1.0.tgz",
+      "integrity": "sha512-dU8dK80ReRO8MS/k/IP3eEtxyNQjM3fLtotRGhHjFursEor3L/HiS/j+aVS0xUjkcm6MJvIechC3Jl9jPnUQ8Q==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@stadiamaps/api": "^1.0.4"
+        "@stadiamaps/api": "^5.0.0"
       },
       "peerDependencies": {
         "maplibre-gl": ">=2.0.0"
@@ -2198,6 +2200,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
       "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1",
@@ -2471,6 +2474,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -3055,6 +3059,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -3379,18 +3384,21 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "CatMe0w <CatMe0w@live.cn> (https://github.com/CatMe0w)",
     "Luke Seelenbinder <luke@stadiamaps.com>"
   ],
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "BSD-3-Clause",
   "type": "module",
   "main": "./dist/ferrostar-webcomponents.js",
@@ -19,7 +19,7 @@
   ],
   "types": "./dist/main.d.ts",
   "scripts": {
-    "dev": "vite --config vite.config.site.ts",
+    "dev": "npm run build:site && vite --config vite.config.site.ts",
     "preview": "vite preview",
     "test": "vitest",
     "prepare:core": "cd ../common && wasm-pack build --scope stadiamaps ferrostar --no-default-features --features wasm_js",
@@ -31,12 +31,12 @@
   },
   "dependencies": {
     "@stadiamaps/ferrostar": "file:../common/ferrostar/pkg",
-    "@stadiamaps/maplibre-search-box": "^1.0.1",
     "lit": "^3.1.4",
     "maplibre-gl": "^4.5.0",
     "vite-plugin-dts": "^4.0.3"
   },
   "devDependencies": {
+    "@stadiamaps/maplibre-search-box": "^1.1.0",
     "typescript": "^5.2.2",
     "vite": "^5.4.1",
     "vitest": "^2.0.5",

--- a/web/src/ferrostar-map.ts
+++ b/web/src/ferrostar-map.ts
@@ -314,6 +314,7 @@ export class FerrostarMap extends LitElement {
           maxAcceptableDeviation: 10.0,
         },
       },
+      snappedLocationCourseFiltering: "Raw",
     };
 
     // Start the navigation


### PR DESCRIPTION
This is another round of web improvements.

* Adds hooks for configuring the map on first load.
* Automatically adds a MapLibre `GeolocateControl`, which is the UI that most people will want/expect. By default, it will automatically trigger location updates on load, but this can be easily disabled.
* Removes the stand-in marker that tracked the user location *except during simulation* (where there is no alternative; the `GeolocateControl` doesn't have a swappable location engine as on mobile).
* Removes the Stadia Maps autocomplete search control, but retains it in the demo app. This is extremely useful, and adding it directly was the quickest path to getting something actually usable+testable over the summer, but now we can remove the tight linkage thanks to other improvements in this PR. The dev dependency is upgraded to the latest version, which has a lot of visual improvements (see https://github.com/stadiamaps/maplibre-search-box/pull/4)
* Adds hooks for supplying custom CSS (needed due to the way Lit's scoped shadow DOM works in order to properly style things like MapLibre plugins).

Closes #206. Closes #207.