### PR TITLE
Fix initializing of traversed variable in distance_along

### DIFF
--- a/common/ferrostar/src/algorithms.rs
+++ b/common/ferrostar/src/algorithms.rs
@@ -353,7 +353,7 @@ fn distance_along(point: &Point, linestring: &LineString) -> Option<f64> {
     }
 
     let (_, _, traversed) = linestring.lines().try_fold(
-        (0f64, f64::INFINITY, 06f64),
+        (0f64, f64::INFINITY, 0f64),
         |(cum_length, closest_dist_to_point, traversed), segment| {
             // Convert to a LineString so we get haversine ops
             let segment_linestring = LineString::from(segment);


### PR DESCRIPTION
This pull request includes a correction to the initialization of a variable in the `distance_along` function in `common/ferrostar/src/algorithms.rs`.

Code correction:

* [`common/ferrostar/src/algorithms.rs`](diffhunk://#diff-f7c5ec8445aeb8de995c5d062546eb6ce2633d1b0f4b9e9581b8d4e78d4bb6e3L356-R356): Corrected the initialization value of the `traversed` variable from `06f64` to `0f64` in the `distance_along` function.