### PR TITLE
Improve navigation camera and view model parameter docs

### DIFF
--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationMapView.kt
@@ -29,8 +29,10 @@ import com.stadiamaps.ferrostar.maplibreui.runtime.navigationMapViewCamera
  * @param camera The bi-directional camera state to use for the map. Note: this is a bit
  *   non-standard as far as normal compose patterns go, but we independently came up with this
  *   approach and later verified that Google Maps does the same thing in their compose SDK.
- * @param navigationCamera The default camera settings to use when navigation starts. This will be
- *   re-applied to the camera any time that navigation is started.
+ * @param navigationCamera The default camera state to use for navigation. This is a *template*
+ *   value, which will be applied on initial display and when re-centering. The default value is
+ *   sufficient for most applications. If you set a custom value (e.g.) to change the pitch), you
+ *   must ensure that it is some variation on [MapViewCamera.TrackingUserLocationWithBearing].
  * @param uiState The navigation UI state.
  * @param locationRequestProperties The location request properties to use for the map's location
  *   engine.

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
@@ -46,9 +46,12 @@ import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapControlsForProgres
  * @param modifier The modifier to apply to the view.
  * @param styleUrl The MapLibre style URL to use for the map.
  * @param camera The bi-directional camera state to use for the map.
- * @param navigationCamera The default camera state to use for navigation. This is applied on launch
- *   and when centering.
- * @param viewModel The navigation view model provided by Ferrostar Core.
+ * @param navigationCamera The default camera state to use for navigation. This is a *template*
+ *   value, which will be applied on initial display and when re-centering. The default value is
+ *   sufficient for most applications. If you set a custom value (e.g.) to change the pitch), you
+ *   must ensure that it is some variation on [MapViewCamera.TrackingUserLocationWithBearing].
+ * @param viewModel The navigation view model (see
+ *   [com.stadiamaps.ferrostar.core.DefaultNavigationViewModel] for a common implementation]).
  * @param locationRequestProperties The location request properties to use for the map's location
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
@@ -48,9 +48,12 @@ import kotlinx.coroutines.flow.asStateFlow
  * @param modifier The modifier to apply to the view.
  * @param styleUrl The MapLibre style URL to use for the map.
  * @param camera The bi-directional camera state to use for the map.
- * @param navigationCamera The default camera state to use for navigation. This is applied on launch
- *   and when centering.
- * @param viewModel The navigation view model provided by Ferrostar Core.
+ * @param navigationCamera The default camera state to use for navigation. This is a *template*
+ *   value, which will be applied on initial display and when re-centering. The default value is
+ *   sufficient for most applications. If you set a custom value (e.g.) to change the pitch), you
+ *   must ensure that it is some variation on [MapViewCamera.TrackingUserLocationWithBearing].
+ * @param viewModel The navigation view model (see
+ *   [com.stadiamaps.ferrostar.core.DefaultNavigationViewModel] for a common implementation]).
  * @param locationRequestProperties The location request properties to use for the map's location
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the

--- a/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
+++ b/android/maplibreui/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
@@ -51,9 +51,12 @@ import kotlinx.coroutines.flow.asStateFlow
  * @param modifier The modifier to apply to the view.
  * @param styleUrl The MapLibre style URL to use for the map.
  * @param camera The bi-directional camera state to use for the map.
- * @param navigationCamera The default camera state to use for navigation. This is applied on launch
- *   and when centering.
- * @param viewModel The navigation view model provided by Ferrostar Core.
+ * @param navigationCamera The default camera state to use for navigation. This is a *template*
+ *   value, which will be applied on initial display and when re-centering. The default value is
+ *   sufficient for most applications. If you set a custom value (e.g.) to change the pitch), you
+ *   must ensure that it is some variation on [MapViewCamera.TrackingUserLocationWithBearing].
+ * @param viewModel The navigation view model (see
+ *   [com.stadiamaps.ferrostar.core.DefaultNavigationViewModel] for a common implementation]).
  * @param locationRequestProperties The location request properties to use for the map's location
  *   engine.
  * @param snapUserLocationToRoute If true, the user's displayed location will be snapped to the


### PR DESCRIPTION
A user reported an issue where the route overview button wasn't showing up. Upon looking at the code, I found something along the lines of `navigationCamera = mapCamera.value`. That's not an entirely unreasonable thing to expect when just going through filling out params in Android Studio, since the IDE doesn't always make it clear where there's a default for a parameter.

I'm not sure we can actually do anything about the editor experience, but we can at least have a better docstring explaining why you probably want the default, and what you should do in case you are going to set it.

In the process, I also noticed that the docstring for `viewModel` is outdated, since we no longer return the value from `startNavigation` in `FerrostarCore` anymore. This gives a slightly more helpful pointer to the default view model implementation.