### PR TITLE
Feat/osrm init fs waypoints

### DIFF
--- a/apple/Sources/UniFFI/ferrostar.swift
+++ b/apple/Sources/UniFFI/ferrostar.swift
@@ -6345,6 +6345,22 @@ public func createRouteFromOsrm(routeData: Data, waypointData: Data, polylinePre
 })
 }
 /**
+ * Creates a [`Route`] from OSRM route data and ferrostar waypoints.
+ *
+ * This uses the same logic as the [`OsrmResponseParser`] and is designed to be fairly flexible,
+ * supporting both vanilla OSRM and enhanced Valhalla (ex: from Stadia Maps and Mapbox) outputs
+ * which contain richer information like banners and voice instructions for navigation.
+ */
+public func createRouteFromOsrmRoute(routeData: Data, waypoints: [Waypoint], polylinePrecision: UInt32)throws  -> Route {
+    return try  FfiConverterTypeRoute.lift(try rustCallWithError(FfiConverterTypeParsingError.lift) {
+    uniffi_ferrostar_fn_func_create_route_from_osrm_route(
+        FfiConverterData.lower(routeData),
+        FfiConverterSequenceTypeWaypoint.lower(waypoints),
+        FfiConverterUInt32.lower(polylinePrecision),$0
+    )
+})
+}
+/**
  * Creates a [`RouteRequestGenerator`]
  * which generates requests to an arbitrary Valhalla server (using the OSRM response format).
  *
@@ -6441,6 +6457,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ferrostar_checksum_func_create_route_from_osrm() != 42270) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ferrostar_checksum_func_create_route_from_osrm_route() != 43326) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ferrostar_checksum_func_create_valhalla_request_generator() != 16275) {

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -453,7 +453,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "ferrostar"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "android_logger",
  "assert-json-diff",

--- a/common/ferrostar/Cargo.toml
+++ b/common/ferrostar/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "ferrostar"
-version = "0.27.0"
+version = "0.28.0"
 readme = "README.md"
 description = "The core of modern turn-by-turn navigation."
 keywords = ["navigation", "routing", "valhalla", "osrm"]

--- a/common/ferrostar/src/lib.rs
+++ b/common/ferrostar/src/lib.rs
@@ -179,9 +179,9 @@ fn create_route_from_osrm(
 #[uniffi::export]
 fn create_route_from_osrm_route(
     route_data: &[u8],
-    waypoints: &Vec<Waypoint>,
+    waypoints: &[Waypoint],
     polyline_precision: u32,
 ) -> Result<Route, ParsingError> {
     let route: OsrmRoute = serde_json::from_slice(route_data)?;
-    Route::from_osrm_route(&route, waypoints, polyline_precision)
+    Route::from_osrm_with_standard_waypoints(&route, waypoints, polyline_precision)
 }

--- a/common/ferrostar/src/lib.rs
+++ b/common/ferrostar/src/lib.rs
@@ -131,7 +131,7 @@ impl UniffiCustomTypeConverter for DateTime<Utc> {
 fn create_valhalla_request_generator(
     endpoint_url: String,
     profile: String,
-    options_json: &Option<String>,
+    options_json: Option<String>,
 ) -> Result<Arc<dyn RouteRequestGenerator>, InstantiationError> {
     Ok(Arc::new(ValhallaHttpRequestGenerator::with_options_json(
         endpoint_url,

--- a/common/ferrostar/src/lib.rs
+++ b/common/ferrostar/src/lib.rs
@@ -56,7 +56,7 @@ pub fn create_ferrostar_logger() {
 
 #[cfg(feature = "uniffi")]
 mod uniffi_deps {
-    pub use crate::models::Route;
+    pub use crate::models::{Route, Waypoint};
     pub use crate::routing_adapters::{
         error::{InstantiationError, ParsingError},
         osrm::{
@@ -131,7 +131,7 @@ impl UniffiCustomTypeConverter for DateTime<Utc> {
 fn create_valhalla_request_generator(
     endpoint_url: String,
     profile: String,
-    options_json: Option<String>,
+    options_json: &Option<String>,
 ) -> Result<Arc<dyn RouteRequestGenerator>, InstantiationError> {
     Ok(Arc::new(ValhallaHttpRequestGenerator::with_options_json(
         endpoint_url,
@@ -168,4 +168,20 @@ fn create_route_from_osrm(
     let route: OsrmRoute = serde_json::from_slice(route_data)?;
     let waypoints: Vec<OsrmWaypoint> = serde_json::from_slice(waypoint_data)?;
     Route::from_osrm(&route, &waypoints, polyline_precision)
+}
+
+/// Creates a [`Route`] from OSRM route data and ferrostar waypoints.
+///
+/// This uses the same logic as the [`OsrmResponseParser`] and is designed to be fairly flexible,
+/// supporting both vanilla OSRM and enhanced Valhalla (ex: from Stadia Maps and Mapbox) outputs
+/// which contain richer information like banners and voice instructions for navigation.
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
+fn create_route_from_osrm_route(
+    route_data: &[u8],
+    waypoints: &Vec<Waypoint>,
+    polyline_precision: u32,
+) -> Result<Route, ParsingError> {
+    let route: OsrmRoute = serde_json::from_slice(route_data)?;
+    Route::from_osrm_route(&route, waypoints, polyline_precision)
 }

--- a/common/ferrostar/src/routing_adapters/mod.rs
+++ b/common/ferrostar/src/routing_adapters/mod.rs
@@ -153,7 +153,7 @@ impl RouteAdapter {
     pub fn new_valhalla_http(
         endpoint_url: String,
         profile: String,
-        options_json: Option<String>,
+        options_json: &Option<String>,
     ) -> Result<Self, InstantiationError> {
         let request_generator = Arc::new(ValhallaHttpRequestGenerator::with_options_json(
             endpoint_url,

--- a/common/ferrostar/src/routing_adapters/mod.rs
+++ b/common/ferrostar/src/routing_adapters/mod.rs
@@ -153,7 +153,7 @@ impl RouteAdapter {
     pub fn new_valhalla_http(
         endpoint_url: String,
         profile: String,
-        options_json: &Option<String>,
+        options_json: Option<String>,
     ) -> Result<Self, InstantiationError> {
         let request_generator = Arc::new(ValhallaHttpRequestGenerator::with_options_json(
             endpoint_url,

--- a/common/ferrostar/src/routing_adapters/osrm/mod.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/mod.rs
@@ -54,6 +54,12 @@ impl RouteResponseParser for OsrmResponseParser {
 }
 
 impl Route {
+    /// Create a route from an OSRM route and OSRM waypoints.
+    ///
+    /// # Arguments
+    /// * `route` - The OSRM route.
+    /// * `waypoints` - The OSRM waypoints.
+    /// * `polyline_precision` - The precision of the polyline.
     pub fn from_osrm(
         route: &OsrmRoute,
         waypoints: &[OsrmWaypoint],
@@ -81,12 +87,18 @@ impl Route {
             })
             .collect();
 
-        Self::from_osrm_route(route, &waypoints, polyline_precision)
+        Self::from_osrm_with_standard_waypoints(route, &waypoints, polyline_precision)
     }
 
-    pub fn from_osrm_route(
+    /// Create a route from an OSRM route and Ferrostar waypoints.
+    ///
+    /// # Arguments
+    /// * `route` - The OSRM route.
+    /// * `waypoints` - The Ferrostar waypoints.
+    /// * `polyline_precision` - The precision of the polyline.
+    pub fn from_osrm_with_standard_waypoints(
         route: &OsrmRoute,
-        waypoints: &Vec<Waypoint>,
+        waypoints: &[Waypoint],
         polyline_precision: u32,
     ) -> Result<Self, ParsingError> {
         let linestring = decode_polyline(&route.geometry, polyline_precision).map_err(|error| {
@@ -188,7 +200,7 @@ impl Route {
                 geometry,
                 bbox: bbox.into(),
                 distance: route.distance,
-                waypoints: waypoints.clone(),
+                waypoints: waypoints.into(),
                 steps,
             })
         } else {

--- a/common/ferrostar/src/routing_adapters/osrm/mod.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/mod.rs
@@ -81,6 +81,14 @@ impl Route {
             })
             .collect();
 
+        Self::from_osrm_route(route, &waypoints, polyline_precision)
+    }
+
+    pub fn from_osrm_route(
+        route: &OsrmRoute,
+        waypoints: &Vec<Waypoint>,
+        polyline_precision: u32,
+    ) -> Result<Self, ParsingError> {
         let linestring = decode_polyline(&route.geometry, polyline_precision).map_err(|error| {
             ParsingError::InvalidGeometry {
                 error: error.to_string(),

--- a/guide/src/route-providers.md
+++ b/guide/src/route-providers.md
@@ -164,9 +164,9 @@ sequenceDiagram
 ```
 
 When using a custom provider, it can be challenging to construct the
-ferrostar `Route` object from your provider's response. Ferrostar offers
+Ferrostar `Route` object from your provider's response. Ferrostar offers
 multiple shortcuts for this including `createRouteFromOsrm`
-and `createRouteFromOsrmRoute`. These methods allow you create a ferrostar route
+and `createRouteFromOsrmRoute`. These methods allow you create a Ferrostar `Route`
 directly from OSRM formatted json byte data.
 
 #### Example (kotlin)
@@ -207,7 +207,7 @@ class MyCustomRouteProvider(
 ```
 
 For different formats, you can manually
-convert sub-types by initializing a ferrostar Route directly, or contribute your
+convert sub-types by initializing a Ferrostar `Route` directly, or contribute your
 own route provider to the core rust code. Sharing this functionality in the core
 avoids having to reimplement this verbose functionality for each platform.
 

--- a/guide/src/route-providers.md
+++ b/guide/src/route-providers.md
@@ -169,7 +169,7 @@ multiple shortcuts for this including `createRouteFromOsrm`
 and `createRouteFromOsrmRoute`. These methods allow you create a ferrostar route
 directly from OSRM formatted json byte data.
 
-Example
+#### Example (kotlin)
 
 ```kt
 class MyCustomRouteProvider(
@@ -205,6 +205,11 @@ class MyCustomRouteProvider(
   }
 }
 ```
+
+For different formats, you can manually
+convert sub-types by initializing a ferrostar Route directly, or contribute your
+own route provider to the core rust code. Sharing this functionality in the core
+avoids having to reimplement this verbose functionality for each platform.
 
 ## Using a `RouteProvider`
 

--- a/guide/src/route-providers.md
+++ b/guide/src/route-providers.md
@@ -163,6 +163,49 @@ sequenceDiagram
     CustomRouteProvider--)FerrostarCore: [Route] or error
 ```
 
+When using a custom provider, it can be challenging to construct the
+ferrostar `Route` object from your provider's response. Ferrostar offers
+multiple shortcuts for this including `createRouteFromOsrm`
+and `createRouteFromOsrmRoute`. These methods allow you create a ferrostar route
+directly from OSRM formatted json byte data.
+
+Example
+
+```kt
+class MyCustomRouteProvider(
+  private val client: MyClient
+): CustomRouteProvider {
+
+  private val moshi: Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+
+  override suspend fun getRoutes(
+    userLocation: UserLocation,
+    waypoints: List<Waypoint>
+  ): List<Route> {
+    val myRequest = SomeRequestType(userLocation, waypoints)
+    val myResponse = client.getRoute(myRequest)
+
+    // Convert our response's waypoints into ferrostar waypoints.
+    val outWaypoints = myResponse.waypoints.map {
+      it.toFerrostarWaypoint()
+    }
+
+    val jsonAdapter = moshi.adapter(MyOsrmRoute::class.java)
+    // Using the intermediate OSRM route JSON. We map our custom response
+    // data into ferrostar waypionts.
+    val routes = myResponse.routes {
+      val osrmRoute = jsonAdapter.toJson(it.route).encodeToByteArray()
+      createRouteFromOsrmRoute(osrmRoute, outWaypoints, MyCustomRouteProvider.POLYLINE_PRECISION)
+    }
+    return routes
+  }
+
+  companion object {
+    const val POLYLINE_PRECISION: UInt = 6u
+  }
+}
+```
+
 ## Using a `RouteProvider`
 
 The parts of Ferrostar concerned with routing are managed


### PR DESCRIPTION
- Adds `create_route_from_osrm_route` which enables generating ferrostar Routes from an OSRM json bytes + ferrostar waypoints.
- Adds example using this function to the guide. Effectively how to create your custom route provider using the conveniences.