### PR TITLE
Fix subtle bug in setSimulatedRoute

### DIFF
--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/Location.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/Location.kt
@@ -164,6 +164,7 @@ class SimulatedLocationProvider : LocationProvider {
 
   fun setSimulatedRoute(route: Route) {
     simulationState = locationSimulationFromRoute(route, resampleDistance = 10.0)
+    lastLocation = simulationState?.currentLocation
 
     if (listeners.isNotEmpty() && simulationJob == null) {
       simulationJob = scope.launch { startSimulation() }

--- a/apple/Sources/FerrostarCore/Location.swift
+++ b/apple/Sources/FerrostarCore/Location.swift
@@ -158,6 +158,7 @@ public class SimulatedLocationProvider: LocationProviding, ObservableObject {
 
     public func setSimulatedRoute(_ route: Route, resampleDistance: Double = 10) throws {
         simulationState = try locationSimulationFromRoute(route: route, resampleDistance: resampleDistance)
+        lastLocation = simulationState?.currentLocation
     }
 
     public func startUpdating() {

--- a/web/src/location.ts
+++ b/web/src/location.ts
@@ -26,7 +26,7 @@ export function ferrostarUserLocation(position: GeolocationPosition): object {
 }
 
 export class SimulatedLocationProvider {
-  private simulationState = null;
+  private simulationState: any | null = null;
   private isRunning = false;
 
   lastLocation = null;
@@ -37,6 +37,7 @@ export class SimulatedLocationProvider {
 
   setSimulatedRoute(route: any) {
     this.simulationState = locationSimulationFromRoute(route, 10.0);
+    this.lastLocation = this.simulationState?.current_location;
     this.start();
   }
 


### PR DESCRIPTION
When responding to a question on Slack about how to "reset" trip simulation, I realized that `setSimulatedRoute` does not immediately set `lastLocation`, and further that `startNavigation` assumes that `lastLocation` will be up to date. This would cause issues during simulation as the first state would be wrong (user's location at the end of the route and wildly off course) after a reset unless you explicitly set `lastLocation`. The demo app currently does this, which is why it works.