### PR TITLE
Pin JDK toolchain

### DIFF
--- a/android/composeui/build.gradle
+++ b/android/composeui/build.gradle
@@ -21,6 +21,13 @@ android {
         consumerProguardFiles "consumer-rules.pro"
     }
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+            vendor = JvmVendorSpec.ADOPTIUM
+        }
+    }
+
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/core/build.gradle
+++ b/android/core/build.gradle
@@ -23,6 +23,13 @@ android {
         consumerProguardFiles "consumer-rules.pro"
     }
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+            vendor = JvmVendorSpec.ADOPTIUM
+        }
+    }
+
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/demo-app/build.gradle
+++ b/android/demo-app/build.gradle
@@ -34,6 +34,14 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+            vendor = JvmVendorSpec.ADOPTIUM
+        }
+    }
+
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/google-play-services/build.gradle
+++ b/android/google-play-services/build.gradle
@@ -19,6 +19,13 @@ android {
         consumerProguardFiles "consumer-rules.pro"
     }
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+            vendor = JvmVendorSpec.ADOPTIUM
+        }
+    }
+
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/maplibreui/build.gradle
+++ b/android/maplibreui/build.gradle
@@ -21,6 +21,13 @@ android {
         consumerProguardFiles "consumer-rules.pro"
     }
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+            vendor = JvmVendorSpec.ADOPTIUM
+        }
+    }
+
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Here's an attempt to pin down one free variables in troubleshooting build tooling issues on some machines. Adopted from the Android docs here: https://developer.android.com/build/jdks#toolchain.

I think at a minimum we can at least specify the `JavaLanguageVersion` to force using JDK 17 consistently. I am NOT sure about specifying the vendor; this may be going a bit too far. Perhaps @haysmike has some input on this.