### PR TITLE
Add fixes for SimulatedLocationProvider

### DIFF
--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/Location.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/Location.kt
@@ -155,7 +155,7 @@ class SimulatedLocationProvider : LocationProvider {
   override fun addListener(listener: LocationUpdateListener, executor: Executor) {
     listeners.add(listener to executor)
 
-    if (simulationJob == null) {
+    if (simulationJob?.isActive != true) {
       simulationJob = scope.launch { startSimulation() }
     }
   }
@@ -172,7 +172,7 @@ class SimulatedLocationProvider : LocationProvider {
     simulationState = locationSimulationFromRoute(route, resampleDistance = 10.0)
     lastLocation = simulationState?.currentLocation
 
-    if (listeners.isNotEmpty() && simulationJob == null) {
+    if (listeners.isNotEmpty() && simulationJob?.isActive != true) {
       simulationJob = scope.launch { startSimulation() }
     }
   }


### PR DESCRIPTION
Instead of determining whether or not to start the simulation based on whether or not the job is null, instead, use the active state of the job to determine whether or not to start the simulator. This allows the SimulatedLocationProvider to be reused more than once, and also allows for addListener to happen before setSimulatedRoute is called without breaking the simulation.