### PR TITLE
Android demo api keys

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Install cargo-ndk
       run: cargo install cargo-ndk
 
-    - name: Touch local.properties (required for cargo-ndk)
-      run: touch local.properties
+    - name: Touch local.properties (required for build)
+      run: echo 'stadiaApiKey=' > local.properties
       working-directory: android
 
     - name: Build with Gradle
@@ -77,7 +77,7 @@ jobs:
       run: cargo install cargo-ndk
 
     - name: Touch local.properties (required for cargo-ndk)
-      run: touch local.properties
+      run: echo 'stadiaApiKey=' > local.properties
       working-directory: android
 
     - name: Verify Kotlin formatting
@@ -117,7 +117,7 @@ jobs:
       run: cargo install cargo-ndk
 
     - name: Touch local.properties (required for cargo-ndk)
-      run: touch local.properties
+      run: echo 'stadiaApiKey=' > local.properties
       working-directory: android
 
     - name: Unit test
@@ -166,7 +166,7 @@ jobs:
       run: cargo install cargo-ndk
 
     - name: Touch local.properties (required for cargo-ndk)
-      run: touch local.properties
+      run: echo 'stadiaApiKey=' > local.properties
       working-directory: android
 
     - name: Verify snapshots
@@ -215,8 +215,8 @@ jobs:
     - name: Install cargo-ndk
       run: cargo install cargo-ndk
 
-    - name: Touch local.properties (required for cargo-ndk)
-      run: touch local.properties
+    - name: Touch local.properties (required for build)
+      run: echo 'stadiaApiKey=' > local.properties
       working-directory: android
 
     - name: Run Connected Checks

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -32,8 +32,8 @@ jobs:
     - name: Install cargo-ndk
       run: cargo install cargo-ndk
 
