### PR TITLE
fix: clear utterance queue on replace route

### DIFF
--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/FerrostarCore.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/FerrostarCore.kt
@@ -285,6 +285,9 @@ class FerrostarCore(
         locationProvider.lastLocation
             ?: UserLocation(route.geometry.first(), 0.0, null, Instant.now(), null)
 
+    _queuedUtteranceIds.clear()
+    spokenInstructionObserver?.stopAndClearQueue()
+
     _navigationController = controller
     _state.update {
       val newState = controller.getInitialState(startingLocation)


### PR DESCRIPTION
- Clears utterance queue on replace route in android core.

Potential fix for #452 