### PR TITLE
Support incidents for OSRM responses

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ if useLocalFramework {
         path: "./common/target/ios/libferrostar-rs.xcframework"
     )
 } else {
-    let releaseTag = "0.22.0"
+    let releaseTag = "0.23.0"
     let releaseChecksum = "00b7372e4c0a3f3c63845d411db0b9841dffc7ed201af8a5ca4b279ef3eab516"
     binaryTarget = .binaryTarget(
         name: "FerrostarCoreRS",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ ext {
 
 allprojects {
     group = "com.stadiamaps.ferrostar"
-    version = "0.22.0"
+    version = "0.23.0"
 }

--- a/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/FerrostarCoreTest.kt
+++ b/android/core/src/androidTest/java/com/stadiamaps/ferrostar/core/FerrostarCoreTest.kt
@@ -122,7 +122,8 @@ class FerrostarCoreTest {
                                   triggerDistanceBeforeManeuver = 42.0)),
                       spokenInstructions = listOf(),
                       duration = 0.0,
-                      annotations = null)))
+                      annotations = null,
+                      incidents = listOf())))
 
   @Test
   fun test401UnauthorizedRouteResponse() = runTest {

--- a/apple/Sources/FerrostarCore/Mock/MockNavigationState.swift
+++ b/apple/Sources/FerrostarCore/Mock/MockNavigationState.swift
@@ -68,7 +68,8 @@ public extension NavigationState {
                             ),
                         ],
                         spokenInstructions: [],
-                        annotations: nil
+                        annotations: nil,
+                        incidents: []
                     ),
                 ],
                 remainingWaypoints: [],

--- a/apple/Sources/FerrostarSwiftUI/TestFixtureFactory.swift
+++ b/apple/Sources/FerrostarSwiftUI/TestFixtureFactory.swift
@@ -74,7 +74,8 @@ struct RouteStepFactory: TestFixtureFactory {
             instruction: "Walk west on \(roadNameBuilder(n))",
             visualInstructions: [visualInstructionBuilder(n)],
             spokenInstructions: [],
-            annotations: nil
+            annotations: nil,
+            incidents: []
         )
     }
 }

