### PR TITLE
Route Polyline Configuration

### DIFF
--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
@@ -58,8 +58,10 @@ data class NavigationUiState(
     val isMuted: Boolean?,
     /** The name of the road which the current route step is traversing. */
     val currentStepRoadName: String?,
-    /** The index of the closest coordinate to the user's snapped location.
-     *  The index is Relative to the *current* (i.e. first in remainingSteps) RouteStep Geometry */
+    /**
+     * The index of the closest coordinate to the user's snapped location. The index is Relative to
+     * the *current* (i.e. first in remainingSteps) RouteStep Geometry
+     */
     val currentStepGeometryIndex: Int?,
     /** The remaining steps in the trip (including the current step). */
     val remainingSteps: List<RouteStep>?,

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/NavigationViewModel.kt
@@ -7,6 +7,7 @@ import com.stadiamaps.ferrostar.core.annotation.AnnotationPublisher
 import com.stadiamaps.ferrostar.core.annotation.AnnotationWrapper
 import com.stadiamaps.ferrostar.core.annotation.NoOpAnnotationPublisher
 import com.stadiamaps.ferrostar.core.extensions.currentRoadName
+import com.stadiamaps.ferrostar.core.extensions.currentStepGeometryIndex
 import com.stadiamaps.ferrostar.core.extensions.deviation
 import com.stadiamaps.ferrostar.core.extensions.progress
 import com.stadiamaps.ferrostar.core.extensions.remainingSteps
@@ -57,6 +58,9 @@ data class NavigationUiState(
     val isMuted: Boolean?,
     /** The name of the road which the current route step is traversing. */
     val currentStepRoadName: String?,
+    /** The index of the closest coordinate to the user's snapped location.
+     *  The index is Relative to the *current* (i.e. first in remainingSteps) RouteStep Geometry */
+    val currentStepGeometryIndex: Int?,
     /** The remaining steps in the trip (including the current step). */
     val remainingSteps: List<RouteStep>?,
     /** The route annotation object at the current location. */
@@ -83,6 +87,7 @@ data class NavigationUiState(
             routeDeviation = coreState.tripState.deviation(),
             isMuted = isMuted,
             currentStepRoadName = coreState.tripState.currentRoadName(),
+            currentStepGeometryIndex = coreState.tripState.currentStepGeometryIndex(),
             remainingSteps = coreState.tripState.remainingSteps(),
             currentAnnotation = annotation)
   }

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/extensions/TripStateExtensions.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/extensions/TripStateExtensions.kt
@@ -62,15 +62,16 @@ fun TripState.currentRoadName() =
     }
 
 /**
- * Get the current step geometry index - closest coordinate to the user's snapped location
- * This index is relative to the *current* [`RouteStep`]'s geometry.
+ * Get the current step geometry index - closest coordinate to the user's snapped location This
+ * index is relative to the *current* [`RouteStep`]'s geometry.
+ *
  * @return The current step geometry index (if available and navigating).
  */
 fun TripState.currentStepGeometryIndex() =
     when (this) {
-        is TripState.Navigating -> this.currentStepGeometryIndex?.toInt()
-        is TripState.Complete,
-        TripState.Idle -> null
+      is TripState.Navigating -> this.currentStepGeometryIndex?.toInt()
+      is TripState.Complete,
+      TripState.Idle -> null
     }
 
 /**

--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/extensions/TripStateExtensions.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/extensions/TripStateExtensions.kt
@@ -62,6 +62,18 @@ fun TripState.currentRoadName() =
     }
 
 /**
+ * Get the current step geometry index - closest coordinate to the user's snapped location
+ * This index is relative to the *current* [`RouteStep`]'s geometry.
+ * @return The current step geometry index (if available and navigating).
+ */
+fun TripState.currentStepGeometryIndex() =
+    when (this) {
+        is TripState.Navigating -> this.currentStepGeometryIndex?.toInt()
+        is TripState.Complete,
+        TripState.Idle -> null
+    }
+
+/**
  * Get the remaining steps (including the current) in the current trip.
  *
  * @return The list of remaining steps (if any).

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoNavigationViewModel.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoNavigationViewModel.kt
@@ -67,6 +67,7 @@ class DemoNavigationViewModel(
                       null,
                       null,
                       null,
+                      null,
                       null))
 
   override fun toggleMute() {

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
@@ -19,7 +19,7 @@ import com.maplibre.compose.settings.MapControls
 import com.stadiamaps.ferrostar.core.NavigationUiState
 import com.stadiamaps.ferrostar.core.toAndroidLocation
 import com.stadiamaps.ferrostar.maplibreui.extensions.NavigationDefault
-import com.stadiamaps.ferrostar.maplibreui.routeline.NavigationPathBuilder
+import com.stadiamaps.ferrostar.maplibreui.routeline.RouteOverlayBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
 
 /**
@@ -36,8 +36,8 @@ import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
- * @param navigationPathBuilder The navigation path builder to use for rendering the route line on
- *   the MapView.
+ * @param routeOverlayBuilder The route overlay builder to use for rendering the route line on the
+ *   MapView.
  * @param onMapReadyCallback A callback that is invoked when the map is ready to be interacted with.
  *   If unspecified, the camera will change to `navigationCamera` if navigation is in progress.
  * @param content Any additional composable map symbol content to render.
@@ -52,7 +52,7 @@ fun NavigationMapView(
     locationRequestProperties: LocationRequestProperties =
         LocationRequestProperties.NavigationDefault(),
     snapUserLocationToRoute: Boolean = true,
-    navigationPathBuilder: NavigationPathBuilder = NavigationPathBuilder.Default(),
+    routeOverlayBuilder: RouteOverlayBuilder = RouteOverlayBuilder.Default(),
     onMapReadyCallback: ((Style) -> Unit)? = null,
     content: @Composable @MapLibreComposable ((NavigationUiState) -> Unit)? = null
 ) {
@@ -83,7 +83,7 @@ fun NavigationMapView(
       onMapReadyCallback =
           onMapReadyCallback ?: { if (isNavigating) camera.value = navigationCamera },
   ) {
-    navigationPathBuilder.navigationPath(uiState)
+    routeOverlayBuilder.navigationPath(uiState)
 
     if (content != null) {
       content(uiState)

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
@@ -36,7 +36,8 @@ import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
- * @param navigationPathBuilder The navigation path builder to use for rendering the route line on the MapView.
+ * @param navigationPathBuilder The navigation path builder to use for rendering the route line on
+ *   the MapView.
  * @param onMapReadyCallback A callback that is invoked when the map is ready to be interacted with.
  *   If unspecified, the camera will change to `navigationCamera` if navigation is in progress.
  * @param content Any additional composable map symbol content to render.

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.Style
 import com.maplibre.compose.MapView
 import com.maplibre.compose.StaticLocationEngine
@@ -20,6 +19,7 @@ import com.maplibre.compose.settings.MapControls
 import com.stadiamaps.ferrostar.core.NavigationUiState
 import com.stadiamaps.ferrostar.core.toAndroidLocation
 import com.stadiamaps.ferrostar.maplibreui.extensions.NavigationDefault
+import com.stadiamaps.ferrostar.maplibreui.routeline.NavigationPathBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
 
 /**
@@ -36,8 +36,8 @@ import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
- * @param showCompleteRoute If true, the complete route will be displayed.
- *   If false, only the remaining geometry will be displayed on the polyline.
+ * @param showCompleteRoute If true, the complete route will be displayed. If false, only the
+ *   remaining geometry will be displayed on the polyline.
  * @param onMapReadyCallback A callback that is invoked when the map is ready to be interacted with.
  *   If unspecified, the camera will change to `navigationCamera` if navigation is in progress.
  * @param content Any additional composable map symbol content to render.
@@ -52,7 +52,7 @@ fun NavigationMapView(
     locationRequestProperties: LocationRequestProperties =
         LocationRequestProperties.NavigationDefault(),
     snapUserLocationToRoute: Boolean = true,
-    showCompleteRoute: Boolean = true,
+    navigationPathBuilder: NavigationPathBuilder = NavigationPathBuilder.Default(),
     onMapReadyCallback: ((Style) -> Unit)? = null,
     content: @Composable @MapLibreComposable ((NavigationUiState) -> Unit)? = null
 ) {
@@ -73,11 +73,6 @@ fun NavigationMapView(
         uiState.location?.toAndroidLocation()
       }
 
-    val polylineGeometry = uiState.routeGeometry?.let {
-        if (showCompleteRoute && isNavigating) it.subList(uiState.remainingSteps?.size ?: 0, it.size)
-        else it
-    }
-
   MapView(
       modifier = Modifier.fillMaxSize(),
       styleUrl,
@@ -88,8 +83,7 @@ fun NavigationMapView(
       onMapReadyCallback =
           onMapReadyCallback ?: { if (isNavigating) camera.value = navigationCamera },
   ) {
-    if (polylineGeometry != null)
-        BorderedPolyline(points = polylineGeometry.map { LatLng(it.lat, it.lng) }, zIndex = 0)
+    navigationPathBuilder.navigationPath(uiState)
 
     if (content != null) {
       content(uiState)

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
@@ -36,8 +36,7 @@ import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
- * @param showCompleteRoute If true, the complete route will be displayed. If false, only the
- *   remaining geometry will be displayed on the polyline.
+ * @param navigationPathBuilder The navigation path builder to use for rendering the route line on the MapView.
  * @param onMapReadyCallback A callback that is invoked when the map is ready to be interacted with.
  *   If unspecified, the camera will change to `navigationCamera` if navigation is in progress.
  * @param content Any additional composable map symbol content to render.

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/routeline/BorderedPolyline.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/routeline/BorderedPolyline.kt
@@ -1,4 +1,4 @@
-package com.stadiamaps.ferrostar.maplibreui
+package com.stadiamaps.ferrostar.maplibreui.routeline
 
 import androidx.compose.runtime.Composable
 import com.mapbox.mapboxsdk.geometry.LatLng

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/routeline/NavigationPathBuilder.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/routeline/NavigationPathBuilder.kt
@@ -1,0 +1,23 @@
+package com.stadiamaps.ferrostar.maplibreui.routeline
+
+import androidx.compose.runtime.Composable
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.maplibre.compose.ramani.MapLibreComposable
+import com.stadiamaps.ferrostar.core.NavigationUiState
+
+data class NavigationPathBuilder(
+    internal val navigationPath:
+        @Composable
+        @MapLibreComposable
+        (uiState: NavigationUiState) -> Unit
+) {
+  companion object {
+    fun Default() =
+        NavigationPathBuilder(
+            navigationPath = { uiState ->
+              uiState.routeGeometry?.let { geometry ->
+                BorderedPolyline(points = geometry.map { LatLng(it.lat, it.lng) }, zIndex = 0)
+              }
+            })
+  }
+}

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/routeline/RouteOverlayBuilder.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/routeline/RouteOverlayBuilder.kt
@@ -5,7 +5,16 @@ import com.mapbox.mapboxsdk.geometry.LatLng
 import com.maplibre.compose.ramani.MapLibreComposable
 import com.stadiamaps.ferrostar.core.NavigationUiState
 
-data class NavigationPathBuilder(
+/**
+ * A Route Overlay (Polyline) Builder with sensible defaults - showing the full Navigation Route
+ * Geometry.
+ *
+ * This banner view includes the default [BorderedPolyline] to display the full supplied Route
+ * Geometry. Custom implementations to the appearance/functionality of the Route Overlay can be
+ * achieved by passing a custom implementation of the [navigationPath] parameter, using the
+ * [NavigationUiState] to access the Route Geometry.
+ */
+data class RouteOverlayBuilder(
     internal val navigationPath:
         @Composable
         @MapLibreComposable
@@ -13,7 +22,7 @@ data class NavigationPathBuilder(
 ) {
   companion object {
     fun Default() =
-        NavigationPathBuilder(
+        RouteOverlayBuilder(
             navigationPath = { uiState ->
               uiState.routeGeometry?.let { geometry ->
                 BorderedPolyline(points = geometry.map { LatLng(it.lat, it.lng) }, zIndex = 0)

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
@@ -35,7 +35,7 @@ import com.stadiamaps.ferrostar.core.boundingBox
 import com.stadiamaps.ferrostar.maplibreui.NavigationMapView
 import com.stadiamaps.ferrostar.maplibreui.extensions.NavigationDefault
 import com.stadiamaps.ferrostar.maplibreui.extensions.cameraControlState
-import com.stadiamaps.ferrostar.maplibreui.routeline.NavigationPathBuilder
+import com.stadiamaps.ferrostar.maplibreui.routeline.RouteOverlayBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapControlsForProgressViewHeight
 
@@ -53,8 +53,8 @@ import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapControlsForProgres
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
- * @param navigationPathBuilder The navigation path builder to use for rendering the route line on
- *   the MapView.
+ * @param routeOverlayBuilder The route overlay builder to use for rendering the route line on the
+ *   MapView.
  * @param theme The navigation UI theme to use for the view.
  * @param config The configuration for the navigation view.
  * @param views The navigation view component builder to use for the view.
@@ -76,7 +76,7 @@ fun DynamicallyOrientingNavigationView(
     config: VisualNavigationViewConfig = VisualNavigationViewConfig.Default(),
     views: NavigationViewComponentBuilder = NavigationViewComponentBuilder.Default(theme),
     mapViewInsets: MutableState<PaddingValues> = remember { mutableStateOf(PaddingValues(0.dp)) },
-    navigationPathBuilder: NavigationPathBuilder = NavigationPathBuilder.Default(),
+    routeOverlayBuilder: RouteOverlayBuilder = RouteOverlayBuilder.Default(),
     onTapExit: (() -> Unit)? = null,
     mapContent: @Composable @MapLibreComposable ((NavigationUiState) -> Unit)? = null,
 ) {
@@ -102,7 +102,7 @@ fun DynamicallyOrientingNavigationView(
         mapControls = mapControls,
         locationRequestProperties = locationRequestProperties,
         snapUserLocationToRoute = snapUserLocationToRoute,
-        navigationPathBuilder = navigationPathBuilder,
+        routeOverlayBuilder = routeOverlayBuilder,
         content = mapContent)
 
     if (uiState.isNavigating()) {

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
@@ -70,6 +70,7 @@ fun DynamicallyOrientingNavigationView(
     locationRequestProperties: LocationRequestProperties =
         LocationRequestProperties.NavigationDefault(),
     snapUserLocationToRoute: Boolean = true,
+    showCompleteRoute: Boolean = true,
     theme: NavigationUITheme = DefaultNavigationUITheme,
     config: VisualNavigationViewConfig = VisualNavigationViewConfig.Default(),
     views: NavigationViewComponentBuilder = NavigationViewComponentBuilder.Default(theme),
@@ -99,6 +100,7 @@ fun DynamicallyOrientingNavigationView(
         mapControls = mapControls,
         locationRequestProperties = locationRequestProperties,
         snapUserLocationToRoute = snapUserLocationToRoute,
+        showCompleteRoute = showCompleteRoute,
         content = mapContent)
 
     if (uiState.isNavigating()) {

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
@@ -53,7 +53,8 @@ import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapControlsForProgres
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
- * @param navigationPathBuilder The navigation path builder to use for rendering the route line on the MapView.
+ * @param navigationPathBuilder The navigation path builder to use for rendering the route line on
+ *   the MapView.
  * @param theme The navigation UI theme to use for the view.
  * @param config The configuration for the navigation view.
  * @param views The navigation view component builder to use for the view.

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
@@ -53,6 +53,7 @@ import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapControlsForProgres
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
+ * @param navigationPathBuilder The navigation path builder to use for rendering the route line on the MapView.
  * @param theme The navigation UI theme to use for the view.
  * @param config The configuration for the navigation view.
  * @param views The navigation view component builder to use for the view.

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
@@ -4,7 +4,6 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -36,6 +35,7 @@ import com.stadiamaps.ferrostar.core.boundingBox
 import com.stadiamaps.ferrostar.maplibreui.NavigationMapView
 import com.stadiamaps.ferrostar.maplibreui.extensions.NavigationDefault
 import com.stadiamaps.ferrostar.maplibreui.extensions.cameraControlState
+import com.stadiamaps.ferrostar.maplibreui.routeline.NavigationPathBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapControlsForProgressViewHeight
 
@@ -70,11 +70,11 @@ fun DynamicallyOrientingNavigationView(
     locationRequestProperties: LocationRequestProperties =
         LocationRequestProperties.NavigationDefault(),
     snapUserLocationToRoute: Boolean = true,
-    showCompleteRoute: Boolean = true,
     theme: NavigationUITheme = DefaultNavigationUITheme,
     config: VisualNavigationViewConfig = VisualNavigationViewConfig.Default(),
     views: NavigationViewComponentBuilder = NavigationViewComponentBuilder.Default(theme),
     mapViewInsets: MutableState<PaddingValues> = remember { mutableStateOf(PaddingValues(0.dp)) },
+    navigationPathBuilder: NavigationPathBuilder = NavigationPathBuilder.Default(),
     onTapExit: (() -> Unit)? = null,
     mapContent: @Composable @MapLibreComposable ((NavigationUiState) -> Unit)? = null,
 ) {
@@ -100,7 +100,7 @@ fun DynamicallyOrientingNavigationView(
         mapControls = mapControls,
         locationRequestProperties = locationRequestProperties,
         snapUserLocationToRoute = snapUserLocationToRoute,
-        showCompleteRoute = showCompleteRoute,
+        navigationPathBuilder = navigationPathBuilder,
         content = mapContent)
 
     if (uiState.isNavigating()) {

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
@@ -35,7 +35,7 @@ import com.stadiamaps.ferrostar.core.mock.pedestrianExample
 import com.stadiamaps.ferrostar.maplibreui.NavigationMapView
 import com.stadiamaps.ferrostar.maplibreui.extensions.NavigationDefault
 import com.stadiamaps.ferrostar.maplibreui.extensions.cameraControlState
-import com.stadiamaps.ferrostar.maplibreui.routeline.NavigationPathBuilder
+import com.stadiamaps.ferrostar.maplibreui.routeline.RouteOverlayBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapControlsForProgressViewHeight
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -55,8 +55,8 @@ import kotlinx.coroutines.flow.asStateFlow
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
- * @param navigationPathBuilder The navigation path builder to use for rendering the route line on
- *   the MapView.
+ * @param routeOverlayBuilder The route overlay builder to use for rendering the route line on the
+ *   MapView.
  * @param theme The navigation UI theme to use for the view.
  * @param config The configuration for the navigation view.
  * @param views The navigation view component builder to use for the view.
@@ -78,7 +78,7 @@ fun LandscapeNavigationView(
     config: VisualNavigationViewConfig = VisualNavigationViewConfig.Default(),
     views: NavigationViewComponentBuilder = NavigationViewComponentBuilder.Default(theme),
     mapViewInsets: MutableState<PaddingValues> = remember { mutableStateOf(PaddingValues(0.dp)) },
-    navigationPathBuilder: NavigationPathBuilder = NavigationPathBuilder.Default(),
+    routeOverlayBuilder: RouteOverlayBuilder = RouteOverlayBuilder.Default(),
     onTapExit: (() -> Unit)? = null,
     mapContent: @Composable @MapLibreComposable() ((NavigationUiState) -> Unit)? = null,
 ) {
@@ -98,7 +98,7 @@ fun LandscapeNavigationView(
         mapControls,
         locationRequestProperties,
         snapUserLocationToRoute,
-        navigationPathBuilder,
+        routeOverlayBuilder,
         onMapReadyCallback = { camera.value = navigationCamera },
         mapContent)
 

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
@@ -35,6 +35,7 @@ import com.stadiamaps.ferrostar.core.mock.pedestrianExample
 import com.stadiamaps.ferrostar.maplibreui.NavigationMapView
 import com.stadiamaps.ferrostar.maplibreui.extensions.NavigationDefault
 import com.stadiamaps.ferrostar.maplibreui.extensions.cameraControlState
+import com.stadiamaps.ferrostar.maplibreui.routeline.NavigationPathBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapControlsForProgressViewHeight
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -71,11 +72,11 @@ fun LandscapeNavigationView(
     locationRequestProperties: LocationRequestProperties =
         LocationRequestProperties.NavigationDefault(),
     snapUserLocationToRoute: Boolean = true,
-    showCompleteRoute: Boolean = true,
     theme: NavigationUITheme = DefaultNavigationUITheme,
     config: VisualNavigationViewConfig = VisualNavigationViewConfig.Default(),
     views: NavigationViewComponentBuilder = NavigationViewComponentBuilder.Default(theme),
     mapViewInsets: MutableState<PaddingValues> = remember { mutableStateOf(PaddingValues(0.dp)) },
+    navigationPathBuilder: NavigationPathBuilder = NavigationPathBuilder.Default(),
     onTapExit: (() -> Unit)? = null,
     mapContent: @Composable @MapLibreComposable() ((NavigationUiState) -> Unit)? = null,
 ) {
@@ -95,7 +96,7 @@ fun LandscapeNavigationView(
         mapControls,
         locationRequestProperties,
         snapUserLocationToRoute,
-        showCompleteRoute,
+        navigationPathBuilder,
         onMapReadyCallback = { camera.value = navigationCamera },
         mapContent)
 

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.flow.asStateFlow
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
+ * @param navigationPathBuilder The navigation path builder to use for rendering the route line on the MapView.
  * @param theme The navigation UI theme to use for the view.
  * @param config The configuration for the navigation view.
  * @param views The navigation view component builder to use for the view.

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
@@ -55,7 +55,8 @@ import kotlinx.coroutines.flow.asStateFlow
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
- * @param navigationPathBuilder The navigation path builder to use for rendering the route line on the MapView.
+ * @param navigationPathBuilder The navigation path builder to use for rendering the route line on
+ *   the MapView.
  * @param theme The navigation UI theme to use for the view.
  * @param config The configuration for the navigation view.
  * @param views The navigation view component builder to use for the view.

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
@@ -71,6 +71,7 @@ fun LandscapeNavigationView(
     locationRequestProperties: LocationRequestProperties =
         LocationRequestProperties.NavigationDefault(),
     snapUserLocationToRoute: Boolean = true,
+    showCompleteRoute: Boolean = true,
     theme: NavigationUITheme = DefaultNavigationUITheme,
     config: VisualNavigationViewConfig = VisualNavigationViewConfig.Default(),
     views: NavigationViewComponentBuilder = NavigationViewComponentBuilder.Default(theme),
@@ -94,6 +95,7 @@ fun LandscapeNavigationView(
         mapControls,
         locationRequestProperties,
         snapUserLocationToRoute,
+        showCompleteRoute,
         onMapReadyCallback = { camera.value = navigationCamera },
         mapContent)
 

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.flow.asStateFlow
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
+ * @param navigationPathBuilder The navigation path builder to use for rendering the route line on the MapView.
  * @param theme The navigation UI theme to use for the view.
  * @param config The configuration for the navigation view.
  * @param views The navigation view component builder to use for the view.

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
@@ -58,7 +58,8 @@ import kotlinx.coroutines.flow.asStateFlow
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
- * @param navigationPathBuilder The navigation path builder to use for rendering the route line on the MapView.
+ * @param navigationPathBuilder The navigation path builder to use for rendering the route line on
+ *   the MapView.
  * @param theme The navigation UI theme to use for the view.
  * @param config The configuration for the navigation view.
  * @param views The navigation view component builder to use for the view.

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
@@ -74,6 +74,7 @@ fun PortraitNavigationView(
     locationRequestProperties: LocationRequestProperties =
         LocationRequestProperties.NavigationDefault(),
     snapUserLocationToRoute: Boolean = true,
+    showCompleteRoute: Boolean = true,
     theme: NavigationUITheme = DefaultNavigationUITheme,
     config: VisualNavigationViewConfig = VisualNavigationViewConfig.Default(),
     views: NavigationViewComponentBuilder = NavigationViewComponentBuilder.Default(theme),
@@ -104,6 +105,7 @@ fun PortraitNavigationView(
         mapControls,
         locationRequestProperties,
         snapUserLocationToRoute,
+        showCompleteRoute,
         onMapReadyCallback = { camera.value = navigationCamera },
         mapContent)
 

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
@@ -38,7 +38,7 @@ import com.stadiamaps.ferrostar.core.mock.pedestrianExample
 import com.stadiamaps.ferrostar.maplibreui.NavigationMapView
 import com.stadiamaps.ferrostar.maplibreui.extensions.NavigationDefault
 import com.stadiamaps.ferrostar.maplibreui.extensions.cameraControlState
-import com.stadiamaps.ferrostar.maplibreui.routeline.NavigationPathBuilder
+import com.stadiamaps.ferrostar.maplibreui.routeline.RouteOverlayBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapControlsForProgressViewHeight
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -58,8 +58,8 @@ import kotlinx.coroutines.flow.asStateFlow
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the
  *   route line.
- * @param navigationPathBuilder The navigation path builder to use for rendering the route line on
- *   the MapView.
+ * @param routeOverlayBuilder The route overlay builder to use for rendering the route line on the
+ *   MapView.
  * @param theme The navigation UI theme to use for the view.
  * @param config The configuration for the navigation view.
  * @param views The navigation view component builder to use for the view.
@@ -81,7 +81,7 @@ fun PortraitNavigationView(
     config: VisualNavigationViewConfig = VisualNavigationViewConfig.Default(),
     views: NavigationViewComponentBuilder = NavigationViewComponentBuilder.Default(theme),
     mapViewInsets: MutableState<PaddingValues> = remember { mutableStateOf(PaddingValues(0.dp)) },
-    navigationPathBuilder: NavigationPathBuilder = NavigationPathBuilder.Default(),
+    routeOverlayBuilder: RouteOverlayBuilder = RouteOverlayBuilder.Default(),
     onTapExit: (() -> Unit)? = null,
     mapContent: @Composable @MapLibreComposable() ((NavigationUiState) -> Unit)? = null,
 ) {
@@ -108,7 +108,7 @@ fun PortraitNavigationView(
         mapControls,
         locationRequestProperties,
         snapUserLocationToRoute,
-        navigationPathBuilder,
+        routeOverlayBuilder,
         onMapReadyCallback = { camera.value = navigationCamera },
         mapContent)
 

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
@@ -38,6 +38,7 @@ import com.stadiamaps.ferrostar.core.mock.pedestrianExample
 import com.stadiamaps.ferrostar.maplibreui.NavigationMapView
 import com.stadiamaps.ferrostar.maplibreui.extensions.NavigationDefault
 import com.stadiamaps.ferrostar.maplibreui.extensions.cameraControlState
+import com.stadiamaps.ferrostar.maplibreui.routeline.NavigationPathBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapControlsForProgressViewHeight
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -74,11 +75,11 @@ fun PortraitNavigationView(
     locationRequestProperties: LocationRequestProperties =
         LocationRequestProperties.NavigationDefault(),
     snapUserLocationToRoute: Boolean = true,
-    showCompleteRoute: Boolean = true,
     theme: NavigationUITheme = DefaultNavigationUITheme,
     config: VisualNavigationViewConfig = VisualNavigationViewConfig.Default(),
     views: NavigationViewComponentBuilder = NavigationViewComponentBuilder.Default(theme),
     mapViewInsets: MutableState<PaddingValues> = remember { mutableStateOf(PaddingValues(0.dp)) },
+    navigationPathBuilder: NavigationPathBuilder = NavigationPathBuilder.Default(),
     onTapExit: (() -> Unit)? = null,
     mapContent: @Composable @MapLibreComposable() ((NavigationUiState) -> Unit)? = null,
 ) {
@@ -105,7 +106,7 @@ fun PortraitNavigationView(
         mapControls,
         locationRequestProperties,
         snapUserLocationToRoute,
-        showCompleteRoute,
+        navigationPathBuilder,
         onMapReadyCallback = { camera.value = navigationCamera },
         mapContent)
 


### PR DESCRIPTION
As discussed in #437, I have put together a minimal change to allow overriding of the current BorderedPolyline implementation for displaying the Route on the Map.
This allows for a custom NavigationPathBuilder _(not precious on the name...)_ to be injected into the NavigationView and be re-composed with changes to the UiState.

Found that having currentStepGeometryIndex exposed in the NavigationUiState was needed for the tracking in my implementation so have added this.

This is just Android for now, happy to work on implementation on the other platforms to work in a similar way to this if others would fine this useful.