### PR TITLE
UUID type fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ if useLocalFramework {
         path: "./common/target/ios/libferrostar-rs.xcframework"
     )
 } else {
-    let releaseTag = "0.10.1"
+    let releaseTag = "0.11.0"
     let releaseChecksum = "cc959191f3d066f628264c103e5ea0c3544664ffd0e61907e082d7f1a4d8c5d2"
     binaryTarget = .binaryTarget(
         name: "FerrostarCoreRS",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,5 +12,5 @@ plugins {
 
 allprojects {
     group = "com.stadiamaps.ferrostar"
-    version = "0.10.1"
+    version = "0.11.0"
 }

--- a/apple/Sources/FerrostarCore/FerrostarCore.swift
+++ b/apple/Sources/FerrostarCore/FerrostarCore.swift
@@ -89,7 +89,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
     private var lastAutomaticRecalculation: Date? = nil
     private var lastLocation: UserLocation? = nil
     private var recalculationTask: Task<Void, Never>?
-    private var queuedUtteranceIDs: Set<String> = Set()
+    private var queuedUtteranceIDs: Set<UUID> = Set()
 
     private var config: SwiftNavigationControllerConfig
 

--- a/apple/Sources/UniFFI/ferrostar.swift
+++ b/apple/Sources/UniFFI/ferrostar.swift
@@ -3880,25 +3880,30 @@ private struct FfiConverterDictionaryStringString: FfiConverterRustBuffer {
 }
 
 /**
- * Typealias from the type name used in the UDL file to the builtin type.  This
+ * Typealias from the type name used in the UDL file to the custom type.  This
  * is needed because the UDL type name is used in function/method signatures.
  */
-public typealias Uuid = String
+public typealias Uuid = UUID
+
 public struct FfiConverterTypeUuid: FfiConverter {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Uuid {
-        try FfiConverterString.read(from: &buf)
+        let builtinValue = try FfiConverterString.read(from: &buf)
+        return UUID(uuidString: builtinValue)!
     }
 
     public static func write(_ value: Uuid, into buf: inout [UInt8]) {
-        FfiConverterString.write(value, into: &buf)
+        let builtinValue = value.uuidString
+        return FfiConverterString.write(builtinValue, into: &buf)
     }
 
     public static func lift(_ value: RustBuffer) throws -> Uuid {
-        try FfiConverterString.lift(value)
+        let builtinValue = try FfiConverterString.lift(value)
+        return UUID(uuidString: builtinValue)!
     }
 
     public static func lower(_ value: Uuid) -> RustBuffer {
-        FfiConverterString.lower(value)
+        let builtinValue = value.uuidString
+        return FfiConverterString.lower(builtinValue)
     }
 }
 

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -337,7 +337,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "ferrostar"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "assert-json-diff",
  "geo",

--- a/common/ferrostar/Cargo.toml
+++ b/common/ferrostar/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "ferrostar"
-version = "0.10.1"
+version = "0.11.0"
 readme = "README.md"
 description = "The core of modern turn-by-turn navigation."
 keywords = ["navigation", "routing", "valhalla", "osrm"]

--- a/common/ferrostar/uniffi.toml
+++ b/common/ferrostar/uniffi.toml
@@ -1,0 +1,12 @@
+[bindings.swift.custom_types.Uuid]
+type_name = "UUID"
+into_custom = "UUID(uuidString: {})!"
+from_custom = "{}.uuidString"
+
+[bindings.kotlin.custom_types.Uuid]
+# Eventually we can transition to the Kotlin stdlib type,
+# but this was only just added in Kotlin 2.0.20 (Aug 2024) and is marked experimental.
+# See https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.uuid/-uuid/.
+type_name = "java.util.UUID"
+into_custom = "java.util.UUID.fromString({})"
+from_custom = "{}.toString()"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stadiamaps/ferrostar-webcomponents",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stadiamaps/ferrostar-webcomponents",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@stadiamaps/ferrostar": "file:../common/ferrostar/pkg",
@@ -25,7 +25,7 @@
     },
     "../common/ferrostar/pkg": {
       "name": "@stadiamaps/ferrostar",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "BSD-3-Clause"
     },
     "node_modules/@ampproject/remapping": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "CatMe0w <CatMe0w@live.cn> (https://github.com/CatMe0w)",
     "Luke Seelenbinder <luke@stadiamaps.com>"
   ],
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "BSD-3-Clause",
   "type": "module",
   "main": "./dist/ferrostar-webcomponents.js",


### PR DESCRIPTION
Mostly an ergonomic fix. I did the initial implementation halfway and stopped with the default alias from our `Uuid` to `String` rather than the types the user is probably expecting.

Closes #131.