### PR TITLE
Add a route border under route for web

### DIFF
--- a/web/src/ferrostar-map.ts
+++ b/web/src/ferrostar-map.ts
@@ -347,10 +347,27 @@ export class FerrostarMap extends LitElement {
         "line-cap": "round",
       },
       paint: {
-        "line-color": "#3700B3",
+        "line-color": "#0099ff",
         "line-width": 8,
       },
     });
+
+    this.map?.addLayer(
+      {
+        id: "route-border",
+        type: "line",
+        source: "route",
+        layout: {
+          "line-join": "round",
+          "line-cap": "round",
+        },
+        paint: {
+          "line-color": "#FFFFFF",
+          "line-width": 13,
+        },
+      },
+      "route",
+    );
 
     this.map?.setCenter(route.geometry[0]);
 
@@ -423,6 +440,7 @@ export class FerrostarMap extends LitElement {
 
   private clearMap() {
     this.map?.getLayer("route") && this.map?.removeLayer("route");
+    this.map?.getLayer("route-border") && this.map?.removeLayer("route-border");
     this.map?.getSource("route") && this.map?.removeSource("route");
     this.simulatedLocationMarker?.remove();
   }

--- a/web/src/ferrostar-map.ts
+++ b/web/src/ferrostar-map.ts
@@ -347,7 +347,7 @@ export class FerrostarMap extends LitElement {
         "line-cap": "round",
       },
       paint: {
-        "line-color": "#0099ff",
+        "line-color": "#3478f6",
         "line-width": 8,
       },
     });


### PR DESCRIPTION
Another simple PR for web that just adds a nice white border under the route line.

I've also changes the route color to be less harsh blue like the current one is, I can revert that one if need be. We could find the route color of the Android/iOS version and use that color so it's synced.