### PR TITLE
Modernize Android CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,14 +8,12 @@ on:
 
 jobs:
   build:
-
-    runs-on: macos-13
+    runs-on: macos-14
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-android-build
       cancel-in-progress: true
     permissions:
-      contents: read
-      packages: read
+      contents: write  # To auto-commit ktfmtFormat changes
 
     steps:
     - uses: actions/checkout@v4
@@ -40,56 +38,22 @@ jobs:
       run: echo 'stadiaApiKey=' > local.properties
       working-directory: android
 
+    - name: Run ktfmtFormat
+      run: ./gradlew ktfmtFormat
+      working-directory: android
+
+    - name: Commit changed Kotlin source (it is easy to forget ktfmtFormat)
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        file_pattern: 'android/**/*.kt'
+      
     - name: Build with Gradle
-      env:
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./gradlew build
-      working-directory: android
-
-  check-ktfmt:
-
-    runs-on: macos-13
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-android-ktfmt
-      cancel-in-progress: true
-    permissions:
-      contents: read
-      packages: read
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - name: set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: gradle
-
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-      working-directory: android
-
-    - name: Install cargo-ndk
-      run: cargo install cargo-ndk
-
-    - name: Touch local.properties (required for cargo-ndk)
-      run: echo 'stadiaApiKey=' > local.properties
-      working-directory: android
-
-    - name: Verify Kotlin formatting
-      env:
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ./gradlew ktfmtCheck
       working-directory: android
 
   test:
 
-    runs-on: macos-13
+    runs-on: macos-14
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-android-test
       cancel-in-progress: true
@@ -121,9 +85,6 @@ jobs:
       working-directory: android
 
     - name: Unit test
-      env:
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./gradlew test
       working-directory: android
 
@@ -138,7 +99,7 @@ jobs:
 
   verify-snapshots:
 
-    runs-on: macos-13
+    runs-on: macos-14
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-android-snapshots
       cancel-in-progress: true
@@ -170,9 +131,6 @@ jobs:
       working-directory: android
 
     - name: Verify snapshots
-      env:
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./gradlew verifyPaparazziDebug
       working-directory: android
 
@@ -188,7 +146,7 @@ jobs:
 
   connected-check:
 
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-android-connected-check
       cancel-in-progress: true
@@ -219,15 +177,18 @@ jobs:
       run: echo 'stadiaApiKey=' > local.properties
       working-directory: android
 
+    - name: Enable KVM group perms
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
     - name: Run Connected Checks
-      env:
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 30
-        avd-name: macOS-13-x86-aosp-atd-30
-        arch: x86
+        avd-name: ubuntu-latest-x86_64-aosp-atd-30
+        arch: x86_64
         target: aosp_atd
         script: ./gradlew connectedCheck
         working-directory: android

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -25,6 +25,9 @@ jobs:
       
   build-ferrostar:
     runs-on: macos-14
+    permissions:
+      contents: write  # To auto-commit Package.swift and binding changes
+    
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-ios-build-lib
       cancel-in-progress: true


### PR DESCRIPTION
* Switches to Apple Silicon runners where possible
* Switches to beefier Ubuntu runners for the connected checks (since, because reasons, Apple Silicon doesn't support Android Emulators on GitHub Actions and probably won't for a while)
* At least for branches on the main repo, auto-commit Kotlin formatting changes rather than failing CI
* Removes env for GitHub actors; we required this previously for packages that have now migrated to Maven Central
* Fix a permission issue with iOS (unrelated)