### PR TITLE
Fix state flow of mute UI updates on Android

### DIFF
--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
@@ -103,7 +103,7 @@ class DefaultNavigationViewModel(
 
   private var userLocation: UserLocation? = locationProvider.lastLocation
   private var muteState: MutableStateFlow<Boolean?> =
-      MutableStateFlow(spokenInstructionObserver?.isMuted)
+      remember { mutableStateOf(spokenInstructionObserver?.isMuted) }
 
   override val uiState =
       combine(ferrostarCore.state, muteState) { a, b -> a to b }

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
@@ -102,8 +102,9 @@ class DefaultNavigationViewModel(
 ) : ViewModel(), NavigationViewModel {
 
   private var userLocation: UserLocation? = locationProvider.lastLocation
-  private var muteState: MutableStateFlow<Boolean?> =
-      remember { mutableStateOf(spokenInstructionObserver?.isMuted) }
+  private var muteState: MutableStateFlow<Boolean?> = remember {
+    mutableStateOf(spokenInstructionObserver?.isMuted)
+  }
 
   override val uiState =
       combine(ferrostarCore.state, muteState) { a, b -> a to b }

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import uniffi.ferrostar.GeographicCoordinate
 import uniffi.ferrostar.RouteDeviation
 import uniffi.ferrostar.RouteStep
@@ -102,8 +101,8 @@ class DefaultNavigationViewModel(
 ) : ViewModel(), NavigationViewModel {
 
   private var userLocation: UserLocation? = locationProvider.lastLocation
-  private var muteState: MutableStateFlow<Boolean?> =
-      MutableStateFlow(spokenInstructionObserver?.isMuted)
+  private val muteState: StateFlow<Boolean?> =
+      spokenInstructionObserver?.muteState ?: MutableStateFlow(null)
 
   override val uiState =
       combine(ferrostarCore.state, muteState) { a, b -> a to b }
@@ -139,10 +138,7 @@ class DefaultNavigationViewModel(
       Log.d("NavigationViewModel", "Spoken instruction observer is null, mute operation ignored.")
       return
     }
-    muteState.update { oldValue ->
-      spokenInstructionObserver.isMuted = !spokenInstructionObserver.isMuted
-      spokenInstructionObserver.isMuted
-    }
+    spokenInstructionObserver.setMuted(!spokenInstructionObserver.isMuted)
   }
 
   // TODO: We can add a hook here to override the current road name.

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
@@ -102,9 +102,8 @@ class DefaultNavigationViewModel(
 ) : ViewModel(), NavigationViewModel {
 
   private var userLocation: UserLocation? = locationProvider.lastLocation
-  private var muteState: MutableStateFlow<Boolean?> = remember {
-    mutableStateOf(spokenInstructionObserver?.isMuted)
-  }
+  private var muteState: MutableStateFlow<Boolean?> =
+      MutableStateFlow(spokenInstructionObserver?.isMuted)
 
   override val uiState =
       combine(ferrostarCore.state, muteState) { a, b -> a to b }


### PR DESCRIPTION
Another small bug fix. This one a bit more obvious.

In the present design, the UI state of the view model is exclusively from FerrostarCore's state. But the mute button being pressed is certainly a state update worth knowing about ;) This is less obvious of a problem when you're moving around, but very obvious when you're stationary / go inside, since the UI will appear to freeze until there's a navigation related update.