### PR TITLE
Add the compose UI dependency to the Android guide

### DIFF
--- a/guide/src/android-getting-started.md
+++ b/guide/src/android-getting-started.md
@@ -24,7 +24,7 @@ dependencies {
     def ferrostarVersion = 'X.Y.Z'
     implementation "com.stadiamaps.ferrostar:core:${ferrostarVersion}"
     implementation "com.stadiamaps.ferrostar:maplibreui:${ferrostarVersion}"
-	implementation "com.stadiamaps.ferrostar:composeui:${ferrostarVersion}"
+    implementation "com.stadiamaps.ferrostar:composeui:${ferrostarVersion}"
 
     // Optional - if using Google Play Service's FusedLocation
     implementation "com.stadiamaps.ferrostar:google-play-services:${ferrostarVersion}"

--- a/guide/src/android-getting-started.md
+++ b/guide/src/android-getting-started.md
@@ -24,6 +24,7 @@ dependencies {
     def ferrostarVersion = 'X.Y.Z'
     implementation "com.stadiamaps.ferrostar:core:${ferrostarVersion}"
     implementation "com.stadiamaps.ferrostar:maplibreui:${ferrostarVersion}"
+	implementation "com.stadiamaps.ferrostar:composeui:${ferrostarVersion}"
 
     // Optional - if using Google Play Service's FusedLocation
     implementation "com.stadiamaps.ferrostar:google-play-services:${ferrostarVersion}"


### PR DESCRIPTION
Closes #430.

Looks like when we added the `KeepScreenOnDisposableEffect`, we forgot to update the guide. Probably should just add this since it's something most apps will want.