### PR TITLE
Android : remainingWaypoints Convenience Accessor on TripState

### DIFF
--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/extensions/TripStateExtensions.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/extensions/TripStateExtensions.kt
@@ -72,3 +72,15 @@ fun TripState.remainingSteps() =
       is TripState.Complete,
       TripState.Idle -> null
     }
+
+/**
+ * Get the remaining waypoints (starting at the *next* waypoint "goal") in the current trip.
+ *
+ * @return The list of remaining waypoints (if any).
+ */
+fun TripState.remainingWaypoints() =
+    when (this) {
+      is TripState.Navigating -> this.remainingWaypoints
+      is TripState.Complete,
+      TripState.Idle -> null
+    }


### PR DESCRIPTION
Added `remainingWaypoints` extension function to `TripState`, replicating the functionality with the `remainingSteps` accessor.

Minor change but took me a while to notice remainingWaypoints was even accessible here as casting to the underlying TripStates was not obvious (to me at least...).
For now can cover my use case, would be interested if it is worth including this in the NavigationUiState so that it could be easily accessible from the ViewModel (similarily to remainingSteps)? Didn't implement currently to avoid congesting that class.