### PR TITLE
Recalculation gating

### DIFF
--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/FerrostarCore.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/FerrostarCore.kt
@@ -82,6 +82,15 @@ class FerrostarCore(
   var minimumTimeBeforeRecalculaton: Long = 5
 
   /**
+   * The minimum distance (in meters) the user must move before performing another route
+   * recalculation.
+   *
+   * This ensures that, while the user remains off the route, we don't keep triggering useless
+   * recalculations.
+   */
+  var minimumMovementBeforeRecalculation = 50.0
+
+  /**
    * Controls what happens when the user deviates from the route.
    *
    * The default behavior (when this property is `null`) is to fetch new routes automatically. These
@@ -126,6 +135,8 @@ class FerrostarCore(
   private var _routeRequestInFlight = false
   private var _lastAutomaticRecalculation: Long? = null
   private var _lastLocation: UserLocation? = null
+  // The last location from which we triggered a recalculation
+  private var _lastRecalculationLocation: UserLocation? = null
 
   private var _config: NavigationControllerConfig = navigationControllerConfig
 
@@ -309,6 +320,7 @@ class FerrostarCore(
     _state.value = NavigationState()
     _queuedUtteranceIds.clear()
     spokenInstructionObserver?.stopAndClearQueue()
+    _lastRecalculationLocation = null
   }
 
   /**
@@ -320,9 +332,15 @@ class FerrostarCore(
   private fun handleStateUpdate(newState: TripState, location: UserLocation) {
     if (newState is TripState.Navigating) {
       if (newState.deviation is RouteDeviation.OffRoute) {
-        if (!_routeRequestInFlight &&
+        if (!_routeRequestInFlight && // We can't have a request in flight already
             _lastAutomaticRecalculation?.let {
+              // Ensure a minimum cool down before a new route fetch
               System.nanoTime() - it > minimumTimeBeforeRecalculaton
+            } != false &&
+            _lastRecalculationLocation?.let {
+              // Don't recalculate again if the user hasn't moved much
+              it.toAndroidLocation().distanceTo(location.toAndroidLocation()) >
+                  minimumMovementBeforeRecalculation
             } != false) {
           val action =
               deviationHandler?.correctiveActionForDeviation(
@@ -334,6 +352,7 @@ class FerrostarCore(
             }
             is CorrectiveAction.GetNewRoutes -> {
               isCalculatingNewRoute = true
+              _lastRecalculationLocation = location
               _scope.launch {
                 try {
                   val routes = getRoutes(location, action.waypoints)

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.8.0"
 kotlin = "2.1.10"
 cargo-ndk = "0.3.4"
 ktfmt = "0.21.0"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Jul 14 13:32:53 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/apple/Sources/FerrostarCore/FerrostarCore.swift
+++ b/apple/Sources/FerrostarCore/FerrostarCore.swift
@@ -78,6 +78,11 @@ public protocol FerrostarCoreDelegate: AnyObject {
     /// This adds a minimum delay (default 5 seconds).
     public var minimumTimeBeforeRecalculaton: TimeInterval = 5
 
+    /// The minimum distance (in meters) the user must move before performing another route recaluclation.
+    ///
+    /// This ensures that, while the user remains off the route, we don't keep triggering useless recalculations.
+    public var minimumMovementBeforeRecaluclation = CLLocationDistance(50)
+
     /// The observable state of the model (for easy binding in SwiftUI views).
     @Published public private(set) var state: NavigationState?
 
@@ -90,6 +95,8 @@ public protocol FerrostarCoreDelegate: AnyObject {
     private var routeRequestInFlight = false
     private var lastAutomaticRecalculation: Date? = nil
     private var lastLocation: UserLocation? = nil
+    // The last location from which we triggered a recalculation
+    private var lastRecalculationLocation: UserLocation? = nil
     private var recalculationTask: Task<Void, Never>?
     private var queuedUtteranceIDs: Set<UUID> = Set()
 
@@ -288,6 +295,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
         queuedUtteranceIDs.removeAll()
         locationProvider.stopUpdating()
         spokenInstructionObserver?.stopAndClearQueue()
+        lastRecalculationLocation = nil
     }
 
     /// Internal state update.
@@ -314,10 +322,15 @@ public protocol FerrostarCoreDelegate: AnyObject {
                     // No action
                     break
                 case let .offRoute(deviationFromRouteLine: deviationFromRouteLine):
-                    guard !self.routeRequestInFlight,
+                    guard !self.routeRequestInFlight, // We can't have a request in flight already
+                          // Ensure a minimum cool down before a new route fetch
                           self.lastAutomaticRecalculation?.timeIntervalSinceNow ?? -TimeInterval
                           .greatestFiniteMagnitude < -self
-                          .minimumTimeBeforeRecalculaton
+                          .minimumTimeBeforeRecalculaton,
+                          // Don't recalculate if the user hasn't moved much
+                          self.lastRecalculationLocation?.clLocation
+                          .distance(from: location.clLocation) ?? .greatestFiniteMagnitude > self
+                          .minimumMovementBeforeRecaluclation
                     else {
                         break
                     }
@@ -331,6 +344,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
                         break
                     case let .getNewRoutes(waypoints):
                         self.state?.isCalculatingNewRoute = true
+                        self.lastRecalculationLocation = location
                         self.recalculationTask = Task {
                             do {
                                 let routes = try await self.getRoutes(

--- a/apple/Sources/FerrostarCore/FerrostarCore.swift
+++ b/apple/Sources/FerrostarCore/FerrostarCore.swift
@@ -327,7 +327,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
                           self.lastAutomaticRecalculation?.timeIntervalSinceNow ?? -TimeInterval
                           .greatestFiniteMagnitude < -self
                           .minimumTimeBeforeRecalculaton,
-                          // Don't recalculate if the user hasn't moved much
+                          // Don't recalculate again if the user hasn't moved much
                           self.lastRecalculationLocation?.clLocation
                           .distance(from: location.clLocation) ?? .greatestFiniteMagnitude > self
                           .minimumMovementBeforeRecaluclation


### PR DESCRIPTION
This adds a new gate to prevent spurious recalculations. We'll avoid recalculating unless the user has moved by at least 50m (configurable threshold) from the *last* point that we triggered a recalculation 