### PR TITLE
Repair compiler warnings

### DIFF
--- a/apple/Sources/FerrostarCarPlayUI/UI/CarPlayNavigationView.swift
+++ b/apple/Sources/FerrostarCarPlayUI/UI/CarPlayNavigationView.swift
@@ -46,7 +46,6 @@ public struct CarPlayNavigationView: View, SpeedLimitViewHost,
                     camera: $camera,
                     navigationState: ferrostarCore.state
                 ) { _ in
-                    userLayers
                 }
                 .navigationMapViewContentInset(.landscape(within: geometry, horizontalPct: 0.65))
             }


### PR DESCRIPTION
```
Expression of type '[any StyleLayerDefinition]' is unused
```

The closure is defined to return `Void`, so the existing empty statement returns that value. Remove the statement to remove the warning. 