### PR TITLE
Properly update sub model with type and modifier

### DIFF
--- a/common/ferrostar/src/routing_adapters/osrm/mod.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/mod.rs
@@ -219,9 +219,9 @@ impl RouteStep {
                 }),
                 sub_content: banner.sub.as_ref().map(|sub| VisualInstructionContent {
                     text: sub.text.clone(),
-                    maneuver_type: None,
-                    maneuver_modifier: None,
-                    roundabout_exit_degrees: None,
+                    maneuver_type: sub.maneuver_type,
+                    maneuver_modifier: sub.maneuver_modifier,
+                    roundabout_exit_degrees: sub.roundabout_exit_degrees,
                     lane_info: {
                         let lane_infos: Vec<LaneInfo> = sub
                             .components


### PR DESCRIPTION
The type and modifier fields are part of the official MapBox spec for allowed sub fields. In practice, they are mostly unused in favor of using them inside of components instead, but they are allowed and we are already parsing them, so this patch properly propagates them.