### PR TITLE
Add a skip.signing parameter for local publishing

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -19,3 +19,9 @@ Set your API key in `local.properties` to run the demo app:
 ```properties
 stadiaApiKey=YOUR-API-KEY
 ```
+
+## Testing locally in a separate project
+
+* Bump the version number to a `SNAPSHOT` in `build.gradle`.
+* run `./gradlew publishToMavenLocal -Pskip.signing`
+* reference the updated version number in the project, and ensure that `mavenLocal` is one of the `repositories`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,10 @@ plugins {
     alias libs.plugins.kotlinSerialization apply false
 }
 
+ext {
+    SKIP_SIGNING_PROPERTY = "skip.signing"
+}
+
 allprojects {
     group = "com.stadiamaps.ferrostar"
     version = "0.18.0"

--- a/android/composeui/build.gradle
+++ b/android/composeui/build.gradle
@@ -68,7 +68,9 @@ dependencies {
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-    signAllPublications()
+    if (!project.hasProperty(SKIP_SIGNING_PROPERTY)) {
+        signAllPublications()
+    }
 
     configure(new AndroidSingleVariantLibrary("release", true, true))
 

--- a/android/core/build.gradle
+++ b/android/core/build.gradle
@@ -102,7 +102,9 @@ android.libraryVariants.all { variant ->
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-    signAllPublications()
+    if (!project.hasProperty(SKIP_SIGNING_PROPERTY)) {
+        signAllPublications()
+    }
 
     configure(new AndroidSingleVariantLibrary("release", true, true))
 

--- a/android/google-play-services/build.gradle
+++ b/android/google-play-services/build.gradle
@@ -47,7 +47,9 @@ dependencies {
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-    signAllPublications()
+    if (!project.hasProperty(SKIP_SIGNING_PROPERTY)) {
+        signAllPublications()
+    }
 
     configure(new AndroidSingleVariantLibrary("release", true, true))
 

--- a/android/maplibreui/build.gradle
+++ b/android/maplibreui/build.gradle
@@ -65,7 +65,10 @@ dependencies {
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-    signAllPublications()
+
+    if (!project.hasProperty(SKIP_SIGNING_PROPERTY)) {
+        signAllPublications()
+    }
 
     configure(new AndroidSingleVariantLibrary("release", true, true))
 

--- a/guide/src/dev-env-setup.md
+++ b/guide/src/dev-env-setup.md
@@ -122,6 +122,10 @@ cargo install cargo-ndk
 4. Open the Gradle workspace ('android/') in Android Studio.
    Gradle builds automatically ensure the core is built,
    so there are no funky scripts needed as on iOS.
+5. (Optional) If you want to use Maven local publishing to test...
+   - Bump the version number to a `SNAPSHOT` in `build.gradle`.
+   - run `./gradlew publishToMavenLocal -Pskip.signing`.
+   - Reference the updated version number in the project, and ensure that `mavenLocal` is one of the `repositories`.
 
 #### PR checklist
 


### PR DESCRIPTION
Today, due to the signing requirement, one can no longer publish to Maven local for testing without having credentials. This patch adds an optional flag for disabling signing for cases when someone wants to publish locally for testing.