--- a/apple/Sources/UniFFI/ferrostar.swift
+++ b/apple/Sources/UniFFI/ferrostar.swift
@@ -463,6 +463,22 @@ fileprivate struct FfiConverterUInt64: FfiConverterPrimitive {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterInt64: FfiConverterPrimitive {
+    typealias FfiType = Int64
+    typealias SwiftType = Int64
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Int64 {
+        return try lift(readInt(&buf))
+    }
+
+    public static func write(_ value: Int64, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterDouble: FfiConverterPrimitive {
     typealias FfiType = Double
     typealias SwiftType = Double
@@ -1696,11 +1712,29 @@ public func FfiConverterTypeBoundingBox_lower(_ value: BoundingBox) -> RustBuffe
  * Details about congestion for an incident.
  */
 public struct Congestion {
+    /**
+     * The level of congestion caused by the incident.
+     *
+     * 0 = no congestion
+     *
+     * 100 = road closed
+     *
+     * Other values mean no congestion was calculated
+     */
     public var value: UInt8
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(value: UInt8) {
+    public init(
+        /**
+         * The level of congestion caused by the incident.
+         *
+         * 0 = no congestion
+         *
+         * 100 = road closed
+         *
+         * Other values mean no congestion was calculated
+         */value: UInt8) {
         self.value = value
     }
 }
@@ -2013,34 +2047,151 @@ public func FfiConverterTypeHeading_lower(_ value: Heading) -> RustBuffer {
 
 
 /**
- * Details about an incident
+ * An incident affecting the free flow of traffic,
+ * such as constructions, accidents, and congestion.
  */
 public struct Incident {
+    /**
+     * A unique identifier for the incident.
+     */
     public var id: String
+    /**
+     * The type of incident.
+     */
     public var incidentType: IncidentType
+    /**
+     * A short description of the incident.
+     */
     public var description: String?
+    /**
+     * A longer description of the incident.
+     */
     public var longDescription: String?
-    public var creationTime: String?
-    public var startTime: String?
-    public var endTime: String?
+    /**
+     * The time at which the incident was *last* created.
+     *
+     * NB: This can change throughout the life of the incident.
+     */
+    public var creationTime: UtcDateTime?
+    /**
+     * The time at which the incident started or is expected to start (ex: planned closure).
+     */
+    public var startTime: UtcDateTime?
+    /**
+     * The time at which the incident ended or is expected to end.
+     */
+    public var endTime: UtcDateTime?
+    /**
+     * The level of impact to traffic.
+     */
     public var impact: Impact?
+    /**
+     * Lanes which are blocked by the incident.
+     */
     public var lanesBlocked: [BlockedLane]
-    public var numLanesBlocked: UInt8?
+    /**
+     * Info about the amount of congestion on the road around the incident.
+     */
     public var congestion: Congestion?
+    /**
+     * Is the road completely closed?
+     */
     public var closed: Bool?
+    /**
+     * The index into the [`RouteStep`] geometry where the incident starts.
+     */
     public var geometryIndexStart: UInt64
+    /**
+     * The index into the [`RouteStep`] geometry where the incident ends.
+     */
     public var geometryIndexEnd: UInt64?
+    /**
+     * Optional additional information about the type of incident (free-form text).
+     */
     public var subType: String?
+    /**
+     * Optional descriptions about the type of incident (free-form text).
+     */
     public var subTypeDescription: String?
+    /**
+     * The ISO 3166-1 alpha-2 code of the country in which the incident occurs.
+     */
     public var iso31661Alpha2: String?
+    /**
+     * The ISO 3166-1 alpha-3 code of the country in which the incident occurs.
+     */
     public var iso31661Alpha3: String?
+    /**
+     * A list of road names affected by the incident.
+     */
     public var affectedRoadNames: [String]
-    public var southWest: GeographicCoordinate?
-    public var northEast: GeographicCoordinate?
+    /**
+     * The bounding box over which the incident occurs.
+     */
+    public var bbox: BoundingBox?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(id: String, incidentType: IncidentType, description: String?, longDescription: String?, creationTime: String?, startTime: String?, endTime: String?, impact: Impact?, lanesBlocked: [BlockedLane], numLanesBlocked: UInt8?, congestion: Congestion?, closed: Bool?, geometryIndexStart: UInt64, geometryIndexEnd: UInt64?, subType: String?, subTypeDescription: String?, iso31661Alpha2: String?, iso31661Alpha3: String?, affectedRoadNames: [String], southWest: GeographicCoordinate?, northEast: GeographicCoordinate?) {
+    public init(
+        /**
+         * A unique identifier for the incident.
+         */id: String, 
+        /**
+         * The type of incident.
+         */incidentType: IncidentType, 
+        /**
+         * A short description of the incident.
+         */description: String?, 
+        /**
+         * A longer description of the incident.
+         */longDescription: String?, 
+        /**
+         * The time at which the incident was *last* created.
+         *
+         * NB: This can change throughout the life of the incident.
+         */creationTime: UtcDateTime?, 
+        /**
+         * The time at which the incident started or is expected to start (ex: planned closure).
+         */startTime: UtcDateTime?, 
+        /**
+         * The time at which the incident ended or is expected to end.
+         */endTime: UtcDateTime?, 
+        /**
+         * The level of impact to traffic.
+         */impact: Impact?, 
+        /**
+         * Lanes which are blocked by the incident.
+         */lanesBlocked: [BlockedLane], 
+        /**
+         * Info about the amount of congestion on the road around the incident.
+         */congestion: Congestion?, 
+        /**
+         * Is the road completely closed?
+         */closed: Bool?, 
+        /**
+         * The index into the [`RouteStep`] geometry where the incident starts.
+         */geometryIndexStart: UInt64, 
+        /**
+         * The index into the [`RouteStep`] geometry where the incident ends.
+         */geometryIndexEnd: UInt64?, 
+        /**
+         * Optional additional information about the type of incident (free-form text).
+         */subType: String?, 
+        /**
+         * Optional descriptions about the type of incident (free-form text).
+         */subTypeDescription: String?, 
+        /**
+         * The ISO 3166-1 alpha-2 code of the country in which the incident occurs.
+         */iso31661Alpha2: String?, 
+        /**
+         * The ISO 3166-1 alpha-3 code of the country in which the incident occurs.
+         */iso31661Alpha3: String?, 
+        /**
+         * A list of road names affected by the incident.
+         */affectedRoadNames: [String], 
+        /**
+         * The bounding box over which the incident occurs.
+         */bbox: BoundingBox?) {
         self.id = id
         self.incidentType = incidentType
         self.description = description
@@ -2050,7 +2201,6 @@ public struct Incident {
         self.endTime = endTime
         self.impact = impact
         self.lanesBlocked = lanesBlocked
-        self.numLanesBlocked = numLanesBlocked
         self.congestion = congestion
         self.closed = closed
         self.geometryIndexStart = geometryIndexStart
@@ -2060,8 +2210,7 @@ public struct Incident {
         self.iso31661Alpha2 = iso31661Alpha2
         self.iso31661Alpha3 = iso31661Alpha3
         self.affectedRoadNames = affectedRoadNames
-        self.southWest = southWest
-        self.northEast = northEast
+        self.bbox = bbox
     }
 }
 
@@ -2096,9 +2245,6 @@ extension Incident: Equatable, Hashable {
         if lhs.lanesBlocked != rhs.lanesBlocked {
             return false
         }
-        if lhs.numLanesBlocked != rhs.numLanesBlocked {
-            return false
-        }
         if lhs.congestion != rhs.congestion {
             return false
         }
@@ -2126,10 +2272,7 @@ extension Incident: Equatable, Hashable {
         if lhs.affectedRoadNames != rhs.affectedRoadNames {
             return false
         }
-        if lhs.southWest != rhs.southWest {
-            return false
-        }
-        if lhs.northEast != rhs.northEast {
+        if lhs.bbox != rhs.bbox {
             return false
         }
         return true
@@ -2145,7 +2288,6 @@ extension Incident: Equatable, Hashable {
         hasher.combine(endTime)
         hasher.combine(impact)
         hasher.combine(lanesBlocked)
-        hasher.combine(numLanesBlocked)
         hasher.combine(congestion)
         hasher.combine(closed)
         hasher.combine(geometryIndexStart)
@@ -2155,8 +2297,7 @@ extension Incident: Equatable, Hashable {
         hasher.combine(iso31661Alpha2)
         hasher.combine(iso31661Alpha3)
         hasher.combine(affectedRoadNames)
-        hasher.combine(southWest)
-        hasher.combine(northEast)
+        hasher.combine(bbox)
     }
 }
 
@@ -2172,12 +2313,11 @@ public struct FfiConverterTypeIncident: FfiConverterRustBuffer {
                 incidentType: FfiConverterTypeIncidentType.read(from: &buf), 
                 description: FfiConverterOptionString.read(from: &buf), 
                 longDescription: FfiConverterOptionString.read(from: &buf), 
-                creationTime: FfiConverterOptionString.read(from: &buf), 
-                startTime: FfiConverterOptionString.read(from: &buf), 
-                endTime: FfiConverterOptionString.read(from: &buf), 
+                creationTime: FfiConverterOptionTypeUtcDateTime.read(from: &buf), 
+                startTime: FfiConverterOptionTypeUtcDateTime.read(from: &buf), 
+                endTime: FfiConverterOptionTypeUtcDateTime.read(from: &buf), 
                 impact: FfiConverterOptionTypeImpact.read(from: &buf), 
                 lanesBlocked: FfiConverterSequenceTypeBlockedLane.read(from: &buf), 
-                numLanesBlocked: FfiConverterOptionUInt8.read(from: &buf), 
                 congestion: FfiConverterOptionTypeCongestion.read(from: &buf), 
                 closed: FfiConverterOptionBool.read(from: &buf), 
                 geometryIndexStart: FfiConverterUInt64.read(from: &buf), 
@@ -2187,8 +2327,7 @@ public struct FfiConverterTypeIncident: FfiConverterRustBuffer {
                 iso31661Alpha2: FfiConverterOptionString.read(from: &buf), 
                 iso31661Alpha3: FfiConverterOptionString.read(from: &buf), 
                 affectedRoadNames: FfiConverterSequenceString.read(from: &buf), 
-                southWest: FfiConverterOptionTypeGeographicCoordinate.read(from: &buf), 
-                northEast: FfiConverterOptionTypeGeographicCoordinate.read(from: &buf)
+                bbox: FfiConverterOptionTypeBoundingBox.read(from: &buf)
         )
     }
 
@@ -2197,12 +2336,11 @@ public struct FfiConverterTypeIncident: FfiConverterRustBuffer {
         FfiConverterTypeIncidentType.write(value.incidentType, into: &buf)
         FfiConverterOptionString.write(value.description, into: &buf)
         FfiConverterOptionString.write(value.longDescription, into: &buf)
-        FfiConverterOptionString.write(value.creationTime, into: &buf)
-        FfiConverterOptionString.write(value.startTime, into: &buf)
-        FfiConverterOptionString.write(value.endTime, into: &buf)
+        FfiConverterOptionTypeUtcDateTime.write(value.creationTime, into: &buf)
+        FfiConverterOptionTypeUtcDateTime.write(value.startTime, into: &buf)
+        FfiConverterOptionTypeUtcDateTime.write(value.endTime, into: &buf)
         FfiConverterOptionTypeImpact.write(value.impact, into: &buf)
         FfiConverterSequenceTypeBlockedLane.write(value.lanesBlocked, into: &buf)
-        FfiConverterOptionUInt8.write(value.numLanesBlocked, into: &buf)
         FfiConverterOptionTypeCongestion.write(value.congestion, into: &buf)
         FfiConverterOptionBool.write(value.closed, into: &buf)
         FfiConverterUInt64.write(value.geometryIndexStart, into: &buf)
@@ -2212,8 +2350,7 @@ public struct FfiConverterTypeIncident: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.iso31661Alpha2, into: &buf)
         FfiConverterOptionString.write(value.iso31661Alpha3, into: &buf)
         FfiConverterSequenceString.write(value.affectedRoadNames, into: &buf)
-        FfiConverterOptionTypeGeographicCoordinate.write(value.southWest, into: &buf)
-        FfiConverterOptionTypeGeographicCoordinate.write(value.northEast, into: &buf)
+        FfiConverterOptionTypeBoundingBox.write(value.bbox, into: &buf)
     }
 }
 
@@ -5205,30 +5342,6 @@ extension WaypointKind: Equatable, Hashable {}
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterOptionUInt8: FfiConverterRustBuffer {
-    typealias SwiftType = UInt8?
-
-    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
-        guard let value = value else {
-            writeInt(&buf, Int8(0))
-            return
-        }
-        writeInt(&buf, Int8(1))
-        FfiConverterUInt8.write(value, into: &buf)
-    }
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
-        switch try readInt(&buf) as Int8 {
-        case 0: return nil
-        case 1: return try FfiConverterUInt8.read(from: &buf)
-        default: throw UniffiInternalError.unexpectedOptionalTag
-        }
-    }
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
 fileprivate struct FfiConverterOptionUInt16: FfiConverterRustBuffer {
     typealias SwiftType = UInt16?
 
@@ -5349,6 +5462,30 @@ fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeBoundingBox: FfiConverterRustBuffer {
+    typealias SwiftType = BoundingBox?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeBoundingBox.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeBoundingBox.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeCongestion: FfiConverterRustBuffer {
     typealias SwiftType = Congestion?
 
@@ -5389,30 +5526,6 @@ fileprivate struct FfiConverterOptionTypeCourseOverGround: FfiConverterRustBuffe
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeCourseOverGround.read(from: &buf)
-        default: throw UniffiInternalError.unexpectedOptionalTag
-        }
-    }
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-fileprivate struct FfiConverterOptionTypeGeographicCoordinate: FfiConverterRustBuffer {
-    typealias SwiftType = GeographicCoordinate?
-
-    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
-        guard let value = value else {
-            writeInt(&buf, Int8(0))
-            return
-        }
-        writeInt(&buf, Int8(1))
-        FfiConverterTypeGeographicCoordinate.write(value, into: &buf)
-    }
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
-        switch try readInt(&buf) as Int8 {
-        case 0: return nil
-        case 1: return try FfiConverterTypeGeographicCoordinate.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -5629,6 +5742,30 @@ fileprivate struct FfiConverterOptionSequenceTypeLaneInfo: FfiConverterRustBuffe
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterSequenceTypeLaneInfo.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeUtcDateTime: FfiConverterRustBuffer {
+    typealias SwiftType = UtcDateTime?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeUtcDateTime.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeUtcDateTime.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -5909,6 +6046,57 @@ fileprivate struct FfiConverterDictionaryStringString: FfiConverterRustBuffer {
         return dict
     }
 }
+
+
+
+
+/**
+ * Typealias from the type name used in the UDL file to the custom type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ */
+public typealias UtcDateTime = Date
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeUtcDateTime: FfiConverter {
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UtcDateTime {
+        let builtinValue = try FfiConverterInt64.read(from: &buf)
+        return Date(timeIntervalSince1970: Double(builtinValue) / 1000.0)
+    }
+
+    public static func write(_ value: UtcDateTime, into buf: inout [UInt8]) {
+        let builtinValue = Int64(value.timeIntervalSince1970 * 1000)
+        return FfiConverterInt64.write(builtinValue, into: &buf)
+    }
+
+    public static func lift(_ value: Int64) throws -> UtcDateTime {
+        let builtinValue = try FfiConverterInt64.lift(value)
+        return Date(timeIntervalSince1970: Double(builtinValue) / 1000.0)
+    }
+
+    public static func lower(_ value: UtcDateTime) -> Int64 {
+        let builtinValue = Int64(value.timeIntervalSince1970 * 1000)
+        return FfiConverterInt64.lower(builtinValue)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeUtcDateTime_lift(_ value: Int64) throws -> UtcDateTime {
+    return try FfiConverterTypeUtcDateTime.lift(value)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeUtcDateTime_lower(_ value: UtcDateTime) -> Int64 {
+    return FfiConverterTypeUtcDateTime.lower(value)
+}
+
 
 
 

--- a/apple/Sources/UniFFI/ferrostar.swift
+++ b/apple/Sources/UniFFI/ferrostar.swift
@@ -399,6 +399,22 @@ fileprivate class UniffiHandleMap<T> {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterUInt8: FfiConverterPrimitive {
+    typealias FfiType = UInt8
+    typealias SwiftType = UInt8
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UInt8 {
+        return try lift(readInt(&buf))
+    }
+
+    public static func write(_ value: UInt8, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterUInt16: FfiConverterPrimitive {
     typealias FfiType = UInt16
     typealias SwiftType = UInt16
@@ -1677,6 +1693,67 @@ public func FfiConverterTypeBoundingBox_lower(_ value: BoundingBox) -> RustBuffe
 
 
 /**
+ * Details about congestion for an incident.
+ */
+public struct Congestion {
+    public var value: UInt8
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(value: UInt8) {
+        self.value = value
+    }
+}
+
+
+
+extension Congestion: Equatable, Hashable {
+    public static func ==(lhs: Congestion, rhs: Congestion) -> Bool {
+        if lhs.value != rhs.value {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(value)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeCongestion: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Congestion {
+        return
+            try Congestion(
+                value: FfiConverterUInt8.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: Congestion, into buf: inout [UInt8]) {
+        FfiConverterUInt8.write(value.value, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeCongestion_lift(_ buf: RustBuffer) throws -> Congestion {
+    return try FfiConverterTypeCongestion.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeCongestion_lower(_ value: Congestion) -> RustBuffer {
+    return FfiConverterTypeCongestion.lower(value)
+}
+
+
+/**
  * The direction in which the user/device is observed to be traveling.
  */
 public struct CourseOverGround {
@@ -1932,6 +2009,227 @@ public func FfiConverterTypeHeading_lift(_ buf: RustBuffer) throws -> Heading {
 #endif
 public func FfiConverterTypeHeading_lower(_ value: Heading) -> RustBuffer {
     return FfiConverterTypeHeading.lower(value)
+}
+
+
+/**
+ * Details about an incident
+ */
+public struct Incident {
+    public var id: String
+    public var incidentType: IncidentType
+    public var description: String?
+    public var longDescription: String?
+    public var creationTime: String?
+    public var startTime: String?
+    public var endTime: String?
+    public var impact: Impact?
+    public var lanesBlocked: [BlockedLane]
+    public var numLanesBlocked: UInt8?
+    public var congestion: Congestion?
+    public var closed: Bool?
+    public var geometryIndexStart: UInt64
+    public var geometryIndexEnd: UInt64?
+    public var subType: String?
+    public var subTypeDescription: String?
+    public var iso31661Alpha2: String?
+    public var iso31661Alpha3: String?
+    public var affectedRoadNames: [String]
+    public var southWest: GeographicCoordinate?
+    public var northEast: GeographicCoordinate?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String, incidentType: IncidentType, description: String?, longDescription: String?, creationTime: String?, startTime: String?, endTime: String?, impact: Impact?, lanesBlocked: [BlockedLane], numLanesBlocked: UInt8?, congestion: Congestion?, closed: Bool?, geometryIndexStart: UInt64, geometryIndexEnd: UInt64?, subType: String?, subTypeDescription: String?, iso31661Alpha2: String?, iso31661Alpha3: String?, affectedRoadNames: [String], southWest: GeographicCoordinate?, northEast: GeographicCoordinate?) {
+        self.id = id
+        self.incidentType = incidentType
+        self.description = description
+        self.longDescription = longDescription
+        self.creationTime = creationTime
+        self.startTime = startTime
+        self.endTime = endTime
+        self.impact = impact
+        self.lanesBlocked = lanesBlocked
+        self.numLanesBlocked = numLanesBlocked
+        self.congestion = congestion
+        self.closed = closed
+        self.geometryIndexStart = geometryIndexStart
+        self.geometryIndexEnd = geometryIndexEnd
+        self.subType = subType
+        self.subTypeDescription = subTypeDescription
+        self.iso31661Alpha2 = iso31661Alpha2
+        self.iso31661Alpha3 = iso31661Alpha3
+        self.affectedRoadNames = affectedRoadNames
+        self.southWest = southWest
+        self.northEast = northEast
+    }
+}
+
+
+
+extension Incident: Equatable, Hashable {
+    public static func ==(lhs: Incident, rhs: Incident) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.incidentType != rhs.incidentType {
+            return false
+        }
+        if lhs.description != rhs.description {
+            return false
+        }
+        if lhs.longDescription != rhs.longDescription {
+            return false
+        }
+        if lhs.creationTime != rhs.creationTime {
+            return false
+        }
+        if lhs.startTime != rhs.startTime {
+            return false
+        }
+        if lhs.endTime != rhs.endTime {
+            return false
+        }
+        if lhs.impact != rhs.impact {
+            return false
+        }
+        if lhs.lanesBlocked != rhs.lanesBlocked {
+            return false
+        }
+        if lhs.numLanesBlocked != rhs.numLanesBlocked {
+            return false
+        }
+        if lhs.congestion != rhs.congestion {
+            return false
+        }
+        if lhs.closed != rhs.closed {
+            return false
+        }
+        if lhs.geometryIndexStart != rhs.geometryIndexStart {
+            return false
+        }
+        if lhs.geometryIndexEnd != rhs.geometryIndexEnd {
+            return false
+        }
+        if lhs.subType != rhs.subType {
+            return false
+        }
+        if lhs.subTypeDescription != rhs.subTypeDescription {
+            return false
+        }
+        if lhs.iso31661Alpha2 != rhs.iso31661Alpha2 {
+            return false
+        }
+        if lhs.iso31661Alpha3 != rhs.iso31661Alpha3 {
+            return false
+        }
+        if lhs.affectedRoadNames != rhs.affectedRoadNames {
+            return false
+        }
+        if lhs.southWest != rhs.southWest {
+            return false
+        }
+        if lhs.northEast != rhs.northEast {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(incidentType)
+        hasher.combine(description)
+        hasher.combine(longDescription)
+        hasher.combine(creationTime)
+        hasher.combine(startTime)
+        hasher.combine(endTime)
+        hasher.combine(impact)
+        hasher.combine(lanesBlocked)
+        hasher.combine(numLanesBlocked)
+        hasher.combine(congestion)
+        hasher.combine(closed)
+        hasher.combine(geometryIndexStart)
+        hasher.combine(geometryIndexEnd)
+        hasher.combine(subType)
+        hasher.combine(subTypeDescription)
+        hasher.combine(iso31661Alpha2)
+        hasher.combine(iso31661Alpha3)
+        hasher.combine(affectedRoadNames)
+        hasher.combine(southWest)
+        hasher.combine(northEast)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeIncident: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Incident {
+        return
+            try Incident(
+                id: FfiConverterString.read(from: &buf), 
+                incidentType: FfiConverterTypeIncidentType.read(from: &buf), 
+                description: FfiConverterOptionString.read(from: &buf), 
+                longDescription: FfiConverterOptionString.read(from: &buf), 
+                creationTime: FfiConverterOptionString.read(from: &buf), 
+                startTime: FfiConverterOptionString.read(from: &buf), 
+                endTime: FfiConverterOptionString.read(from: &buf), 
+                impact: FfiConverterOptionTypeImpact.read(from: &buf), 
+                lanesBlocked: FfiConverterSequenceTypeBlockedLane.read(from: &buf), 
+                numLanesBlocked: FfiConverterOptionUInt8.read(from: &buf), 
+                congestion: FfiConverterOptionTypeCongestion.read(from: &buf), 
+                closed: FfiConverterOptionBool.read(from: &buf), 
+                geometryIndexStart: FfiConverterUInt64.read(from: &buf), 
+                geometryIndexEnd: FfiConverterOptionUInt64.read(from: &buf), 
+                subType: FfiConverterOptionString.read(from: &buf), 
+                subTypeDescription: FfiConverterOptionString.read(from: &buf), 
+                iso31661Alpha2: FfiConverterOptionString.read(from: &buf), 
+                iso31661Alpha3: FfiConverterOptionString.read(from: &buf), 
+                affectedRoadNames: FfiConverterSequenceString.read(from: &buf), 
+                southWest: FfiConverterOptionTypeGeographicCoordinate.read(from: &buf), 
+                northEast: FfiConverterOptionTypeGeographicCoordinate.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: Incident, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterTypeIncidentType.write(value.incidentType, into: &buf)
+        FfiConverterOptionString.write(value.description, into: &buf)
+        FfiConverterOptionString.write(value.longDescription, into: &buf)
+        FfiConverterOptionString.write(value.creationTime, into: &buf)
+        FfiConverterOptionString.write(value.startTime, into: &buf)
+        FfiConverterOptionString.write(value.endTime, into: &buf)
+        FfiConverterOptionTypeImpact.write(value.impact, into: &buf)
+        FfiConverterSequenceTypeBlockedLane.write(value.lanesBlocked, into: &buf)
+        FfiConverterOptionUInt8.write(value.numLanesBlocked, into: &buf)
+        FfiConverterOptionTypeCongestion.write(value.congestion, into: &buf)
+        FfiConverterOptionBool.write(value.closed, into: &buf)
+        FfiConverterUInt64.write(value.geometryIndexStart, into: &buf)
+        FfiConverterOptionUInt64.write(value.geometryIndexEnd, into: &buf)
+        FfiConverterOptionString.write(value.subType, into: &buf)
+        FfiConverterOptionString.write(value.subTypeDescription, into: &buf)
+        FfiConverterOptionString.write(value.iso31661Alpha2, into: &buf)
+        FfiConverterOptionString.write(value.iso31661Alpha3, into: &buf)
+        FfiConverterSequenceString.write(value.affectedRoadNames, into: &buf)
+        FfiConverterOptionTypeGeographicCoordinate.write(value.southWest, into: &buf)
+        FfiConverterOptionTypeGeographicCoordinate.write(value.northEast, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeIncident_lift(_ buf: RustBuffer) throws -> Incident {
+    return try FfiConverterTypeIncident.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeIncident_lower(_ value: Incident) -> RustBuffer {
+    return FfiConverterTypeIncident.lower(value)
 }
 
 
@@ -2318,6 +2616,10 @@ public struct RouteStep {
      * A list of json encoded strings representing annotations between each coordinate along the step.
      */
     public var annotations: [String]?
+    /**
+     * A list of incidents that occur along the step.
+     */
+    public var incidents: [Incident]
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
@@ -2349,7 +2651,10 @@ public struct RouteStep {
          */spokenInstructions: [SpokenInstruction], 
         /**
          * A list of json encoded strings representing annotations between each coordinate along the step.
-         */annotations: [String]?) {
+         */annotations: [String]?, 
+        /**
+         * A list of incidents that occur along the step.
+         */incidents: [Incident]) {
         self.geometry = geometry
         self.distance = distance
         self.duration = duration
@@ -2358,6 +2663,7 @@ public struct RouteStep {
         self.visualInstructions = visualInstructions
         self.spokenInstructions = spokenInstructions
         self.annotations = annotations
+        self.incidents = incidents
     }
 }
 
@@ -2389,6 +2695,9 @@ extension RouteStep: Equatable, Hashable {
         if lhs.annotations != rhs.annotations {
             return false
         }
+        if lhs.incidents != rhs.incidents {
+            return false
+        }
         return true
     }
 
@@ -2401,6 +2710,7 @@ extension RouteStep: Equatable, Hashable {
         hasher.combine(visualInstructions)
         hasher.combine(spokenInstructions)
         hasher.combine(annotations)
+        hasher.combine(incidents)
     }
 }
 
@@ -2419,7 +2729,8 @@ public struct FfiConverterTypeRouteStep: FfiConverterRustBuffer {
                 instruction: FfiConverterString.read(from: &buf), 
                 visualInstructions: FfiConverterSequenceTypeVisualInstruction.read(from: &buf), 
                 spokenInstructions: FfiConverterSequenceTypeSpokenInstruction.read(from: &buf), 
-                annotations: FfiConverterOptionSequenceString.read(from: &buf)
+                annotations: FfiConverterOptionSequenceString.read(from: &buf), 
+                incidents: FfiConverterSequenceTypeIncident.read(from: &buf)
         )
     }
 
@@ -2432,6 +2743,7 @@ public struct FfiConverterTypeRouteStep: FfiConverterRustBuffer {
         FfiConverterSequenceTypeVisualInstruction.write(value.visualInstructions, into: &buf)
         FfiConverterSequenceTypeSpokenInstruction.write(value.spokenInstructions, into: &buf)
         FfiConverterOptionSequenceString.write(value.annotations, into: &buf)
+        FfiConverterSequenceTypeIncident.write(value.incidents, into: &buf)
     }
 }
 
@@ -3186,6 +3498,115 @@ public func FfiConverterTypeWaypoint_lower(_ value: Waypoint) -> RustBuffer {
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 /**
+ * The lane type blocked by the incident.
+ */
+
+public enum BlockedLane {
+    
+    case left
+    case leftCenter
+    case leftTurnLane
+    case center
+    case right
+    case rightCenter
+    case rightTurnLane
+    case hov
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeBlockedLane: FfiConverterRustBuffer {
+    typealias SwiftType = BlockedLane
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BlockedLane {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .left
+        
+        case 2: return .leftCenter
+        
+        case 3: return .leftTurnLane
+        
+        case 4: return .center
+        
+        case 5: return .right
+        
+        case 6: return .rightCenter
+        
+        case 7: return .rightTurnLane
+        
+        case 8: return .hov
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: BlockedLane, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .left:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .leftCenter:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .leftTurnLane:
+            writeInt(&buf, Int32(3))
+        
+        
+        case .center:
+            writeInt(&buf, Int32(4))
+        
+        
+        case .right:
+            writeInt(&buf, Int32(5))
+        
+        
+        case .rightCenter:
+            writeInt(&buf, Int32(6))
+        
+        
+        case .rightTurnLane:
+            writeInt(&buf, Int32(7))
+        
+        
+        case .hov:
+            writeInt(&buf, Int32(8))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeBlockedLane_lift(_ buf: RustBuffer) throws -> BlockedLane {
+    return try FfiConverterTypeBlockedLane.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeBlockedLane_lower(_ value: BlockedLane) -> RustBuffer {
+    return FfiConverterTypeBlockedLane.lower(value)
+}
+
+
+
+extension BlockedLane: Equatable, Hashable {}
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
  * Controls filtering/post-processing of user course by the [`NavigationController`].
  */
 
@@ -3254,6 +3675,231 @@ public func FfiConverterTypeCourseFiltering_lower(_ value: CourseFiltering) -> R
 
 
 extension CourseFiltering: Equatable, Hashable {}
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * The impact of the incident that has occurred.
+ */
+
+public enum Impact {
+    
+    case unknown
+    case critical
+    case major
+    case minor
+    case low
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeImpact: FfiConverterRustBuffer {
+    typealias SwiftType = Impact
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Impact {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .unknown
+        
+        case 2: return .critical
+        
+        case 3: return .major
+        
+        case 4: return .minor
+        
+        case 5: return .low
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: Impact, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .unknown:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .critical:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .major:
+            writeInt(&buf, Int32(3))
+        
+        
+        case .minor:
+            writeInt(&buf, Int32(4))
+        
+        
+        case .low:
+            writeInt(&buf, Int32(5))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeImpact_lift(_ buf: RustBuffer) throws -> Impact {
+    return try FfiConverterTypeImpact.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeImpact_lower(_ value: Impact) -> RustBuffer {
+    return FfiConverterTypeImpact.lower(value)
+}
+
+
+
+extension Impact: Equatable, Hashable {}
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * The type of incident that has occurred.
+ */
+
+public enum IncidentType {
+    
+    case accident
+    case congestion
+    case construction
+    case disabledVehicle
+    case laneRestriction
+    case massTransit
+    case miscellaneous
+    case otherNews
+    case plannedEvent
+    case roadClosure
+    case roadHazard
+    case weather
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeIncidentType: FfiConverterRustBuffer {
+    typealias SwiftType = IncidentType
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> IncidentType {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .accident
+        
+        case 2: return .congestion
+        
+        case 3: return .construction
+        
+        case 4: return .disabledVehicle
+        
+        case 5: return .laneRestriction
+        
+        case 6: return .massTransit
+        
+        case 7: return .miscellaneous
+        
+        case 8: return .otherNews
+        
+        case 9: return .plannedEvent
+        
+        case 10: return .roadClosure
+        
+        case 11: return .roadHazard
+        
+        case 12: return .weather
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: IncidentType, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .accident:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .congestion:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .construction:
+            writeInt(&buf, Int32(3))
+        
+        
+        case .disabledVehicle:
+            writeInt(&buf, Int32(4))
+        
+        
+        case .laneRestriction:
+            writeInt(&buf, Int32(5))
+        
+        
+        case .massTransit:
+            writeInt(&buf, Int32(6))
+        
+        
+        case .miscellaneous:
+            writeInt(&buf, Int32(7))
+        
+        
+        case .otherNews:
+            writeInt(&buf, Int32(8))
+        
+        
+        case .plannedEvent:
+            writeInt(&buf, Int32(9))
+        
+        
+        case .roadClosure:
+            writeInt(&buf, Int32(10))
+        
+        
+        case .roadHazard:
+            writeInt(&buf, Int32(11))
+        
+        
+        case .weather:
+            writeInt(&buf, Int32(12))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeIncidentType_lift(_ buf: RustBuffer) throws -> IncidentType {
+    return try FfiConverterTypeIncidentType.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeIncidentType_lower(_ value: IncidentType) -> RustBuffer {
+    return FfiConverterTypeIncidentType.lower(value)
+}
+
+
+
+extension IncidentType: Equatable, Hashable {}
 
 
 
@@ -4559,6 +5205,30 @@ extension WaypointKind: Equatable, Hashable {}
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionUInt8: FfiConverterRustBuffer {
+    typealias SwiftType = UInt8?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterUInt8.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterUInt8.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionUInt16: FfiConverterRustBuffer {
     typealias SwiftType = UInt16?
 
@@ -4631,6 +5301,30 @@ fileprivate struct FfiConverterOptionDouble: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionBool: FfiConverterRustBuffer {
+    typealias SwiftType = Bool?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterBool.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterBool.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
     typealias SwiftType = String?
 
@@ -4655,6 +5349,30 @@ fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeCongestion: FfiConverterRustBuffer {
+    typealias SwiftType = Congestion?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeCongestion.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeCongestion.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeCourseOverGround: FfiConverterRustBuffer {
     typealias SwiftType = CourseOverGround?
 
@@ -4671,6 +5389,30 @@ fileprivate struct FfiConverterOptionTypeCourseOverGround: FfiConverterRustBuffe
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeCourseOverGround.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeGeographicCoordinate: FfiConverterRustBuffer {
+    typealias SwiftType = GeographicCoordinate?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeGeographicCoordinate.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeGeographicCoordinate.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -4767,6 +5509,30 @@ fileprivate struct FfiConverterOptionTypeVisualInstructionContent: FfiConverterR
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeVisualInstructionContent.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeImpact: FfiConverterRustBuffer {
+    typealias SwiftType = Impact?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeImpact.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeImpact.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -4921,6 +5687,31 @@ fileprivate struct FfiConverterSequenceTypeGeographicCoordinate: FfiConverterRus
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeIncident: FfiConverterRustBuffer {
+    typealias SwiftType = [Incident]
+
+    public static func write(_ value: [Incident], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeIncident.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [Incident] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [Incident]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeIncident.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeLaneInfo: FfiConverterRustBuffer {
     typealias SwiftType = [LaneInfo]
 
@@ -5063,6 +5854,31 @@ fileprivate struct FfiConverterSequenceTypeWaypoint: FfiConverterRustBuffer {
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterTypeWaypoint.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeBlockedLane: FfiConverterRustBuffer {
+    typealias SwiftType = [BlockedLane]
+
+    public static func write(_ value: [BlockedLane], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeBlockedLane.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [BlockedLane] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [BlockedLane]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeBlockedLane.read(from: &buf))
         }
         return seq
     }

--- a/apple/Tests/FerrostarCoreTests/FerrostarCoreTests.swift
+++ b/apple/Tests/FerrostarCoreTests/FerrostarCoreTests.swift
@@ -43,7 +43,8 @@ let mockRoute = Route(
             triggerDistanceBeforeManeuver: 42
         )],
         spokenInstructions: [],
-        annotations: nil
+        annotations: nil,
+        incidents: []
     )]
 )
 

--- a/apple/Tests/FerrostarCoreTests/__Snapshots__/FerrostarCoreTests/test200MockGETRouteResponse.1.txt
+++ b/apple/Tests/FerrostarCoreTests/__Snapshots__/FerrostarCoreTests/test200MockGETRouteResponse.1.txt
@@ -27,6 +27,7 @@
           ▿ GeographicCoordinate
             - lat: 1.0
             - lng: 1.0
+        - incidents: 0 elements
         - instruction: "Sail straight"
         ▿ roadName: Optional<String>
           - some: "foo road"

--- a/apple/Tests/FerrostarCoreTests/__Snapshots__/FerrostarCoreTests/test200MockPOSTRouteResponse.1.txt
+++ b/apple/Tests/FerrostarCoreTests/__Snapshots__/FerrostarCoreTests/test200MockPOSTRouteResponse.1.txt
@@ -27,6 +27,7 @@
           ▿ GeographicCoordinate
             - lat: 1.0
             - lng: 1.0
+        - incidents: 0 elements
         - instruction: "Sail straight"
         ▿ roadName: Optional<String>
           - some: "foo road"

--- a/apple/Tests/FerrostarCoreTests/__Snapshots__/FerrostarCoreTests/testCustomRouteProvider.1.txt
+++ b/apple/Tests/FerrostarCoreTests/__Snapshots__/FerrostarCoreTests/testCustomRouteProvider.1.txt
@@ -27,6 +27,7 @@
           ▿ GeographicCoordinate
             - lat: 1.0
             - lng: 1.0
+        - incidents: 0 elements
         - instruction: "Sail straight"
         ▿ roadName: Optional<String>
           - some: "foo road"

--- a/apple/Tests/FerrostarCoreTests/__Snapshots__/FerrostarCoreTests/testValhallaCostingOptionsJSON.1.txt
+++ b/apple/Tests/FerrostarCoreTests/__Snapshots__/FerrostarCoreTests/testValhallaCostingOptionsJSON.1.txt
@@ -75,6 +75,7 @@
           ▿ GeographicCoordinate
             - lat: 60.534991
             - lng: -149.548581
+        - incidents: 0 elements
         - instruction: "Drive west on AK 1/Seward Highway."
         ▿ roadName: Optional<String>
           - some: "Seward Highway"
@@ -91,6 +92,7 @@
           ▿ GeographicCoordinate
             - lat: 60.534991
             - lng: -149.548581
+        - incidents: 0 elements
         - instruction: "You have arrived at your destination."
         ▿ roadName: Optional<String>
           - some: "Seward Highway"

--- a/apple/Tests/FerrostarCoreTests/__Snapshots__/ValhallaCoreTests/testValhallaRouteParsing.1.txt
+++ b/apple/Tests/FerrostarCoreTests/__Snapshots__/ValhallaCoreTests/testValhallaRouteParsing.1.txt
@@ -75,6 +75,7 @@
           ▿ GeographicCoordinate
             - lat: 60.534991
             - lng: -149.548581
+        - incidents: 0 elements
         - instruction: "Drive west on AK 1/Seward Highway."
         ▿ roadName: Optional<String>
           - some: "Seward Highway"
@@ -91,6 +92,7 @@
           ▿ GeographicCoordinate
             - lat: 60.534991
             - lng: -149.548581
+        - incidents: 0 elements
         - instruction: "You have arrived at your destination."
         ▿ roadName: Optional<String>
           - some: "Seward Highway"

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -400,7 +400,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "ferrostar"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "assert-json-diff",
  "geo",

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -30,6 +30,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +264,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +345,12 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -403,6 +439,7 @@ name = "ferrostar"
 version = "0.23.0"
 dependencies = [
  "assert-json-diff",
+ "chrono",
  "geo",
  "getrandom",
  "insta",
@@ -696,6 +733,29 @@ name = "i_tree"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "155181bc97d770181cf9477da51218a19ee92a8e5be642e796661aee2b601139"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "indexmap"
@@ -1455,9 +1515,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "uniffi"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ce6280c581045879e11b400bae14686a819df22b97171215d15549efa04ddb"
+checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
 dependencies = [
  "anyhow",
  "camino",
@@ -1485,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9f25730c9db2e878521d606f54e921edb719cdd94d735e7f97705d6796d024"
+checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
 dependencies = [
  "anyhow",
  "askama",
@@ -1508,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88dba57ac699bd8ec53d6a352c8dd0e479b33f698c5659831bb1e4ce468c07bd"
+checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
 dependencies = [
  "anyhow",
  "camino",
@@ -1519,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c801f0f05b06df456a2da4c41b9c2c4fdccc6b9916643c6c67275c4c9e4d07"
+checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
 dependencies = [
  "quote",
  "syn",
@@ -1529,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61049e4db6212d0ede80982adf0e1d6fa224e6118387324c5cfbe3083dfb2252"
+checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1543,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40fd2249e0c5dcbd2bfa3c263db1ec981f7273dca7f4132bf06a272359a586c"
+checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
 dependencies = [
  "bincode",
  "camino",
@@ -1561,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ad57039b4fafdbf77428d74fff40e0908e5a1731e023c19cfe538f6d4a8ed6"
+checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1573,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fa171d4d258dc51bbd01893cc9608c1b62273d2f9ea55fb64f639e77824567"
+checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
 dependencies = [
  "anyhow",
  "camino",
@@ -1586,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52299e247419e7e2934bef2f94d7cccb0e6566f3248b1d48b160d8f369a2668"
+checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -1765,6 +1825,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,7 +22,7 @@ lto = "thin"
 opt-level = "s"
 
 [workspace.dependencies]
-uniffi = "0.28.2"
+uniffi = "0.28.3"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/common/ferrostar/Cargo.toml
+++ b/common/ferrostar/Cargo.toml
@@ -28,6 +28,7 @@ wasm_js = [
 ]
 
 [dependencies]
+chrono = { version = "0.4.38", features = ["serde"] }
 geo = "0.29.0"
 polyline = "0.11.0"
 rand = "0.8.5"

--- a/common/ferrostar/Cargo.toml
+++ b/common/ferrostar/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "ferrostar"
-version = "0.22.0"
+version = "0.23.0"
 readme = "README.md"
 description = "The core of modern turn-by-turn navigation."
 keywords = ["navigation", "routing", "valhalla", "osrm"]

--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -24,8 +24,8 @@ use web_time::SystemTime;
 #[cfg(feature = "wasm-bindgen")]
 use tsify::Tsify;
 
-use std::collections::HashMap;
 use chrono::{DateTime, Utc};
+use std::collections::HashMap;
 use uniffi::deps::anyhow::anyhow;
 use uuid::Uuid;
 

--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -26,11 +26,9 @@ use tsify::Tsify;
 
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
-use uniffi::deps::anyhow::anyhow;
 use uuid::Uuid;
 
 use crate::algorithms::get_linestring;
-use crate::UniffiCustomTypeConverter;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
@@ -564,10 +562,13 @@ pub struct Incident {
     /// The time at which the incident was *last* created.
     ///
     /// NB: This can change throughout the life of the incident.
+    #[cfg_attr(feature = "wasm-bindgen", tsify(type = "Date | null"))]
     pub creation_time: Option<DateTime<Utc>>,
     /// The time at which the incident started or is expected to start (ex: planned closure).
+    #[cfg_attr(feature = "wasm-bindgen", tsify(type = "Date | null"))]
     pub start_time: Option<DateTime<Utc>>,
     /// The time at which the incident ended or is expected to end.
+    #[cfg_attr(feature = "wasm-bindgen", tsify(type = "Date | null"))]
     pub end_time: Option<DateTime<Utc>>,
     /// The level of impact to traffic.
     pub impact: Option<Impact>,
@@ -593,26 +594,6 @@ pub struct Incident {
     pub affected_road_names: Vec<String>,
     /// The bounding box over which the incident occurs.
     pub bbox: Option<BoundingBox>,
-}
-
-// Silliness to keep the macro happy; TODO: open a ticket
-#[cfg(feature = "uniffi")]
-type UtcDateTime = DateTime<Utc>;
-
-#[cfg(feature = "uniffi")]
-uniffi::custom_type!(UtcDateTime, i64);
-
-#[cfg(feature = "uniffi")]
-impl UniffiCustomTypeConverter for DateTime<Utc> {
-    type Builtin = i64;
-
-    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-        Self::from_timestamp_millis(val).ok_or(anyhow!("Timestamp {val} out of range"))
-    }
-
-    fn from_custom(obj: Self) -> Self::Builtin {
-        obj.timestamp_millis()
-    }
 }
 
 /// The content of a visual instruction.

--- a/common/ferrostar/src/models.rs
+++ b/common/ferrostar/src/models.rs
@@ -322,6 +322,8 @@ pub struct RouteStep {
     pub spoken_instructions: Vec<SpokenInstruction>,
     /// A list of json encoded strings representing annotations between each coordinate along the step.
     pub annotations: Option<Vec<String>>,
+    /// A list of incidents that occur along the step.
+    pub incidents: Vec<Incident>,
 }
 
 impl RouteStep {
@@ -460,6 +462,107 @@ pub enum ManeuverModifier {
     Left,
     #[serde(rename = "sharp left")]
     SharpLeft,
+}
+
+/// The type of incident that has occurred.
+#[derive(Deserialize, Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(any(test, feature = "wasm-bindgen"), derive(Serialize))]
+#[cfg_attr(feature = "wasm-bindgen", derive(Tsify))]
+#[cfg_attr(feature = "wasm-bindgen", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum IncidentType {
+    Accident,
+    Congestion,
+    Construction,
+    DisabledVehicle,
+    LaneRestriction,
+    MassTransit,
+    Miscellaneous,
+    OtherNews,
+    PlannedEvent,
+    RoadClosure,
+    RoadHazard,
+    Weather,
+}
+
+/// The impact of the incident that has occurred.
+#[derive(Deserialize, Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(any(test, feature = "wasm-bindgen"), derive(Serialize))]
+#[cfg_attr(feature = "wasm-bindgen", derive(Tsify))]
+#[cfg_attr(feature = "wasm-bindgen", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "lowercase")]
+pub enum Impact {
+    Unknown,
+    Critical,
+    Major,
+    Minor,
+    Low,
+}
+
+/// The lane type blocked by the incident.
+#[derive(Deserialize, Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(any(test, feature = "wasm-bindgen"), derive(Serialize))]
+#[cfg_attr(feature = "wasm-bindgen", derive(Tsify))]
+#[cfg_attr(feature = "wasm-bindgen", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "lowercase")]
+pub enum BlockedLane {
+    Left,
+    #[serde(rename = "left center")]
+    LeftCenter,
+    #[serde(rename = "left turn lane")]
+    LeftTurnLane,
+    Center,
+    Right,
+    #[serde(rename = "right center")]
+    RightCenter,
+    #[serde(rename = "right turn lane")]
+    RightTurnLane,
+    #[serde(rename = "hov")]
+    HOV,
+}
+
+/// Details about congestion for an incident.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "wasm-bindgen", derive(Tsify))]
+#[cfg_attr(feature = "wasm-bindgen", tsify(into_wasm_abi, from_wasm_abi))]
+pub struct Congestion {
+    pub value: u8,
+}
+
+/// Details about an incident
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(any(feature = "wasm-bindgen", test), derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wasm-bindgen", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "wasm-bindgen", derive(Tsify))]
+#[cfg_attr(feature = "wasm-bindgen", tsify(into_wasm_abi, from_wasm_abi))]
+pub struct Incident {
+    pub id: String,
+    pub incident_type: IncidentType,
+    pub description: Option<String>,
+    pub long_description: Option<String>,
+    pub creation_time: Option<String>,
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub impact: Option<Impact>,
+    pub lanes_blocked: Vec<BlockedLane>,
+    pub num_lanes_blocked: Option<u8>,
+    pub congestion: Option<Congestion>,
+    pub closed: Option<bool>,
+    pub geometry_index_start: u64,
+    pub geometry_index_end: Option<u64>,
+    pub sub_type: Option<String>,
+    pub sub_type_description: Option<String>,
+    pub iso_3166_1_alpha2: Option<String>,
+    pub iso_3166_1_alpha3: Option<String>,
+    pub affected_road_names: Vec<String>,
+    pub south_west: Option<GeographicCoordinate>,
+    pub north_east: Option<GeographicCoordinate>,
 }
 
 /// The content of a visual instruction.

--- a/common/ferrostar/src/navigation_controller/snapshots/ferrostar__navigation_controller__tests__complex_route_snapshot_test.snap
+++ b/common/ferrostar/src/navigation_controller/snapshots/ferrostar__navigation_controller__tests__complex_route_snapshot_test.snap
@@ -41,6 +41,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 64.13
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775191
             lng: -74.031311
@@ -80,6 +81,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -137,6 +139,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -233,6 +236,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -356,6 +360,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -391,6 +396,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -424,6 +430,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -436,6 +443,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -495,6 +503,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 64.13
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775191
             lng: -74.031311
@@ -534,6 +543,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -591,6 +601,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -687,6 +698,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -810,6 +822,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -845,6 +858,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -878,6 +892,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -890,6 +905,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -949,6 +965,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 64.13
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775191
             lng: -74.031311
@@ -988,6 +1005,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -1045,6 +1063,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -1141,6 +1160,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -1264,6 +1284,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -1299,6 +1320,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -1332,6 +1354,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -1344,6 +1367,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -1403,6 +1427,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 64.13
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775191
             lng: -74.031311
@@ -1442,6 +1467,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -1499,6 +1525,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -1595,6 +1622,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -1718,6 +1746,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -1753,6 +1782,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -1786,6 +1816,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -1798,6 +1829,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -1871,6 +1903,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -1928,6 +1961,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -2024,6 +2058,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -2147,6 +2182,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -2182,6 +2218,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -2215,6 +2252,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -2227,6 +2265,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -2300,6 +2339,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -2357,6 +2397,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -2453,6 +2494,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -2576,6 +2618,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -2611,6 +2654,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -2644,6 +2688,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -2656,6 +2701,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -2729,6 +2775,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -2786,6 +2833,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -2882,6 +2930,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -3005,6 +3054,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -3040,6 +3090,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -3073,6 +3124,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -3085,6 +3137,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -3158,6 +3211,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -3215,6 +3269,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -3311,6 +3366,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -3434,6 +3490,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -3469,6 +3526,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -3502,6 +3560,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -3514,6 +3573,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -3587,6 +3647,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -3644,6 +3705,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -3740,6 +3802,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -3863,6 +3926,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -3898,6 +3962,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -3931,6 +3996,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -3943,6 +4009,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -4016,6 +4083,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -4073,6 +4141,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -4169,6 +4238,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -4292,6 +4362,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -4327,6 +4398,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -4360,6 +4432,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -4372,6 +4445,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -4445,6 +4519,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -4502,6 +4577,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -4598,6 +4674,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -4721,6 +4798,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -4756,6 +4834,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -4789,6 +4868,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -4801,6 +4881,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -4874,6 +4955,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -4931,6 +5013,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -5027,6 +5110,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -5150,6 +5234,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -5185,6 +5270,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -5218,6 +5304,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -5230,6 +5317,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -5303,6 +5391,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -5360,6 +5449,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -5456,6 +5546,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -5579,6 +5670,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -5614,6 +5706,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -5647,6 +5740,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -5659,6 +5753,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -5732,6 +5827,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -5789,6 +5885,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -5885,6 +5982,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -6008,6 +6106,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -6043,6 +6142,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -6076,6 +6176,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -6088,6 +6189,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -6161,6 +6263,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -6218,6 +6321,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -6314,6 +6418,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -6437,6 +6542,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -6472,6 +6578,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -6505,6 +6612,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -6517,6 +6625,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -6590,6 +6699,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -6647,6 +6757,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -6743,6 +6854,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -6866,6 +6978,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -6901,6 +7014,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -6934,6 +7048,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -6946,6 +7061,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -7019,6 +7135,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -7076,6 +7193,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -7172,6 +7290,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -7295,6 +7414,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -7330,6 +7450,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -7363,6 +7484,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -7375,6 +7497,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -7448,6 +7571,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -7505,6 +7629,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -7601,6 +7726,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -7724,6 +7850,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -7759,6 +7886,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -7792,6 +7920,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -7804,6 +7933,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -7877,6 +8007,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 115
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775214
             lng: -74.032662
@@ -7934,6 +8065,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -8030,6 +8162,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -8153,6 +8286,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -8188,6 +8322,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -8221,6 +8356,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -8233,6 +8369,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -8324,6 +8461,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -8420,6 +8558,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -8543,6 +8682,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -8578,6 +8718,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -8611,6 +8752,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -8623,6 +8765,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -8714,6 +8857,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -8810,6 +8954,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -8933,6 +9078,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -8968,6 +9114,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -9001,6 +9148,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -9013,6 +9161,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -9104,6 +9253,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -9200,6 +9350,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -9323,6 +9474,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -9358,6 +9510,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -9391,6 +9544,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -9403,6 +9557,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -9494,6 +9649,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -9590,6 +9746,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -9713,6 +9870,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -9748,6 +9906,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -9781,6 +9940,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -9793,6 +9953,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -9884,6 +10045,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -9980,6 +10142,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -10103,6 +10266,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -10138,6 +10302,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -10171,6 +10336,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -10183,6 +10349,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -10274,6 +10441,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -10370,6 +10538,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -10493,6 +10662,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -10528,6 +10698,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -10561,6 +10732,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -10573,6 +10745,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -10664,6 +10837,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -10760,6 +10934,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -10883,6 +11058,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -10918,6 +11094,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -10951,6 +11128,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -10963,6 +11141,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -11054,6 +11233,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -11150,6 +11330,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -11273,6 +11454,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -11308,6 +11490,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -11341,6 +11524,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -11353,6 +11537,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -11444,6 +11629,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -11540,6 +11726,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -11663,6 +11850,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -11698,6 +11886,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -11731,6 +11920,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -11743,6 +11933,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -11834,6 +12025,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -11930,6 +12122,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -12053,6 +12246,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -12088,6 +12282,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -12121,6 +12316,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -12133,6 +12329,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -12224,6 +12421,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -12320,6 +12518,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -12443,6 +12642,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -12478,6 +12678,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -12511,6 +12712,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -12523,6 +12725,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -12614,6 +12817,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -12710,6 +12914,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -12833,6 +13038,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -12868,6 +13074,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -12901,6 +13108,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -12913,6 +13121,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -13004,6 +13213,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -13100,6 +13310,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -13223,6 +13434,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -13258,6 +13470,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -13291,6 +13504,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -13303,6 +13517,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -13394,6 +13609,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -13490,6 +13706,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -13613,6 +13830,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -13648,6 +13866,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -13681,6 +13900,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -13693,6 +13913,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -13784,6 +14005,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -13880,6 +14102,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -14003,6 +14226,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -14038,6 +14262,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -14071,6 +14296,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -14083,6 +14309,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -14174,6 +14401,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -14270,6 +14498,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -14393,6 +14622,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -14428,6 +14658,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -14461,6 +14692,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -14473,6 +14705,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -14564,6 +14797,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -14660,6 +14894,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -14783,6 +15018,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -14818,6 +15054,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -14851,6 +15088,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -14863,6 +15101,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -14954,6 +15193,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -15050,6 +15290,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -15173,6 +15414,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -15208,6 +15450,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -15241,6 +15484,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -15253,6 +15497,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -15344,6 +15589,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -15440,6 +15686,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -15563,6 +15810,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -15598,6 +15846,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -15631,6 +15880,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -15643,6 +15893,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -15734,6 +15985,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -15830,6 +16082,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -15953,6 +16206,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -15988,6 +16242,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -16021,6 +16276,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -16033,6 +16289,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -16124,6 +16381,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -16220,6 +16478,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -16343,6 +16602,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -16378,6 +16638,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -16411,6 +16672,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -16423,6 +16685,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -16514,6 +16777,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -16610,6 +16874,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -16733,6 +16998,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -16768,6 +17034,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -16801,6 +17068,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -16813,6 +17081,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -16904,6 +17173,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -17000,6 +17270,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -17123,6 +17394,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -17158,6 +17430,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -17191,6 +17464,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -17203,6 +17477,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -17294,6 +17569,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -17390,6 +17666,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -17513,6 +17790,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -17548,6 +17826,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -17581,6 +17860,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -17593,6 +17873,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -17684,6 +17965,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -17780,6 +18062,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -17903,6 +18186,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -17938,6 +18222,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -17971,6 +18256,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -17983,6 +18269,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -18074,6 +18361,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -18170,6 +18458,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -18293,6 +18582,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -18328,6 +18618,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -18361,6 +18652,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -18373,6 +18665,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -18464,6 +18757,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -18560,6 +18854,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -18683,6 +18978,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -18718,6 +19014,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -18751,6 +19048,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -18763,6 +19061,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -18854,6 +19153,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -18950,6 +19250,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -19073,6 +19374,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -19108,6 +19410,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -19141,6 +19444,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -19153,6 +19457,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -19244,6 +19549,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -19340,6 +19646,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -19463,6 +19770,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -19498,6 +19806,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -19531,6 +19840,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -19543,6 +19853,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -19634,6 +19945,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -19730,6 +20042,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -19853,6 +20166,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -19888,6 +20202,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -19921,6 +20236,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -19933,6 +20249,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -20024,6 +20341,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -20120,6 +20438,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -20243,6 +20562,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -20278,6 +20598,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -20311,6 +20632,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -20323,6 +20645,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -20414,6 +20737,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -20510,6 +20834,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -20633,6 +20958,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -20668,6 +20994,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -20701,6 +21028,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -20713,6 +21041,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -20804,6 +21133,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 236
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.773943
             lng: -74.034778
@@ -20900,6 +21230,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -21023,6 +21354,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -21058,6 +21390,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -21091,6 +21424,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -21103,6 +21437,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -21233,6 +21568,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -21356,6 +21692,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -21391,6 +21728,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -21424,6 +21762,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -21436,6 +21775,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -21571,6 +21911,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -21694,6 +22035,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -21729,6 +22071,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -21762,6 +22105,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -21774,6 +22118,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -21909,6 +22254,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -22032,6 +22378,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -22067,6 +22414,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -22100,6 +22448,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -22112,6 +22461,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -22247,6 +22597,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -22370,6 +22721,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -22405,6 +22757,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -22438,6 +22791,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -22450,6 +22804,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -22585,6 +22940,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -22708,6 +23064,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -22743,6 +23100,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -22776,6 +23134,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -22788,6 +23147,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -22923,6 +23283,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -23046,6 +23407,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -23081,6 +23443,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -23114,6 +23477,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -23126,6 +23490,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -23261,6 +23626,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -23384,6 +23750,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -23419,6 +23786,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -23452,6 +23820,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -23464,6 +23833,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -23599,6 +23969,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -23722,6 +24093,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -23757,6 +24129,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -23790,6 +24163,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -23802,6 +24176,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -23937,6 +24312,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -24060,6 +24436,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -24095,6 +24472,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -24128,6 +24506,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -24140,6 +24519,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -24275,6 +24655,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -24398,6 +24779,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -24433,6 +24815,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -24466,6 +24849,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -24478,6 +24862,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -24613,6 +24998,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -24736,6 +25122,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -24771,6 +25158,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -24804,6 +25192,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -24816,6 +25205,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -24951,6 +25341,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -25074,6 +25465,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -25109,6 +25501,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -25142,6 +25535,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -25154,6 +25548,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -25289,6 +25684,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -25412,6 +25808,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -25447,6 +25844,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -25480,6 +25878,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -25492,6 +25891,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -25627,6 +26027,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -25750,6 +26151,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -25785,6 +26187,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -25818,6 +26221,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -25830,6 +26234,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -25965,6 +26370,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -26088,6 +26494,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -26123,6 +26530,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -26156,6 +26564,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -26168,6 +26577,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -26303,6 +26713,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -26426,6 +26837,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -26461,6 +26873,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -26494,6 +26907,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -26506,6 +26920,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -26641,6 +27056,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -26764,6 +27180,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -26799,6 +27216,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -26832,6 +27250,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -26844,6 +27263,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -26979,6 +27399,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -27102,6 +27523,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -27137,6 +27559,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -27170,6 +27593,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -27182,6 +27606,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -27317,6 +27742,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -27440,6 +27866,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -27475,6 +27902,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -27508,6 +27936,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -27520,6 +27949,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -27655,6 +28085,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -27778,6 +28209,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -27813,6 +28245,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -27846,6 +28279,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -27858,6 +28292,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -27993,6 +28428,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -28116,6 +28552,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -28151,6 +28588,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -28184,6 +28622,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -28196,6 +28635,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -28353,6 +28793,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -28476,6 +28917,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -28511,6 +28953,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -28544,6 +28987,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -28556,6 +29000,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -28713,6 +29158,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -28836,6 +29282,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -28871,6 +29318,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -28904,6 +29352,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -28916,6 +29365,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -29073,6 +29523,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -29196,6 +29647,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -29231,6 +29683,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -29264,6 +29717,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -29276,6 +29730,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -29433,6 +29888,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -29556,6 +30012,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -29591,6 +30048,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -29624,6 +30082,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -29636,6 +30095,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -29793,6 +30253,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -29916,6 +30377,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -29951,6 +30413,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -29984,6 +30447,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -29996,6 +30460,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -30153,6 +30618,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -30276,6 +30742,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -30311,6 +30778,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -30344,6 +30812,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -30356,6 +30825,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -30513,6 +30983,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -30636,6 +31107,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -30671,6 +31143,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -30704,6 +31177,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -30716,6 +31190,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -30873,6 +31348,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -30996,6 +31472,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -31031,6 +31508,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -31064,6 +31542,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -31076,6 +31555,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -31233,6 +31713,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -31356,6 +31837,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -31391,6 +31873,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -31424,6 +31907,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -31436,6 +31920,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -31593,6 +32078,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -31716,6 +32202,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -31751,6 +32238,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -31784,6 +32272,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -31796,6 +32285,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -31953,6 +32443,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -32076,6 +32567,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -32111,6 +32603,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -32144,6 +32637,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -32156,6 +32650,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -32313,6 +32808,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -32436,6 +32932,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -32471,6 +32968,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -32504,6 +33002,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -32516,6 +33015,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -32673,6 +33173,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -32796,6 +33297,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -32831,6 +33333,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -32864,6 +33367,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -32876,6 +33380,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -33033,6 +33538,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -33156,6 +33662,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -33191,6 +33698,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -33224,6 +33732,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -33236,6 +33745,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -33393,6 +33903,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -33516,6 +34027,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -33551,6 +34063,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -33584,6 +34097,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -33596,6 +34110,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -33753,6 +34268,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -33876,6 +34392,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -33911,6 +34428,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -33944,6 +34462,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -33956,6 +34475,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -34113,6 +34633,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -34236,6 +34757,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -34271,6 +34793,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -34304,6 +34827,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -34316,6 +34840,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -34473,6 +34998,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -34596,6 +35122,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -34631,6 +35158,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -34664,6 +35192,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -34676,6 +35205,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -34833,6 +35363,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -34956,6 +35487,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -34991,6 +35523,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -35024,6 +35557,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -35036,6 +35570,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -35193,6 +35728,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -35316,6 +35852,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -35351,6 +35888,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -35384,6 +35922,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -35396,6 +35935,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -35553,6 +36093,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -35676,6 +36217,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -35711,6 +36253,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -35744,6 +36287,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -35756,6 +36300,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -35913,6 +36458,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -36036,6 +36582,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -36071,6 +36618,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -36104,6 +36652,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -36116,6 +36665,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -36273,6 +36823,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -36396,6 +36947,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -36431,6 +36983,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -36464,6 +37017,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -36476,6 +37030,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -36633,6 +37188,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -36756,6 +37312,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -36791,6 +37348,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -36824,6 +37382,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -36836,6 +37395,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -36993,6 +37553,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -37116,6 +37677,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -37151,6 +37713,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -37184,6 +37747,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -37196,6 +37760,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -37353,6 +37918,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -37476,6 +38042,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -37511,6 +38078,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -37544,6 +38112,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -37556,6 +38125,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -37713,6 +38283,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -37836,6 +38407,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -37871,6 +38443,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -37904,6 +38477,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -37916,6 +38490,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -38073,6 +38648,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -38196,6 +38772,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -38231,6 +38808,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -38264,6 +38842,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -38276,6 +38855,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -38433,6 +39013,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -38556,6 +39137,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -38591,6 +39173,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -38624,6 +39207,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -38636,6 +39220,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -38793,6 +39378,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -38916,6 +39502,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -38951,6 +39538,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -38984,6 +39572,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -38996,6 +39585,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -39153,6 +39743,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -39276,6 +39867,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -39311,6 +39903,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -39344,6 +39937,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -39356,6 +39950,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -39513,6 +40108,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -39636,6 +40232,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -39671,6 +40268,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -39704,6 +40302,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -39716,6 +40315,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -39873,6 +40473,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -39996,6 +40597,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -40031,6 +40633,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -40064,6 +40667,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -40076,6 +40680,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -40233,6 +40838,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -40356,6 +40962,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -40391,6 +40998,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -40424,6 +41032,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -40436,6 +41045,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -40593,6 +41203,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -40716,6 +41327,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -40751,6 +41363,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -40784,6 +41397,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -40796,6 +41410,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -40953,6 +41568,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -41076,6 +41692,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -41111,6 +41728,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -41144,6 +41762,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -41156,6 +41775,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -41313,6 +41933,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -41436,6 +42057,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -41471,6 +42093,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -41504,6 +42127,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -41516,6 +42140,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -41673,6 +42298,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -41796,6 +42422,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -41831,6 +42458,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -41864,6 +42492,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -41876,6 +42505,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -42033,6 +42663,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -42156,6 +42787,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -42191,6 +42823,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -42224,6 +42857,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -42236,6 +42870,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -42393,6 +43028,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -42516,6 +43152,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -42551,6 +43188,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -42584,6 +43222,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -42596,6 +43235,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -42753,6 +43393,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -42876,6 +43517,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -42911,6 +43553,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -42944,6 +43587,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -42956,6 +43600,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -43113,6 +43758,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -43236,6 +43882,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -43271,6 +43918,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -43304,6 +43952,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -43316,6 +43965,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -43473,6 +44123,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -43596,6 +44247,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -43631,6 +44283,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -43664,6 +44317,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -43676,6 +44330,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -43833,6 +44488,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -43956,6 +44612,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -43991,6 +44648,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -44024,6 +44682,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -44036,6 +44695,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -44193,6 +44853,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 400
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775971
             lng: -74.040798
@@ -44316,6 +44977,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -44351,6 +45013,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -44384,6 +45047,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -44396,6 +45060,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -44580,6 +45245,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -44615,6 +45281,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -44648,6 +45315,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -44660,6 +45328,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -44817,6 +45486,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -44852,6 +45522,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -44885,6 +45556,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -44897,6 +45569,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -45054,6 +45727,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -45089,6 +45763,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -45122,6 +45797,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -45134,6 +45810,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -45291,6 +45968,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -45326,6 +46004,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -45359,6 +46038,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -45371,6 +46051,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -45528,6 +46209,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -45563,6 +46245,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -45596,6 +46279,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -45608,6 +46292,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -45765,6 +46450,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -45800,6 +46486,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -45833,6 +46520,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -45845,6 +46533,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -46002,6 +46691,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -46037,6 +46727,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -46070,6 +46761,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -46082,6 +46774,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -46239,6 +46932,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -46274,6 +46968,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -46307,6 +47002,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -46319,6 +47015,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -46476,6 +47173,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -46511,6 +47209,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -46544,6 +47243,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -46556,6 +47256,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -46713,6 +47414,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -46748,6 +47450,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -46781,6 +47484,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -46793,6 +47497,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -46950,6 +47655,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -46985,6 +47691,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -47018,6 +47725,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -47030,6 +47738,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -47187,6 +47896,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -47222,6 +47932,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -47255,6 +47966,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -47267,6 +47979,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -47424,6 +48137,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -47459,6 +48173,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -47492,6 +48207,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -47504,6 +48220,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -47661,6 +48378,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -47696,6 +48414,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -47729,6 +48448,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -47741,6 +48461,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -47898,6 +48619,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -47933,6 +48655,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -47966,6 +48689,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -47978,6 +48702,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -48135,6 +48860,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -48170,6 +48896,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -48203,6 +48930,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -48215,6 +48943,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -48372,6 +49101,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -48407,6 +49137,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -48440,6 +49171,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -48452,6 +49184,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -48609,6 +49342,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -48644,6 +49378,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -48677,6 +49412,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -48689,6 +49425,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -48846,6 +49583,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -48881,6 +49619,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -48914,6 +49653,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -48926,6 +49666,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -49083,6 +49824,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -49118,6 +49860,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -49151,6 +49894,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -49163,6 +49907,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -49320,6 +50065,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -49355,6 +50101,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -49388,6 +50135,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -49400,6 +50148,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -49557,6 +50306,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -49592,6 +50342,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -49625,6 +50376,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -49637,6 +50389,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -49794,6 +50547,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -49829,6 +50583,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -49862,6 +50617,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -49874,6 +50630,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -50031,6 +50788,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -50066,6 +50824,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -50099,6 +50858,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -50111,6 +50871,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -50268,6 +51029,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -50303,6 +51065,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -50336,6 +51099,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -50348,6 +51112,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -50505,6 +51270,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -50540,6 +51306,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -50573,6 +51340,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -50585,6 +51353,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -50742,6 +51511,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -50777,6 +51547,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -50810,6 +51581,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -50822,6 +51594,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -50979,6 +51752,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -51014,6 +51788,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -51047,6 +51822,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -51059,6 +51835,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -51216,6 +51993,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -51251,6 +52029,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -51284,6 +52063,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -51296,6 +52076,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -51453,6 +52234,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -51488,6 +52270,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -51521,6 +52304,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -51533,6 +52317,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -51690,6 +52475,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -51725,6 +52511,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -51758,6 +52545,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -51770,6 +52558,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -51927,6 +52716,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -51962,6 +52752,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -51995,6 +52786,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -52007,6 +52799,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -52164,6 +52957,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -52199,6 +52993,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -52232,6 +53027,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -52244,6 +53040,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -52401,6 +53198,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -52436,6 +53234,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -52469,6 +53268,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -52481,6 +53281,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -52638,6 +53439,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -52673,6 +53475,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -52706,6 +53509,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -52718,6 +53522,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -52875,6 +53680,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -52910,6 +53716,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -52943,6 +53750,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -52955,6 +53763,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -53112,6 +53921,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -53147,6 +53957,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -53180,6 +53991,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -53192,6 +54004,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -53349,6 +54162,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -53384,6 +54198,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -53417,6 +54232,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -53429,6 +54245,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -53586,6 +54403,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -53621,6 +54439,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -53654,6 +54473,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -53666,6 +54486,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -53823,6 +54644,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -53858,6 +54680,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -53891,6 +54714,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -53903,6 +54727,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -54060,6 +54885,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -54095,6 +54921,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -54128,6 +54955,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -54140,6 +54968,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -54297,6 +55126,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -54332,6 +55162,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -54365,6 +55196,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -54377,6 +55209,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -54534,6 +55367,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -54569,6 +55403,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -54602,6 +55437,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -54614,6 +55450,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -54771,6 +55608,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -54806,6 +55644,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -54839,6 +55678,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -54851,6 +55691,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -55008,6 +55849,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -55043,6 +55885,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -55076,6 +55919,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -55088,6 +55932,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -55245,6 +56090,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -55280,6 +56126,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -55313,6 +56160,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -55325,6 +56173,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -55482,6 +56331,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -55517,6 +56367,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -55550,6 +56401,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -55562,6 +56414,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -55719,6 +56572,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -55754,6 +56608,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -55787,6 +56642,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -55799,6 +56655,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -55956,6 +56813,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -55991,6 +56849,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -56024,6 +56883,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -56036,6 +56896,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -56193,6 +57054,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -56228,6 +57090,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -56261,6 +57124,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -56273,6 +57137,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -56430,6 +57295,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -56465,6 +57331,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -56498,6 +57365,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -56510,6 +57378,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -56667,6 +57536,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -56702,6 +57572,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -56735,6 +57606,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -56747,6 +57619,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -56904,6 +57777,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -56939,6 +57813,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -56972,6 +57847,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -56984,6 +57860,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -57141,6 +58018,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -57176,6 +58054,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -57209,6 +58088,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -57221,6 +58101,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -57378,6 +58259,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -57413,6 +58295,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -57446,6 +58329,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -57458,6 +58342,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -57615,6 +58500,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -57650,6 +58536,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -57683,6 +58570,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -57695,6 +58583,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -57852,6 +58741,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -57887,6 +58777,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -57920,6 +58811,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -57932,6 +58824,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -58089,6 +58982,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -58124,6 +59018,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -58157,6 +59052,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -58169,6 +59065,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -58326,6 +59223,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -58361,6 +59259,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -58394,6 +59293,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -58406,6 +59306,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -58563,6 +59464,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -58598,6 +59500,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -58631,6 +59534,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -58643,6 +59547,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -58800,6 +59705,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -58835,6 +59741,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -58868,6 +59775,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -58880,6 +59788,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -59037,6 +59946,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -59072,6 +59982,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -59105,6 +60016,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -59117,6 +60029,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -59274,6 +60187,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -59309,6 +60223,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -59342,6 +60257,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -59354,6 +60270,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -59511,6 +60428,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -59546,6 +60464,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -59579,6 +60498,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -59591,6 +60511,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -59748,6 +60669,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 372
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775543
             lng: -74.040677
@@ -59783,6 +60705,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -59816,6 +60739,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -59828,6 +60752,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -59897,6 +60822,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -59930,6 +60856,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -59942,6 +60869,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -60011,6 +60939,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -60044,6 +60973,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -60056,6 +60986,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -60125,6 +61056,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -60158,6 +61090,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -60170,6 +61103,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -60239,6 +61173,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -60272,6 +61207,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -60284,6 +61220,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -60353,6 +61290,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -60386,6 +61324,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -60398,6 +61337,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -60467,6 +61407,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -60500,6 +61441,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -60512,6 +61454,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -60581,6 +61524,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -60614,6 +61558,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -60626,6 +61571,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -60695,6 +61641,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -60728,6 +61675,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -60740,6 +61688,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -60809,6 +61758,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -60842,6 +61792,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -60854,6 +61805,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -60923,6 +61875,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -60956,6 +61909,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -60968,6 +61922,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61037,6 +61992,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -61070,6 +62026,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61082,6 +62039,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61151,6 +62109,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -61184,6 +62143,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61196,6 +62156,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61265,6 +62226,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 84
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.775673
             lng: -74.041608
@@ -61298,6 +62260,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61310,6 +62273,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61377,6 +62341,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61389,6 +62354,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61456,6 +62422,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61468,6 +62435,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61535,6 +62503,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61547,6 +62516,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61614,6 +62584,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61626,6 +62597,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61693,6 +62665,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61705,6 +62678,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61772,6 +62746,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61784,6 +62759,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61851,6 +62827,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61863,6 +62840,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -61930,6 +62908,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -61942,6 +62921,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62009,6 +62989,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62021,6 +63002,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62088,6 +63070,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62100,6 +63083,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62167,6 +63151,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62179,6 +63164,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62246,6 +63232,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62258,6 +63245,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62325,6 +63313,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62337,6 +63326,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62404,6 +63394,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62416,6 +63407,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62483,6 +63475,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62495,6 +63488,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62562,6 +63556,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62574,6 +63569,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62641,6 +63637,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62653,6 +63650,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62720,6 +63718,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62732,6 +63731,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62799,6 +63799,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62811,6 +63812,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62878,6 +63880,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62890,6 +63893,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -62957,6 +63961,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -62969,6 +63974,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63036,6 +64042,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63048,6 +64055,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63115,6 +64123,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63127,6 +64136,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63194,6 +64204,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63206,6 +64217,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63273,6 +64285,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63285,6 +64298,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63352,6 +64366,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63364,6 +64379,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63431,6 +64447,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63443,6 +64460,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63510,6 +64528,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63522,6 +64541,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63589,6 +64609,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63601,6 +64622,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63668,6 +64690,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63680,6 +64703,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63747,6 +64771,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63759,6 +64784,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63826,6 +64852,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63838,6 +64865,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63905,6 +64933,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63917,6 +64946,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -63984,6 +65014,7 @@ snapshot_kind: text
             trigger_distance_before_maneuver: 289.074
         spoken_instructions: []
         annotations: ~
+        incidents: []
       - geometry:
           - lat: 40.777985
             lng: -74.040048
@@ -63996,6 +65027,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints:
       - coordinate:
           lat: 40.777985
@@ -64042,6 +65074,7 @@ snapshot_kind: text
         visual_instructions: []
         spoken_instructions: []
         annotations: ~
+        incidents: []
     remaining_waypoints: []
     progress:
       distanceToNextManeuver: 0

--- a/common/ferrostar/src/navigation_controller/test_helpers.rs
+++ b/common/ferrostar/src/navigation_controller/test_helpers.rs
@@ -48,6 +48,7 @@ pub fn gen_dummy_route_step(
         visual_instructions: vec![],
         spoken_instructions: vec![],
         annotations: None,
+        incidents: vec![],
     }
 }
 

--- a/common/ferrostar/src/routing_adapters/osrm/mod.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/mod.rs
@@ -105,7 +105,7 @@ impl Route {
                     let incident_items = leg
                         .incidents
                         .iter()
-                        .map(|incident| Incident::from(incident))
+                        .map(Incident::from)
                         .collect::<Vec<Incident>>();
 
                     // Index for the annotations slice

--- a/common/ferrostar/src/routing_adapters/osrm/models.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/models.rs
@@ -8,13 +8,13 @@ use crate::models::{
     BlockedLane, Congestion, Impact, IncidentType, ManeuverModifier, ManeuverType,
 };
 use alloc::{string::String, vec::Vec};
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
+#[cfg(test)]
+use serde::Serialize;
 use serde_json::Value;
 #[cfg(feature = "alloc")]
 use std::collections::HashMap;
-use chrono::{DateTime, Utc};
-#[cfg(test)]
-use serde::Serialize;
 
 #[derive(Deserialize, Debug)]
 #[serde(transparent)]
@@ -586,7 +586,8 @@ mod tests {
         }
         "#;
 
-        let incident: MapboxOsrmIncident = serde_json::from_str(data).expect("Failed to parse Incident");
+        let incident: MapboxOsrmIncident =
+            serde_json::from_str(data).expect("Failed to parse Incident");
 
         insta::assert_yaml_snapshot!(incident);
     }

--- a/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__models__tests__deserialize_incidents.snap
+++ b/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__models__tests__deserialize_incidents.snap
@@ -1,0 +1,30 @@
+---
+source: ferrostar/src/routing_adapters/osrm/models.rs
+expression: incident
+snapshot_kind: text
+---
+id: "13956787949218641"
+type: construction
+description: "I-84 W/B: intermittent lane closures from Exit 57 CT-15 to US-44 Connecticut Blvd"
+long_description: Intermittent lane closures due to barrier repairs on I-84 Westbound from Exit 57 CT-15 to US-44 Connecticut Blvd.
+creation_time: "2024-11-13T16:39:17Z"
+start_time: "2023-04-03T22:00:00Z"
+end_time: "2024-11-26T04:59:00Z"
+impact: major
+lanes_blocked: []
+num_lanes_blocked: ~
+congestion:
+  value: 101
+closed: ~
+geometry_index_start: 2932
+geometry_index_end: 3017
+sub_type: CONSTRUCTION
+sub_type_description: ~
+iso_3166_1_alpha2: US
+iso_3166_1_alpha3: USA
+affected_road_names:
+  - Officer Brian A. Aselton Memorial Highway
+south: 41.763362
+west: -72.661148
+north: 41.769363
+east: -72.633712

--- a/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_valhalla_osrm.snap
+++ b/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_valhalla_osrm.snap
@@ -338,6 +338,7 @@ expression: routes
           ssml: "<speak>In 200 feet, Turn left onto the walkway.</speak>"
           trigger_distance_before_maneuver: 60
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.442754
           lng: 24.763449
@@ -362,6 +363,7 @@ expression: routes
           ssml: "<speak>In 14 feet, Turn right onto Laeva.</speak>"
           trigger_distance_before_maneuver: 4.5
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.442671
           lng: 24.763423
@@ -386,6 +388,7 @@ expression: routes
           ssml: "<speak>In 26 feet, Bear right.</speak>"
           trigger_distance_before_maneuver: 8
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.442709
           lng: 24.763155
@@ -412,6 +415,7 @@ expression: routes
           ssml: "<speak>In 24 feet, Bear left onto the walkway.</speak>"
           trigger_distance_before_maneuver: 7.5
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.442819
           lng: 24.763
@@ -440,6 +444,7 @@ expression: routes
           ssml: "<speak>In 62 feet, Continue.</speak>"
           trigger_distance_before_maneuver: 19
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.442918
           lng: 24.762356
@@ -464,6 +469,7 @@ expression: routes
           ssml: "<speak>In 11 feet, Turn right onto Admiralisild/Admiral Bridge.</speak>"
           trigger_distance_before_maneuver: 3.5
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.442936
           lng: 24.762237
@@ -494,6 +500,7 @@ expression: routes
           ssml: "<speak>In 200 feet, Continue on the walkway.</speak>"
           trigger_distance_before_maneuver: 60
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.443526
           lng: 24.761765
@@ -520,6 +527,7 @@ expression: routes
           ssml: "<speak>In 75 feet, Turn left onto the walkway.</speak>"
           trigger_distance_before_maneuver: 23
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.4439
           lng: 24.761432
@@ -544,6 +552,7 @@ expression: routes
           ssml: "<speak>In 200 feet, Turn right onto the walkway.</speak>"
           trigger_distance_before_maneuver: 60
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.443487
           lng: 24.759273
@@ -574,6 +583,7 @@ expression: routes
           ssml: "<speak>In 41 feet, Turn left onto the walkway.</speak>"
           trigger_distance_before_maneuver: 12.5
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.443712
           lng: 24.759127
@@ -602,6 +612,7 @@ expression: routes
           ssml: "<speak>In 26 feet, Turn right onto Logi.</speak>"
           trigger_distance_before_maneuver: 8
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.443674
           lng: 24.758853
@@ -644,6 +655,7 @@ expression: routes
           ssml: "<speak>In 200 feet, Turn left onto the walkway.</speak>"
           trigger_distance_before_maneuver: 60
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.444448
           lng: 24.758392
@@ -668,6 +680,7 @@ expression: routes
           ssml: "<speak>In 13 feet, Turn right onto the walkway.</speak>"
           trigger_distance_before_maneuver: 4
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.444431
           lng: 24.758246
@@ -698,6 +711,7 @@ expression: routes
           ssml: "<speak>In 200 feet, Bear left onto Kultuurikilomeeter.</speak>"
           trigger_distance_before_maneuver: 60
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.445069
           lng: 24.757636
@@ -828,6 +842,7 @@ expression: routes
           ssml: "<speak>In 200 feet, Turn right onto the walkway.</speak>"
           trigger_distance_before_maneuver: 60
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.44946
           lng: 24.739543
@@ -854,6 +869,7 @@ expression: routes
           ssml: "<speak>In 37 feet, Turn left onto the walkway.</speak>"
           trigger_distance_before_maneuver: 11.5
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.449652
           lng: 24.739675
@@ -880,6 +896,7 @@ expression: routes
           ssml: "<speak>In 26 feet, Turn left onto the crosswalk.</speak>"
           trigger_distance_before_maneuver: 8
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.449733
           lng: 24.739454
@@ -942,6 +959,7 @@ expression: routes
           ssml: "<speak>In 200 feet, Turn right onto the walkway.</speak>"
           trigger_distance_before_maneuver: 60
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.450765
           lng: 24.733721
@@ -966,6 +984,7 @@ expression: routes
           ssml: "<speak>In 3 feet, Turn left onto the walkway.</speak>"
           trigger_distance_before_maneuver: 1
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.450787
           lng: 24.733717
@@ -1016,6 +1035,7 @@ expression: routes
           ssml: "<speak>In 200 feet, Bear left onto Allveelaeva.</speak>"
           trigger_distance_before_maneuver: 60
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.451907
           lng: 24.730259
@@ -1040,6 +1060,7 @@ expression: routes
           ssml: "<speak>In 45 feet, Turn right onto Peetri.</speak>"
           trigger_distance_before_maneuver: 14
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.452026
           lng: 24.729829
@@ -1066,6 +1087,7 @@ expression: routes
           ssml: "<speak>In 41 feet, You have arrived at your destination.</speak>"
           trigger_distance_before_maneuver: 12.5495
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 59.452226
           lng: 24.730034
@@ -1087,3 +1109,4 @@ expression: routes
           trigger_distance_before_maneuver: 0
       spoken_instructions: []
       annotations: redacted annotations json strings vec
+      incidents: []

--- a/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_valhalla_osrm_with_via_ways.snap
+++ b/common/ferrostar/src/routing_adapters/osrm/snapshots/ferrostar__routing_adapters__osrm__tests__parse_valhalla_osrm_with_via_ways.snap
@@ -452,6 +452,7 @@ expression: routes
           ssml: "<speak>In 200 feet, You have arrived at your destination.</speak>"
           trigger_distance_before_maneuver: 60
       annotations: redacted annotations json strings vec
+      incidents: []
     - geometry:
         - lat: 28.790106
           lng: -82.018021
@@ -473,3 +474,4 @@ expression: routes
           trigger_distance_before_maneuver: 0
       spoken_instructions: []
       annotations: redacted annotations json strings vec
+      incidents: []

--- a/common/ferrostar/src/routing_adapters/osrm/utilities.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/utilities.rs
@@ -1,5 +1,5 @@
-use super::models::AnyAnnotation;
-use crate::models::AnyAnnotationValue;
+use super::models::{AnyAnnotation, OsrmIncident};
+use crate::models::{AnyAnnotationValue, GeographicCoordinate, Incident};
 use crate::routing_adapters::error::ParsingError;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -45,6 +45,46 @@ pub(crate) fn zip_annotations(annotation: AnyAnnotation) -> Vec<AnyAnnotationVal
         })
         .map(|value| AnyAnnotationValue { value })
         .collect::<Vec<AnyAnnotationValue>>();
+}
+
+impl From<&OsrmIncident> for Incident {
+    fn from(incident: &OsrmIncident) -> Self {
+        Incident {
+            id: incident.id.clone(),
+            incident_type: incident.incident_type,
+            description: incident.description.clone(),
+            long_description: incident.long_description.clone(),
+            creation_time: incident.creation_time.clone(),
+            start_time: incident.start_time.clone(),
+            end_time: incident.end_time.clone(),
+            impact: incident.impact,
+            lanes_blocked: incident.lanes_blocked.clone(),
+            num_lanes_blocked: incident.num_lanes_blocked,
+            congestion: incident.congestion.clone(),
+            closed: incident.closed,
+            geometry_index_start: incident.geometry_index_start,
+            geometry_index_end: incident.geometry_index_end,
+            sub_type: incident.sub_type.clone(),
+            sub_type_description: incident.sub_type_description.clone(),
+            iso_3166_1_alpha2: incident.iso_3166_1_alpha2.clone(),
+            iso_3166_1_alpha3: incident.iso_3166_1_alpha3.clone(),
+            affected_road_names: incident.affected_road_names.clone(),
+            south_west: match (incident.south, incident.west) {
+                (Some(south), Some(west)) => Some(GeographicCoordinate {
+                    lat: south,
+                    lng: west,
+                }),
+                _ => None,
+            },
+            north_east: match (incident.north, incident.east) {
+                (Some(north), Some(east)) => Some(GeographicCoordinate {
+                    lat: north,
+                    lng: east,
+                }),
+                _ => None,
+            },
+        }
+    }
 }
 
 #[cfg(test)]

--- a/common/ferrostar/src/routing_adapters/osrm/utilities.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/utilities.rs
@@ -69,18 +69,16 @@ impl From<&MapboxOsrmIncident> for Incident {
             iso_3166_1_alpha3: incident.iso_3166_1_alpha3.clone(),
             affected_road_names: incident.affected_road_names.clone(),
             bbox: match (incident.south, incident.west, incident.north, incident.east) {
-                (Some(south), Some(west), Some(north), Some(east)) => Some(
-                    BoundingBox {
-                        sw: GeographicCoordinate {
-                            lat: south,
-                            lng: west,
-                        },
-                        ne: GeographicCoordinate {
-                            lat: north,
-                            lng: east,
-                        },
-                    }
-                ),
+                (Some(south), Some(west), Some(north), Some(east)) => Some(BoundingBox {
+                    sw: GeographicCoordinate {
+                        lat: south,
+                        lng: west,
+                    },
+                    ne: GeographicCoordinate {
+                        lat: north,
+                        lng: east,
+                    },
+                }),
                 _ => None,
             },
         }

--- a/common/ferrostar/src/routing_adapters/osrm/utilities.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/utilities.rs
@@ -1,5 +1,5 @@
-use super::models::{AnyAnnotation, OsrmIncident};
-use crate::models::{AnyAnnotationValue, GeographicCoordinate, Incident};
+use super::models::{AnyAnnotation, MapboxOsrmIncident};
+use crate::models::{AnyAnnotationValue, BoundingBox, GeographicCoordinate, Incident};
 use crate::routing_adapters::error::ParsingError;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -47,8 +47,8 @@ pub(crate) fn zip_annotations(annotation: AnyAnnotation) -> Vec<AnyAnnotationVal
         .collect::<Vec<AnyAnnotationValue>>();
 }
 
-impl From<&OsrmIncident> for Incident {
-    fn from(incident: &OsrmIncident) -> Self {
+impl From<&MapboxOsrmIncident> for Incident {
+    fn from(incident: &MapboxOsrmIncident) -> Self {
         Incident {
             id: incident.id.clone(),
             incident_type: incident.incident_type,
@@ -59,7 +59,6 @@ impl From<&OsrmIncident> for Incident {
             end_time: incident.end_time.clone(),
             impact: incident.impact,
             lanes_blocked: incident.lanes_blocked.clone(),
-            num_lanes_blocked: incident.num_lanes_blocked,
             congestion: incident.congestion.clone(),
             closed: incident.closed,
             geometry_index_start: incident.geometry_index_start,
@@ -69,18 +68,19 @@ impl From<&OsrmIncident> for Incident {
             iso_3166_1_alpha2: incident.iso_3166_1_alpha2.clone(),
             iso_3166_1_alpha3: incident.iso_3166_1_alpha3.clone(),
             affected_road_names: incident.affected_road_names.clone(),
-            south_west: match (incident.south, incident.west) {
-                (Some(south), Some(west)) => Some(GeographicCoordinate {
-                    lat: south,
-                    lng: west,
-                }),
-                _ => None,
-            },
-            north_east: match (incident.north, incident.east) {
-                (Some(north), Some(east)) => Some(GeographicCoordinate {
-                    lat: north,
-                    lng: east,
-                }),
+            bbox: match (incident.south, incident.west, incident.north, incident.east) {
+                (Some(south), Some(west), Some(north), Some(east)) => Some(
+                    BoundingBox {
+                        sw: GeographicCoordinate {
+                            lat: south,
+                            lng: west,
+                        },
+                        ne: GeographicCoordinate {
+                            lat: north,
+                            lng: east,
+                        },
+                    }
+                ),
                 _ => None,
             },
         }

--- a/common/ferrostar/uniffi.toml
+++ b/common/ferrostar/uniffi.toml
@@ -10,3 +10,13 @@ from_custom = "{}.uuidString"
 type_name = "java.util.UUID"
 into_custom = "java.util.UUID.fromString({})"
 from_custom = "{}.toString()"
+
+[bindings.swift.custom_types.UtcDateTime]
+type_name = "Date"
+into_custom = "Date(timeIntervalSince1970: Double({}) / 1000.0)"
+from_custom = "Int64({}.timeIntervalSince1970 * 1000)"
+
+[bindings.kotlin.custom_types.UtcDateTime]
+type_name = "java.util.Date"
+into_custom = "java.util.Date({})"
+from_custom = "{}.time"

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "CatMe0w <CatMe0w@live.cn> (https://github.com/CatMe0w)",
     "Luke Seelenbinder <luke@stadiamaps.com>"
   ],
-  "version": "0.22.0",
+  "version": "0.23.0",
   "license": "BSD-3-Clause",
   "type": "module",
   "main": "./dist/ferrostar-webcomponents.js",


### PR DESCRIPTION
This parses incidents on the OSRM response route leg, and splits the
incidents across the corresponding route step. Since an incident may
span multiple steps, this will duplicate an incident and adjust the
indices accordingly whenever that happens. Clients can de-duplicate
these if necessary based on the incident identifier.