-    - name: Touch local.properties (required for cargo-ndk)
-      run: touch local.properties
+    - name: Creat local.properties (required for cargo-ndk and the demo app)
+      run: echo 'stadiaApiKey=' > local.properties
       working-directory: android
 
     - name: Publish to Maven Central

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "def156895a9ce38ea9bf9632c1e2272280ce0ae3",
-        "version" : "6.6.0"
+        "revision" : "e409318144091c3ee9ad551b202e1c36695f8086",
+        "version" : "6.7.0"
       }
     },
     {

--- a/android/README.md
+++ b/android/README.md
@@ -7,3 +7,15 @@ This directory tree contains the Gradle workspace for Ferrostar on Android.
 * `demo-app` - A minimal demonstration app.
 * `google-play-services` - Optional functionality that depends on Google Play Services (like the a fused location client wrapper). This is a separate module so that apps are able to "de-Google" if necessary.
 * `maplibreui` - Map-related user interface components built with MapLibre.
+
+## Running the demo app
+
+To run the demo app, you'll need a Stadia Maps API key
+(free for development and evaluation use; no credit card required; get one at https://client.stadiamaps.com/).
+You can also modify it to work with your preferred maps and routing vendor by editing `AppModule.kt`.
+
+Set your API key in `local.properties` to run the demo app:
+
+```properties
+stadiaApiKey=YOUR-API-KEY
+```

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,9 @@
+# Ferrostar Android
+
+This directory tree contains the Gradle workspace for Ferrostar on Android.
+
+* `composeui` - Jetpack Compose UI elements which are not tightly coupled to any particular map renderer.
+* `core` - The core module is where all the "business logic", location management, and other core functionality lives.
+* `demo-app` - A minimal demonstration app.
+* `google-play-services` - Optional functionality that depends on Google Play Services (like the a fused location client wrapper). This is a separate module so that apps are able to "de-Google" if necessary.
+* `maplibreui` - Map-related user interface components built with MapLibre.

--- a/android/README.md
+++ b/android/README.md
@@ -5,7 +5,7 @@ This directory tree contains the Gradle workspace for Ferrostar on Android.
 * `composeui` - Jetpack Compose UI elements which are not tightly coupled to any particular map renderer.
 * `core` - The core module is where all the "business logic", location management, and other core functionality lives.
 * `demo-app` - A minimal demonstration app.
-* `google-play-services` - Optional functionality that depends on Google Play Services (like the a fused location client wrapper). This is a separate module so that apps are able to "de-Google" if necessary.
+* `google-play-services` - Optional functionality that depends on Google Play Services (like a fused location client wrapper). This is a separate module so that apps are able to "de-Google" if necessary.
 * `maplibreui` - Map-related user interface components built with MapLibre.
 
 ## Running the demo app

--- a/android/demo-app/build.gradle
+++ b/android/demo-app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     alias libs.plugins.jetbrainsKotlinAndroid
     alias libs.plugins.ktfmt
     alias libs.plugins.compose.compiler
+    alias libs.plugins.mapsplatform.secrets.plugin
 }
 
 android {

--- a/android/demo-app/src/main/AndroidManifest.xml
+++ b/android/demo-app/src/main/AndroidManifest.xml
@@ -21,6 +21,12 @@
         android:theme="@style/Theme.Ferrostar"
         tools:targetApi="31">
 
+        <!--
+            Set a value for stadiaApiKey in local.properties.
+            You can get an API key (no credit card required; free for development and evaluation) at client.stadiamaps.com
+        -->
+        <meta-data android:name="stadiaApiKey" android:value="${stadiaApiKey}" />
+
         <activity
             android:name="com.stadiamaps.ferrostar.MainActivity"
             android:exported="true"

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/AppModule.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/AppModule.kt
@@ -1,6 +1,7 @@
 package com.stadiamaps.ferrostar
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.util.Log
 import com.stadiamaps.ferrostar.composeui.notification.DefaultForegroundNotificationBuilder
 import com.stadiamaps.ferrostar.core.AlternativeRouteProcessor
@@ -29,6 +30,28 @@ object AppModule {
 
   private lateinit var appContext: Context
 
+  // You can get an API key (free for development and evaluation; no credit card required)
+  // at client.stadiamaps.com.
+  // You can also modify this file to use your preferred sources for maps and/or routing.
+  // See https://stadiamaps.github.io/ferrostar/vendors.html for vendors known to work with
+  // Ferrostar.
+  val stadiaApiKey: String by lazy {
+    val appInfo =
+        appContext.packageManager.getApplicationInfo(
+            appContext.packageName, PackageManager.GET_META_DATA)
+    val metaData = appInfo.metaData
+
+    metaData.getString("stadiaApiKey")!!
+  }
+
+  val mapStyleUrl: String by lazy {
+    "https://tiles.stadiamaps.com/styles/outdoors.json?api_key=$stadiaApiKey"
+  }
+
+  val valhallaEndpointUrl: URL by lazy {
+    URL("https://api.stadiamaps.com/route/v1?api_key=$stadiaApiKey")
+  }
+
   fun init(context: Context) {
     appContext = context
   }
@@ -42,15 +65,10 @@ object AppModule {
     FerrostarForegroundServiceManager(appContext, DefaultForegroundNotificationBuilder(appContext))
   }
 
-  // NOTE: This is a public instance which is suitable for development, but not for heavy use.
-  // This server is suitable for testing and building your app, but once you are ready to go live,
-  // YOU MUST USE ANOTHER SERVER.
-  //
-  // See https://github.com/stadiamaps/ferrostar/blob/main/VENDORS.md for options
   val ferrostarCore: FerrostarCore by lazy {
     val core =
         FerrostarCore(
-            valhallaEndpointURL = URL("https://valhalla1.openstreetmap.de/route"),
+            valhallaEndpointURL = valhallaEndpointUrl,
             profile = "bicycle",
             httpClient = httpClient,
             locationProvider = locationProvider,
@@ -59,7 +77,7 @@ object AppModule {
                 NavigationControllerConfig(
                     StepAdvanceMode.RelativeLineStringDistance(
                         minimumHorizontalAccuracy = 25U, automaticAdvanceDistance = 10U),
-                    RouteDeviationTracking.StaticThreshold(25U, 10.0),
+                    RouteDeviationTracking.StaticThreshold(15U, 25.0),
                     CourseFiltering.SNAP_TO_ROUTE),
             costingOptions = mapOf("bicycle" to mapOf("use_roads" to 0.2)))
 
@@ -74,7 +92,7 @@ object AppModule {
     core.alternativeRouteProcessor = AlternativeRouteProcessor { it, routes ->
       Log.i(TAG, "Received alternate route(s): $routes")
       if (routes.isNotEmpty()) {
-        // NB: Use `replaceRoute` for cases like this!!
+        // NB: Use `replaceRoute` for cases like this!
         it.replaceRoute(
             routes.first(),
             NavigationControllerConfig(

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ junitCompose = "1.7.2"
 espressoCore = "3.6.1"
 okhttp-mock = "2.0.0"
 mavenPublish = "0.29.0"
+secretsGradlePlugin = "2.0.1"
 material = "1.12.0"
 
 [libraries]
@@ -73,3 +74,4 @@ cargo-ndk = { id = "com.github.willir.rust.cargo-ndk-android", version.ref = "ca
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+mapsplatform-secrets-plugin = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secretsGradlePlugin" }


### PR DESCRIPTION
This makes the Android demo app a bit more like the iOS one with API key management separated out. Finally found a good way to do this with a Gradle plugin.