### PR TITLE
Change package.json for React Native to allow for optional deps for views

### DIFF
--- a/react-native/package.json
+++ b/react-native/package.json
@@ -92,14 +92,33 @@
     "react-native-builder-bob": "^0.32.0",
     "release-it": "^17.10.0",
     "turbo": "^1.10.7",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "@maplibre/maplibre-react-native": "^10.0.0",
+    "@turf/bbox": "^7.2.0",
+    "react-native-svg": "^15.10.1",
+    "@react-native-community/geolocation": "^3.4.0"
   },
   "resolutions": {
     "@types/react": "^18.2.44"
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "@maplibre/maplibre-react-native": ">=10.0.0",
+    "@turf/bbox": ">=7.2.0",
+    "react-native-svg": ">=15.10.1",
+    "@react-native-community/geolocation": ">=3.4.0"
+  },
+  "peerDependenciesMeta": {
+    "@maplibre/maplibre-react-native": {
+      "optional": true
+    },
+    "@turf/bbox": {
+      "optional": true
+    },
+    "react-native-svg": {
+      "optional": true
+    }
   },
   "workspaces": [
     "example"
@@ -210,10 +229,6 @@
     "version": "0.45.5"
   },
   "dependencies": {
-    "@maplibre/maplibre-react-native": "^10.0.0",
-    "@react-native-community/geolocation": "^3.4.0",
-    "@turf/bbox": "^7.2.0",
-    "react-native-svg": "^15.10.1",
     "uniffi-bindgen-react-native": "^0.28.3-1"
   }
 }


### PR DESCRIPTION
This is a small PR and related to #425 

I've been wondering about a way to properly do this within the package.json and was looking through some other projects and found the way https://github.com/computerjazz/react-native-draggable-flatlist/blob/main/package.json handles this. 

It seems peerDependencies seems the way to go, look through the documentation on NPM and it seems we can label some of the peer deps as optional which I think will work well for the view related packages (React Native MapLibre and so on.)

Documentation if anyone else want to have a look in case I've missed something https://docs.npmjs.com/cli/v11/configuring-npm/package-json#peerdependencies

This PR just makes that change. Another way to potential do this is to separate the view and core logic into to two separate package which we upload separately onto NPM