### PR TITLE
[iOS] Render route polyline below symbols

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/swiftui-dsl",
       "state" : {
-        "revision" : "61cffb65b6d58289c152ae1aaed526b75bb13ade",
-        "version" : "0.5.1"
+        "revision" : "ac5f240ec0be8bb5b91793c0efd3c233dad211f2",
+        "version" : "0.7.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ if useLocalMapLibreSwiftUIDSL {
 } else {
     maplibreSwiftUIDSLPackage = .package(
         url: "https://github.com/maplibre/swiftui-dsl",
-        from: "0.5.1"
+        from: "0.7.0"
     )
 }
 

--- a/apple/DemoApp/Ferrostar Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apple/DemoApp/Ferrostar Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "b84a0decbe9ca1caeff1402efdce71349c09d790",
-        "version" : "6.8.1"
+        "revision" : "0f0359865882095c57a555a002bb90b677388874",
+        "version" : "6.11.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "da977ecb20974c4b1cf185f5fd38771b2d4674fb",
-        "version" : "0.0.10"
+        "revision" : "203336d0ccb7ff03a8a03db54a4fa18fc2b0c771",
+        "version" : "0.3.0"
       }
     },
     {
@@ -42,8 +42,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/swiftui-dsl",
       "state" : {
-        "revision" : "59853fd148b565c5cd1d67f14a9aa4b446048f03",
-        "version" : "0.4.0"
+        "revision" : "ac5f240ec0be8bb5b91793c0efd3c233dad211f2",
+        "version" : "0.7.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "b444594f79844b0d6d76d70fbfb3f7f71728f938",
+        "version" : "1.5.1"
       }
     }
   ],

--- a/apple/Sources/FerrostarMapLibreUI/Layers/RouteStyleLayer.swift
+++ b/apple/Sources/FerrostarMapLibreUI/Layers/RouteStyleLayer.swift
@@ -63,6 +63,7 @@ public struct RouteStyleLayer: StyleLayerCollection {
                            curveType: .exponential,
                            parameters: NSExpression(forConstantValue: 1.5),
                            stops: NSExpression(forConstantValue: [14: 6, 18: 24]))
+                .renderBelow(.symbols)
         }
 
         LineStyleLayer(identifier: "\(identifier)-polyline", source: source)
@@ -73,5 +74,6 @@ public struct RouteStyleLayer: StyleLayerCollection {
                        curveType: .exponential,
                        parameters: NSExpression(forConstantValue: 1.5),
                        stops: NSExpression(forConstantValue: [14: 3, 18: 16]))
+            .renderBelow(.symbols)
     }
 }


### PR DESCRIPTION
Title says it all. This upgrades the SwiftUI DSL and changes the Z order of the polyline. It's still basically invisible since the text is black, but that's a map style issue ;)