### PR TITLE
[Android] Added the ability to hide the recenter button in the navigation view

### DIFF
--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/config/VisualNavigationViewConfig.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/config/VisualNavigationViewConfig.kt
@@ -10,7 +10,7 @@ data class VisualNavigationViewConfig(
     var showZoom: Boolean = false,
     
     // Recenter
-    var showRecenter: Boolean = true,
+    var showRecenter: Boolean = false,
 
     // Speed Limit
     var speedLimitStyle: SignageStyle? = null,

--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/config/VisualNavigationViewConfig.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/config/VisualNavigationViewConfig.kt
@@ -8,7 +8,7 @@ data class VisualNavigationViewConfig(
 
     // Zoom
     var showZoom: Boolean = false,
-    
+
     // Recenter
     var showRecenter: Boolean = false,
 
@@ -16,7 +16,8 @@ data class VisualNavigationViewConfig(
     var speedLimitStyle: SignageStyle? = null,
 ) {
   companion object {
-    fun Default() = VisualNavigationViewConfig(showMute = true, showZoom = true, showRecenter = true)
+    fun Default() =
+        VisualNavigationViewConfig(showMute = true, showZoom = true, showRecenter = true)
   }
 }
 

--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/config/VisualNavigationViewConfig.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/config/VisualNavigationViewConfig.kt
@@ -8,12 +8,15 @@ data class VisualNavigationViewConfig(
 
     // Zoom
     var showZoom: Boolean = false,
+    
+    // Recenter
+    var showRecenter: Boolean = true,
 
     // Speed Limit
     var speedLimitStyle: SignageStyle? = null,
 ) {
   companion object {
-    fun Default() = VisualNavigationViewConfig(showMute = true, showZoom = true)
+    fun Default() = VisualNavigationViewConfig(showMute = true, showZoom = true, showRecenter = true)
   }
 }
 
@@ -25,6 +28,11 @@ fun VisualNavigationViewConfig.useMuteButton(): VisualNavigationViewConfig {
 /** Enables the zoom button in the navigation view. */
 fun VisualNavigationViewConfig.useZoomButton(): VisualNavigationViewConfig {
   return copy(showZoom = true)
+}
+
+/** Enables the recenter button in the navigation view. */
+fun VisualNavigationViewConfig.useRecenterButton(): VisualNavigationViewConfig {
+  return copy(showRecenter = true)
 }
 
 fun VisualNavigationViewConfig.withSpeedLimitStyle(

--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/views/components/gridviews/NavigatingInnerGridView.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/views/components/gridviews/NavigatingInnerGridView.kt
@@ -39,6 +39,7 @@ fun NavigatingInnerGridView(
     buttonSize: DpSize,
     cameraControlState: CameraControlState = CameraControlState.Hidden,
     showZoom: Boolean = true,
+    showRecenter: Boolean = true,
     onClickZoomIn: () -> Unit = {},
     onClickZoomOut: () -> Unit = {},
     topCenter: @Composable () -> Unit = { Spacer(Modifier.width(12.dp)) },
@@ -99,7 +100,7 @@ fun NavigatingInnerGridView(
         }
       },
       bottomStart = {
-        if (cameraControlState is CameraControlState.ShowRecenter) {
+        if (showRecenter && cameraControlState is CameraControlState.ShowRecenter) {
           NavigationUIButton(onClick = cameraControlState.updateCamera, buttonSize = buttonSize) {
             Icon(
                 Icons.Filled.Navigation,

--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/views/overlays/LandscapeNavigationOverlayView.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/views/overlays/LandscapeNavigationOverlayView.kt
@@ -100,6 +100,7 @@ fun LandscapeNavigationOverlayView(
           buttonSize = theme.buttonSize,
           cameraControlState = cameraControlState,
           showZoom = config.showZoom,
+          showRecenter = config.showRecenter,
           onClickZoomIn = { onClickZoomIn?.invoke() },
           onClickZoomOut = { onClickZoomOut?.invoke() },
           bottomCenter = {

--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/views/overlays/PortraitNavigationOverlayView.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/views/overlays/PortraitNavigationOverlayView.kt
@@ -81,6 +81,7 @@ fun PortraitNavigationOverlayView(
         buttonSize = theme.buttonSize,
         cameraControlState = cameraControlState,
         showZoom = config.showZoom,
+        showRecenter = config.showRecenter,
         onClickZoomIn = { onClickZoomIn?.invoke() },
         onClickZoomOut = { onClickZoomOut?.invoke() },
         bottomCenter = {


### PR DESCRIPTION
## Summary
This PR adds a new configuration option to hide the recenter button in the navigation UI. Similar to the existing options for mute and zoom buttons, users can now control the visibility of the recenter button that appears in the bottom-left corner when the camera is not following the user's location.

## Changes
- Added a new `showRecenter` boolean parameter to `VisualNavigationViewConfig` (defaults to `true` for backward compatibility)
- Added a new helper function `useRecenterButton()` in line with existing button visibility controls
- Updated the `NavigatingInnerGridView` to check the new parameter before displaying the recenter button
- Updated the overlay views to pass the config parameter to the inner grid view

## Usage
Developers can now control the recenter button visibility as part of their navigation configuration:

```kotlin
val navigationConfig = VisualNavigationViewConfig.Default().copy(
    // Hide default mute button
    showMute = false,
    // Hide default zoom controls
    showZoom = false,
    // Hide recenter button
    showRecenter = false
)
```

## Testing

The changes maintain backward compatibility, with the recenter button visible by default. The feature can be tested by configuring a navigation view with `showRecenter = false` and verifying that the recenter button doesn't appear when the camera is not tracking the user's location.

I am having trouble testing the changes due to issues with setting up cargo. So I need assistance with testing these changes. 

```
Execution failed for task ':core:buildCargoNdkDebug'.
> Failed to run `cargo --version`. You probably don't have 'cargo' executable in PATH: /Users/joeldean/.rvm/gems/ruby-3.2.1/bin:/Users/joeldean/.rvm/gems/ruby-3.2.1@global/bin:/Users/joeldean/.rvm/rubies/ruby-3.2.1/bin:/Users/joeldean/.codeium/windsurf/bin:/Users/joeldean/.nvm/versions/node/v18.20.4/bin:/Users/joeldean/.local/share/pnpm:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Users/joeldean/.orbstack/bin:/Users/joeldean/Library/Android/sdk:/Users/joeldean/Library/Android/sdk/platform-tools:/Users/joeldean/Library/Android/sdk/cmdline-tools/latest/bin:/Users/joeldean/Library/Android/sdk/emulator:/Users/joeldean/.rvm/bin:~/.npm-global/bin

```