### PR TITLE
[common] Update to georust/geo v0.29.0

### DIFF
--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -326,6 +326,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,14 +544,15 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
+checksum = "81d088357a9cc60cec8253b3578f6834b4a3aa20edb55f5d1c030c36d8143f11"
 dependencies = [
  "earcutr",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
+ "i_overlay",
  "log",
  "num-traits",
  "robust",
@@ -625,6 +651,50 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "i_float"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5fe043aae28ce70bd2f78b2f5f82a3654d63607c82594da4dabb8b6cb81f2b2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347c253b4748a1a28baf94c9ce133b6b166f08573157e05afe718812bc599fcd"
+
+[[package]]
+name = "i_overlay"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a469f68cb8a7cef375b2b0f581faf5859b4b50600438c00d46b71acc25ebbd0c"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b44852d57a991c7dedaf76c55bc44f677f547ff899a430d29e13efd6133d7d8"
+dependencies = [
+ "i_float",
+ "serde",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155181bc97d770181cf9477da51218a19ee92a8e5be642e796661aee2b601139"
 
 [[package]]
 name = "indexmap"
@@ -951,6 +1021,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/common/ferrostar/Cargo.toml
+++ b/common/ferrostar/Cargo.toml
@@ -28,7 +28,7 @@ wasm_js = [
 ]
 
 [dependencies]
-geo = "0.28.0"
+geo = "0.29.0"
 polyline = "0.11.0"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = { version = "1.0.128", default-features = false }

--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -171,8 +171,17 @@ pub struct CourseOverGround {
 }
 
 impl CourseOverGround {
-    pub fn new(degrees: u16, accuracy: Option<u16>) -> Self {
-        Self { degrees, accuracy }
+    /// # Arguments
+    ///
+    /// - degrees: The direction in which the user's device is traveling, measured in clockwise degrees from
+    ///            true north (N = 0, E = 90, S = 180, W = 270).
+    /// - accuracy: the accuracy of the course value, measured in degrees.
+    pub fn new(degrees: f64, accuracy: Option<u16>) -> Self {
+        debug_assert!(degrees >= 0.0 && degrees <= 360.0);
+        Self {
+            degrees: degrees.round() as u16,
+            accuracy,
+        }
     }
 }
 

--- a/common/ferrostar/src/navigation_controller/mod.rs
+++ b/common/ferrostar/src/navigation_controller/mod.rs
@@ -12,7 +12,10 @@ use crate::{
     },
     models::{Route, UserLocation},
 };
-use geo::{HaversineDistance, LineString, Point};
+use geo::{
+    algorithm::{Distance, Haversine},
+    geometry::{LineString, Point},
+};
 use models::{NavigationControllerConfig, StepAdvanceStatus, TripState};
 use std::clone::Clone;
 
@@ -125,7 +128,7 @@ impl NavigationController {
                             let next_waypoint: Point = waypoint.coordinate.into();
                             // TODO: This is just a hard-coded threshold for the time being.
                             // More sophisticated behavior will take some time and use cases, so punting on this for now.
-                            current_location.haversine_distance(&next_waypoint) < 100.0
+                            Haversine::distance(current_location, next_waypoint) < 100.0
                         } else {
                             false
                         };

--- a/common/ferrostar/src/navigation_controller/test_helpers.rs
+++ b/common/ferrostar/src/navigation_controller/test_helpers.rs
@@ -1,7 +1,7 @@
 use crate::models::{BoundingBox, GeographicCoordinate, Route, RouteStep, Waypoint, WaypointKind};
 #[cfg(feature = "alloc")]
 use alloc::string::ToString;
-use geo::{line_string, BoundingRect, HaversineLength, LineString, Point};
+use geo::{line_string, BoundingRect, Haversine, Length, LineString, Point};
 
 pub fn gen_dummy_route_step(
     start_lng: f64,
@@ -24,7 +24,7 @@ pub fn gen_dummy_route_step(
             (x: start_lng, y: start_lat),
             (x: end_lng, y: end_lat)
         ]
-        .haversine_length(),
+        .length::<Haversine>(),
         duration: 0.0,
         road_name: None,
         instruction: "".to_string(),

--- a/common/ferrostar/src/simulation.rs
+++ b/common/ferrostar/src/simulation.rs
@@ -40,7 +40,7 @@
 
 use crate::algorithms::{normalize_bearing, trunc_float};
 use crate::models::{CourseOverGround, GeographicCoordinate, Route, UserLocation};
-use geo::{coord, DensifyHaversine, GeodesicBearing, LineString, Point};
+use geo::{coord, Bearing, Densify, Geodesic, Haversine, LineString, Point};
 use polyline::decode_polyline;
 
 #[cfg(any(test, feature = "wasm-bindgen"))]
@@ -101,7 +101,7 @@ pub fn location_simulation_from_coordinates(
         if let Some(next) = rest.first() {
             let current_point = Point::from(*current);
             let next_point = Point::from(*next);
-            let bearing = current_point.geodesic_bearing(next_point);
+            let bearing = Geodesic::bearing(current_point, next_point);
             let current_location = UserLocation {
                 coordinates: *current,
                 horizontal_accuracy: 0.0,
@@ -125,7 +125,7 @@ pub fn location_simulation_from_coordinates(
                     })
                     .collect();
                 let linestring: LineString = coords.into();
-                let densified_linestring = linestring.densify_haversine(distance);
+                let densified_linestring = linestring.densify::<Haversine>(distance);
                 densified_linestring
                     .points()
                     .map(|point| GeographicCoordinate {
@@ -199,7 +199,7 @@ pub fn advance_location_simulation(state: &LocationSimulationState) -> LocationS
     if let Some((next_coordinate, rest)) = state.remaining_locations.split_first() {
         let current_point = Point::from(state.current_location.coordinates);
         let next_point = Point::from(*next_coordinate);
-        let bearing = normalize_bearing(current_point.geodesic_bearing(next_point));
+        let bearing = normalize_bearing(Geodesic::bearing(current_point, next_point));
 
         let next_location = UserLocation {
             coordinates: *next_coordinate,
@@ -277,7 +277,7 @@ pub fn js_advance_location_simulation(state: JsValue) -> JsValue {
 mod tests {
     use super::*;
     use crate::algorithms::snap_user_location_to_line;
-    use geo::HaversineDistance;
+    use geo::{Distance, Haversine};
     use rstest::rstest;
 
     #[rstest]
@@ -348,7 +348,7 @@ mod tests {
             // The distance between each point in the simulation should be <= max_distance
             let current_point: Point = state.current_location.into();
             let next_point: Point = new_state.current_location.into();
-            let distance = current_point.haversine_distance(&next_point);
+            let distance = Haversine::distance(current_point, next_point);
             // I'm actually not 100% sure why this extra fudge is needed, but it's not a concern for today.
             assert!(
                 distance <= max_distance + 7.0,
@@ -358,7 +358,7 @@ mod tests {
             let snapped =
                 snap_user_location_to_line(new_state.current_location, &original_linestring);
             let snapped_point: Point = snapped.coordinates.into();
-            let distance = next_point.haversine_distance(&snapped_point);
+            let distance = Haversine::distance(next_point, snapped_point);
             assert!(
                 distance <= max_distance,
                 "Expected snapped point to be on the line; was {distance}m away"

--- a/common/ferrostar/src/simulation.rs
+++ b/common/ferrostar/src/simulation.rs
@@ -38,7 +38,7 @@
 //! # }
 //! ```
 
-use crate::algorithms::{normalize_bearing, trunc_float};
+use crate::algorithms::trunc_float;
 use crate::models::{CourseOverGround, GeographicCoordinate, Route, UserLocation};
 use geo::{coord, Bearing, Densify, Geodesic, Haversine, LineString, Point};
 use polyline::decode_polyline;
@@ -105,10 +105,7 @@ pub fn location_simulation_from_coordinates(
             let current_location = UserLocation {
                 coordinates: *current,
                 horizontal_accuracy: 0.0,
-                course_over_ground: Some(CourseOverGround {
-                    degrees: bearing.round() as u16,
-                    accuracy: None,
-                }),
+                course_over_ground: Some(CourseOverGround::new(bearing, None)),
                 timestamp: SystemTime::now(),
                 speed: None,
             };
@@ -199,15 +196,11 @@ pub fn advance_location_simulation(state: &LocationSimulationState) -> LocationS
     if let Some((next_coordinate, rest)) = state.remaining_locations.split_first() {
         let current_point = Point::from(state.current_location.coordinates);
         let next_point = Point::from(*next_coordinate);
-        let bearing = normalize_bearing(Geodesic::bearing(current_point, next_point));
-
+        let bearing = Geodesic::bearing(current_point, next_point);
         let next_location = UserLocation {
             coordinates: *next_coordinate,
             horizontal_accuracy: 0.0,
-            course_over_ground: Some(CourseOverGround {
-                degrees: bearing,
-                accuracy: None,
-            }),
+            course_over_ground: Some(CourseOverGround::new(bearing, None)),
             timestamp: SystemTime::now(),
             speed: None,
         };

--- a/common/ferrostar/src/snapshots/ferrostar__simulation__tests__state_from_polyline.snap
+++ b/common/ferrostar/src/snapshots/ferrostar__simulation__tests__state_from_polyline.snap
@@ -1,6 +1,6 @@
 ---
 source: ferrostar/src/simulation.rs
-assertion_line: 329
+assertion_line: 322
 expression: state
 ---
 current_location:

--- a/common/ferrostar/src/snapshots/ferrostar__simulation__tests__state_from_polyline.snap
+++ b/common/ferrostar/src/snapshots/ferrostar__simulation__tests__state_from_polyline.snap
@@ -1,5 +1,6 @@
 ---
 source: ferrostar/src/simulation.rs
+assertion_line: 329
 expression: state
 ---
 current_location:
@@ -8,7 +9,7 @@ current_location:
     lng: -149.543469
   horizontal_accuracy: 0
   course_over_ground:
-    degrees: 0
+    degrees: 288
     accuracy: ~
   speed: ~
 remaining_locations:


### PR DESCRIPTION
A lot of the line measure traits were re-worked.

Mostly this is just moving code around in hopes of similar methods across metric spaces being easier to find now that they are uniform.

It also enabled replacing some mostly copy/pasted implementations in geo with generic implementations, which enabled some new functionality - e.g. we can now `.densify::<Geodesic>`

One notable behavioral change: the output of the new `Bearing` trait is now uniformly 0...360.  Previously GeodesicBearing and HaversineBearing returned -180..180 while RhumbBearing returned 0...360. (see https://github.com/georust/geo/issues/1210 for more)

This actually uncovered a bug in ferrostar, reflected in the new output of
ferrostar/src/snapshots/ferrostar__simulation__tests__state_from_polyline.snap

Since previously we were casting a potentially negative number to u16 — now it's always positive (0...360).

There are some other changes I'd like to make, but this represents a mostly drop in replacement for the current behavior.