### PR TITLE
Fix for initial camera position when snapUserLocationToRoute is enabled

### DIFF
--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
@@ -64,7 +64,7 @@ fun NavigationMapView(
 
   val locationEngine = remember { StaticLocationEngine() }
   locationEngine.lastLocation =
-      if (snapUserLocationToRoute) {
+      if (snapUserLocationToRoute && isNavigating) {
         uiState.snappedLocation?.toAndroidLocation()
       } else {
         uiState.location?.toAndroidLocation()


### PR DESCRIPTION
This is a fix for snapUserLocationToRoute option. When it is enabled on NavigationMapView the camera position is defaulted to Lat: 0.0 Lng: 0.0

This happens even when you have a location provider with an activated listener.

The problem seems to be when the locationEngine.lastLocation is initialized in NavigationMapView. It will check snapUserLocationToRoute option and set the LocationEngines last location to the uiState.snappedLocation. 

The problem with this is the current uiState.snappedLocation which when starting the view is null and is not set until navigation has started.

```kotlin
 val locationEngine = remember { StaticLocationEngine() }
  locationEngine.lastLocation =
      if (snapUserLocationToRoute) {
        uiState.snappedLocation?.toAndroidLocation()
      } else {
        uiState.location?.toAndroidLocation()
      }
```

This PR fixes this by simply adding a extra check for isNavigating on the snapUserLocationToRoute option when the LocationEngine lastLocation is initialized.