### PR TITLE
(feat)(core): Add traffic congestion segments to the main Route

### DIFF
--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -268,6 +268,8 @@ pub struct Route {
     /// A waypoint represents a start/end point for a route leg.
     pub waypoints: Vec<Waypoint>,
     pub steps: Vec<RouteStep>,
+    /// A list of congestion segments for the route.
+    pub congestion_segments: Option<Vec<CongestionSegment>>,
 }
 
 /// Helper function for getting the route as an encoded polyline.
@@ -499,6 +501,23 @@ pub struct AnyAnnotationValue {
     pub value: HashMap<String, Value>,
 }
 
+/// Represents a segment of traffic congestion.
+#[derive(Debug, Clone)]
+#[cfg_attr(any(feature = "wasm-bindgen", test), derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct CongestionSegment {
+    /// The level of congestion for this segment.
+    /// 
+    /// This is typically a descriptive string such as "low", "medium", or "high".
+    pub level: String,
+
+    /// The geographical path of the congestion segment.
+    ///
+    /// This is represented as a series of geographic coordinates that define the
+    /// shape and location of the congested area.
+    pub geometry: Vec<GeographicCoordinate>,
+}
+
 #[cfg(test)]
 #[cfg(feature = "uniffi")]
 mod tests {
@@ -514,6 +533,7 @@ mod tests {
             distance: 0.0,
             waypoints: vec![],
             steps: vec![],
+            congestion_segments: None,
         };
 
         let polyline5 = get_route_polyline(&route, 5).expect("Unable to encode polyline for route");

--- a/common/ferrostar/src/navigation_controller/test_helpers.rs
+++ b/common/ferrostar/src/navigation_controller/test_helpers.rs
@@ -63,5 +63,6 @@ pub fn gen_route_from_steps(steps: Vec<RouteStep>) -> Route {
             },
         ],
         steps,
+        congestion_segments: None,
     }
 }

--- a/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_standard_osrm.snap
+++ b/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_standard_osrm.snap
@@ -61,3 +61,4 @@ expression: routes
         lng: 13.428554
       kind: Break
   steps: []
+  congestion_segments: []

--- a/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_valhalla_osrm.snap
+++ b/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_valhalla_osrm.snap
@@ -1041,3 +1041,4 @@ expression: routes
           trigger_distance_before_maneuver: 0
       spoken_instructions: []
       annotations: redacted annotations json strings vec
+  congestion_segments: []

--- a/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_valhalla_osrm_with_via_ways.snap
+++ b/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_valhalla_osrm_with_via_ways.snap
@@ -469,3 +469,4 @@ expression: routes
           trigger_distance_before_maneuver: 0
       spoken_instructions: []
       annotations: redacted annotations json strings vec
+  congestion_segments: []

--- a/common/ferrostar/src/routing_adapters/osrm/utilities.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/utilities.rs
@@ -1,5 +1,7 @@
 use super::models::AnyAnnotation;
 use crate::models::AnyAnnotationValue;
+use crate::models::CongestionSegment;
+use crate::models::GeographicCoordinate;
 use crate::routing_adapters::error::ParsingError;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -47,12 +49,93 @@ pub(crate) fn zip_annotations(annotation: AnyAnnotation) -> Vec<AnyAnnotationVal
         .collect::<Vec<AnyAnnotationValue>>();
 }
 
