### PR TITLE
Fix a typo in the web library guide

### DIFF
--- a/guide/src/web-getting-started.md
+++ b/guide/src/web-getting-started.md
@@ -40,7 +40,7 @@ to ensure maximum compatibility across frontend frameworks.
 You can import the components just like other things you’re used to in JavaScript.
 
 ```javascript
-import { FerrostarMap, BrowserLocationProvider } from "@stadiamaps/ferrostar-components";
+import { FerrostarMap, BrowserLocationProvider } from "@stadiamaps/ferrostar-webcomponents";
 ```
 
 ## Configure the `<ferrostar-map>` component


### PR DESCRIPTION
Title says it all; someone pointed out this was a bug.