+pub(crate) fn extract_congestion_segments(
+    annotations: Vec<AnyAnnotation>,
+    geometry: &[GeographicCoordinate],
+) -> Result<Vec<CongestionSegment>, ParsingError> {
+    let mut segments = Vec::new();
+    let mut overall_index = 0;
+
+    for annotation in annotations.iter() {
+        let congestion = match annotation.values.get("congestion") {
+            Some(values) => values
+                .iter()
+                .map(|v| v.as_str().map(|s| s.to_string()))
+                .collect::<Vec<_>>(),
+            None => vec![],
+        };
+
+        let distances = match annotation.values.get("distance") {
+            Some(values) => values.iter().map(|v| v.as_f64()).collect::<Vec<_>>(),
+            None => vec![],
+        };
+
+        let mut current_index = overall_index;
+
+        for (level, distance) in congestion.iter().zip(distances.iter()) {
+            if let (Some(level), Some(distance)) = (level, distance) {
+                let start_index = current_index;
+                let mut end_index = current_index;
+                let mut remaining_distance = *distance;
+
+                while end_index < geometry.len() - 1 && remaining_distance > 0.0 {
+                    let segment_distance =
+                        haversine_distance(&geometry[end_index], &geometry[end_index + 1]);
+                    if remaining_distance >= segment_distance {
+                        remaining_distance -= segment_distance;
+                        end_index += 1;
+                    } else {
+                        break;
+                    }
+                }
+
+                if end_index >= geometry.len() {
+                    break;
+                }
+
+                let segment_geometry: Vec<GeographicCoordinate> = geometry
+                    .iter()
+                    .skip(start_index)
+                    .take(end_index - start_index + 1)
+                    .cloned()
+                    .collect();
+
+                segments.push(CongestionSegment {
+                    level: level.clone(),
+                    geometry: segment_geometry,
+                });
+
+                current_index = end_index;
+            }
+            // if either level or distance is None we skip this segment
+        }
+        overall_index = current_index;
+    }
+
+    Ok(segments)
+}
+
+fn haversine_distance(coord1: &GeographicCoordinate, coord2: &GeographicCoordinate) -> f64 {
+    const EARTH_RADIUS: f64 = 6371000.0;
+
+    let lat1 = coord1.lat.to_radians();
+    let lat2 = coord2.lat.to_radians();
+    let delta_lat = (coord2.lat - coord1.lat).to_radians();
+    let delta_lon = (coord2.lng - coord1.lng).to_radians();
+
+    let a =
+        (delta_lat / 2.0).sin().powi(2) + lat1.cos() * lat2.cos() * (delta_lon / 2.0).sin().powi(2);
+    let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
+
+    EARTH_RADIUS * c
+}
+
 #[cfg(test)]
 mod test {
 
-    use serde_json::Map;
-
     use super::*;
+    use serde_json::json;
+    use serde_json::Map;
 
     #[test]
     fn test_zip_annotation() {
@@ -86,5 +169,170 @@ mod test {
         insta::with_settings!({sort_maps => true}, {
             insta::assert_yaml_snapshot!(result);
         });
+    }
+
+    fn create_annotation(congestion: Vec<&str>, distances: Vec<f64>) -> AnyAnnotation {
+        let mut values = HashMap::new();
+        values.insert(
+            "congestion".to_string(),
+            congestion.into_iter().map(|s| json!(s)).collect(),
+        );
+        values.insert(
+            "distance".to_string(),
+            distances.into_iter().map(|d| json!(d)).collect(),
+        );
+        AnyAnnotation { values }
+    }
+
+    #[test]
+    fn test_extract_congestion_segments_basic() {
+        let annotations = vec![create_annotation(
+            vec!["low", "moderate", "heavy"],
+            vec![10.0, 20.0, 30.0],
+        )];
+        let geometry = vec![
+            GeographicCoordinate { lat: 0.0, lng: 0.0 },
+            GeographicCoordinate {
+                lat: 0.0,
+                lng: 0.001,
+            },
+            GeographicCoordinate {
+                lat: 0.0,
+                lng: 0.002,
+            },
+            GeographicCoordinate {
+                lat: 0.0,
+                lng: 0.003,
+            },
+        ];
+
+        let result = extract_congestion_segments(annotations, &geometry).unwrap();
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].level, "low");
+        assert_eq!(result[1].level, "moderate");
+        assert_eq!(result[2].level, "heavy");
+    }
+
+    #[test]
+    fn test_extract_congestion_segments_empty() {
+        let annotations = vec![];
+        let geometry = vec![];
+
+        let result = extract_congestion_segments(annotations, &geometry).unwrap();
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_extract_congestion_segments_missing_data() {
+        let mut annotation = AnyAnnotation {
+            values: HashMap::new(),
+        };
+        annotation
+            .values
+            .insert("congestion".to_string(), vec![json!("low")]);
+        // Missing distance data
+        let annotations = vec![annotation];
+        let geometry = vec![
+            GeographicCoordinate { lat: 0.0, lng: 0.0 },
+            GeographicCoordinate {
+                lat: 0.0,
+                lng: 0.001,
+            },
+        ];
+
+        let result = extract_congestion_segments(annotations, &geometry).unwrap();
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_extract_congestion_segments_multiple_annotations() {
+        let annotations = vec![
+            create_annotation(vec!["low", "moderate"], vec![10.0, 20.0]),
+            create_annotation(vec!["heavy", "severe"], vec![30.0, 40.0]),
+        ];
+        let geometry = vec![
+            GeographicCoordinate { lat: 0.0, lng: 0.0 },
+            GeographicCoordinate {
+                lat: 0.0,
+                lng: 0.001,
+            },
+            GeographicCoordinate {
+                lat: 0.0,
+                lng: 0.002,
+            },
+            GeographicCoordinate {
+                lat: 0.0,
+                lng: 0.003,
+            },
+            GeographicCoordinate {
+                lat: 0.0,
+                lng: 0.004,
+            },
+        ];
+
+        let result = extract_congestion_segments(annotations, &geometry).unwrap();
+
+        assert_eq!(result.len(), 4);
+        assert_eq!(result[0].level, "low");
+        assert_eq!(result[1].level, "moderate");
+        assert_eq!(result[2].level, "heavy");
+        assert_eq!(result[3].level, "severe");
+    }
+
+    #[test]
+    fn test_extract_congestion_segments_large_distances() {
+        let annotations = vec![create_annotation(
+            vec!["low", "moderate"],
+            vec![1000000.0, 2000000.0],
+        )];
+        let geometry = vec![
+            GeographicCoordinate { lat: 0.0, lng: 0.0 },
+            GeographicCoordinate { lat: 1.0, lng: 1.0 },
+            GeographicCoordinate { lat: 2.0, lng: 2.0 },
+        ];
+
+        let result = extract_congestion_segments(annotations, &geometry).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].level, "low");
+        assert_eq!(result[1].level, "moderate");
+        assert!(result[0].geometry.len() >= 2);
+        assert!(result[1].geometry.len() >= 1);
+    }
+
+    #[test]
+    fn test_extract_congestion_segments_null_values() {
+        let mut annotation = AnyAnnotation {
+            values: HashMap::new(),
+        };
+        annotation.values.insert(
+            "congestion".to_string(),
+            vec![json!("low"), json!(null), json!("high")],
+        );
+        annotation.values.insert(
+            "distance".to_string(),
+            vec![json!(10.0), json!(20.0), json!(30.0)],
+        );
+        let annotations = vec![annotation];
+        let geometry = vec![
+            GeographicCoordinate { lat: 0.0, lng: 0.0 },
+            GeographicCoordinate {
+                lat: 0.0,
+                lng: 0.001,
+            },
+            GeographicCoordinate {
+                lat: 0.0,
+                lng: 0.002,
+            },
+        ];
+
+        let result = extract_congestion_segments(annotations, &geometry).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].level, "low");
+        assert_eq!(result[1].level, "high");
     }
 }


### PR DESCRIPTION
This approach involves:
1. Adding a property or method to the main Route struct to retrieve congestion segments.
2. Each adapter would be responsible for extracting and mapping its specific congestion data to a common format when converting from the adapter-specific route to the main Route.

Pros:
- Keeps the congestion data close to the route data it belongs to.
- Provides a unified interface for accessing congestion data across different platforms.

Cons:
- Slightly increases the complexity of the core Route struct.

This is the implementation of  #292