### PR TITLE
Improve OSRM API error message handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ if useLocalFramework {
         path: "./common/target/ios/libferrostar-rs.xcframework"
     )
 } else {
-    let releaseTag = "0.29.0"
+    let releaseTag = "0.30.0"
     let releaseChecksum = "115e5acc71d60d4e20981a0f82651264952aed2ce0af47d30fd9a9161c5c80a5"
     binaryTarget = .binaryTarget(
         name: "FerrostarCoreRS",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ ext {
 
 allprojects {
     group = "com.stadiamaps.ferrostar"
-    version = "0.29.0"
+    version = "0.30.0"
 }

--- a/apple/Sources/UniFFI/ferrostar.swift
+++ b/apple/Sources/UniFFI/ferrostar.swift
@@ -4584,7 +4584,7 @@ public enum ParsingError {
     )
     case MalformedAnnotations(error: String
     )
-    case InvalidStatusCode(code: String
+    case InvalidStatusCode(code: String, description: String?
     )
     case UnknownParsingError
 }
@@ -4613,7 +4613,8 @@ public struct FfiConverterTypeParsingError: FfiConverterRustBuffer {
             error: try FfiConverterString.read(from: &buf)
             )
         case 4: return .InvalidStatusCode(
-            code: try FfiConverterString.read(from: &buf)
+            code: try FfiConverterString.read(from: &buf), 
+            description: try FfiConverterOptionString.read(from: &buf)
             )
         case 5: return .UnknownParsingError
 
@@ -4643,9 +4644,10 @@ public struct FfiConverterTypeParsingError: FfiConverterRustBuffer {
             FfiConverterString.write(error, into: &buf)
             
         
-        case let .InvalidStatusCode(code):
+        case let .InvalidStatusCode(code,description):
             writeInt(&buf, Int32(4))
             FfiConverterString.write(code, into: &buf)
+            FfiConverterOptionString.write(description, into: &buf)
             
         
         case .UnknownParsingError:

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -453,7 +453,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "ferrostar"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "android_logger",
  "assert-json-diff",

--- a/common/ferrostar/Cargo.toml
+++ b/common/ferrostar/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "ferrostar"
-version = "0.29.0"
+version = "0.30.0"
 readme = "README.md"
 description = "The core of modern turn-by-turn navigation."
 keywords = ["navigation", "routing", "valhalla", "osrm"]

--- a/common/ferrostar/src/routing_adapters/error.rs
+++ b/common/ferrostar/src/routing_adapters/error.rs
@@ -68,7 +68,10 @@ pub enum ParsingError {
         feature = "std",
         error("Routing adapter returned an unexpected status code: {code}.")
     )]
-    InvalidStatusCode { code: String },
+    InvalidStatusCode {
+        code: String,
+        description: Option<String>,
+    },
     #[cfg_attr(
         feature = "std",
         error("An unknown error parsing a response was raised in foreign code.")

--- a/common/ferrostar/src/routing_adapters/osrm/mod.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/mod.rs
@@ -48,12 +48,9 @@ impl RouteResponseParser for OsrmResponseParser {
                 .map(|route| Route::from_osrm(route, &res.waypoints, self.polyline_precision))
                 .collect::<Result<Vec<_>, _>>()
         } else {
-            let error_description = match res.message {
-                Some(message) => format!("{}: {}", res.code, message),
-                None => res.code,
-            };
             Err(ParsingError::InvalidStatusCode {
-                code: error_description,
+                code: res.code,
+                description: res.message,
             })
         }
     }
@@ -467,10 +464,11 @@ mod tests {
         let result = parser.parse_response(error_json.as_bytes().to_vec());
 
         assert!(result.is_err());
-        if let Err(ParsingError::InvalidStatusCode { code }) = result {
+        if let Err(ParsingError::InvalidStatusCode { code, description }) = result {
+            assert_eq!(code, "NoRoute");
             assert_eq!(
-                code,
-                "NoRoute: No route found between the given coordinates"
+                description,
+                Some("No route found between the given coordinates".to_string())
             );
         } else {
             panic!("Expected InvalidStatusCode error with proper message");
@@ -488,10 +486,11 @@ mod tests {
         let result = parser.parse_response(error_json.as_bytes().to_vec());
 
         assert!(result.is_err());
-        if let Err(ParsingError::InvalidStatusCode { code }) = result {
+        if let Err(ParsingError::InvalidStatusCode { code, description }) = result {
+            assert_eq!(code, "NoRoute");
             assert_eq!(
-                code,
-                "NoRoute: No route found between the given coordinates"
+                description,
+                Some("No route found between the given coordinates".to_string())
             );
         } else {
             panic!("Expected InvalidStatusCode error with proper message");

--- a/common/ferrostar/src/routing_adapters/osrm/mod.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/mod.rs
@@ -454,12 +454,29 @@ mod tests {
     }
 
     #[test]
-    fn test_osrm_parser_with_api_error() {
+    fn test_osrm_parser_with_empty_route_array() {
         let error_json = r#"{
-            "code" : "NoRoute",
-            "message" : "No route found between the given coordinates",
-            "routes": [],
-            "waypoints": []
+            "code": "NoRoute",
+            "message": "No route found between the given coordinates",
+            "routes": []
+        }"#;
+
+        let parser = OsrmResponseParser::new(6);
+        let result = parser.parse_response(error_json.as_bytes().to_vec());
+
+        assert!(result.is_err());
+        if let Err(ParsingError::InvalidStatusCode { code }) = result {
+            assert_eq!(code, "NoRoute: No route found between the given coordinates");
+        } else {
+            panic!("Expected InvalidStatusCode error with proper message");
+        }
+    }
+
+    #[test]
+    fn test_osrm_parser_with_missing_route_field() {
+        let error_json = r#"{
+            "code": "NoRoute",
+            "message": "No route found between the given coordinates"
         }"#;
 
         let parser = OsrmResponseParser::new(6);

--- a/common/ferrostar/src/routing_adapters/osrm/mod.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/mod.rs
@@ -52,7 +52,9 @@ impl RouteResponseParser for OsrmResponseParser {
                 Some(message) => format!("{}: {}", res.code, message),
                 None => res.code,
             };
-            Err(ParsingError::InvalidStatusCode { code: error_description })
+            Err(ParsingError::InvalidStatusCode {
+                code: error_description,
+            })
         }
     }
 }
@@ -466,7 +468,10 @@ mod tests {
 
         assert!(result.is_err());
         if let Err(ParsingError::InvalidStatusCode { code }) = result {
-            assert_eq!(code, "NoRoute: No route found between the given coordinates");
+            assert_eq!(
+                code,
+                "NoRoute: No route found between the given coordinates"
+            );
         } else {
             panic!("Expected InvalidStatusCode error with proper message");
         }
@@ -484,7 +489,10 @@ mod tests {
 
         assert!(result.is_err());
         if let Err(ParsingError::InvalidStatusCode { code }) = result {
-            assert_eq!(code, "NoRoute: No route found between the given coordinates");
+            assert_eq!(
+                code,
+                "NoRoute: No route found between the given coordinates"
+            );
         } else {
             panic!("Expected InvalidStatusCode error with proper message");
         }

--- a/common/ferrostar/src/routing_adapters/osrm/models.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/models.rs
@@ -38,6 +38,8 @@ pub struct RouteResponse {
     ///
     /// Ok indicates success. TODO: enumerate others?
     pub code: String,
+    #[serde(default)]
+    pub message: Option<String>,
     pub routes: Vec<Route>,
     pub waypoints: Vec<Waypoint>,
 }

--- a/common/ferrostar/src/routing_adapters/osrm/models.rs
+++ b/common/ferrostar/src/routing_adapters/osrm/models.rs
@@ -40,7 +40,9 @@ pub struct RouteResponse {
     pub code: String,
     #[serde(default)]
     pub message: Option<String>,
+    #[serde(default)]
     pub routes: Vec<Route>,
+    #[serde(default)]
     pub waypoints: Vec<Waypoint>,
 }
 

--- a/guide/src/dev-env-setup.md
+++ b/guide/src/dev-env-setup.md
@@ -84,14 +84,21 @@ cd common
 ./build-ios.sh
 ```
 
+<div class="warning">
+
 **IMPORTANT:** every time you make changes to the common core,
-you will need to run [`build-ios.sh`](common/build-ios.sh) to see your changes on iOS!
+you will need to run [`build-ios.sh`](common/build-ios.sh)!
 We want to integrate this into the Xcode build flow in the future,
 but at the time of this writing,
 it is not possible with the Swift package flow.
 Further, the "normal" Xcode build flow always assumes `xcframeworks` can't change during build,
 so it processes them before any other build rules.
 Given these limitations, we opted for a shell script until further notice.
+
+If you do not have access to a Mac, you can run `./build/ios.sh --ffi-only`
+to regenerate the UniFFI bindings without invoking xcodebuild.
+
+</div>
 
 5. Open the Swift package in Xcode.
    (NOTE: Due to the quirks of how SPM is designed,

--- a/guide/src/dev-env-setup.md
+++ b/guide/src/dev-env-setup.md
@@ -95,7 +95,7 @@ Further, the "normal" Xcode build flow always assumes `xcframeworks` can't chang
 so it processes them before any other build rules.
 Given these limitations, we opted for a shell script until further notice.
 
-If you do not have access to a Mac, you can run `./build/ios.sh --ffi-only`
+If you do not have access to a Mac, you can run `./build-ios.sh --ffi-only`
 to regenerate the UniFFI bindings without invoking xcodebuild.
 
 </div>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stadiamaps/ferrostar-webcomponents",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stadiamaps/ferrostar-webcomponents",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@stadiamaps/ferrostar": "file:../common/ferrostar/pkg",
@@ -26,7 +26,7 @@
     },
     "../common/ferrostar/pkg": {
       "name": "@stadiamaps/ferrostar",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "BSD-3-Clause"
     },
     "node_modules/@babel/helper-string-parser": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "CatMe0w <CatMe0w@live.cn> (https://github.com/CatMe0w)",
     "Luke Seelenbinder <luke@stadiamaps.com>"
   ],
-  "version": "0.29.0",
+  "version": "0.30.0",
   "license": "BSD-3-Clause",
   "type": "module",
   "main": "./dist/ferrostar-webcomponents.js",

--- a/web/src/ferrostar-map.ts
+++ b/web/src/ferrostar-map.ts
@@ -300,7 +300,7 @@ export class FerrostarMap extends LitElement {
     try {
       return this.routeAdapter.parseResponse(responseData);
     } catch (e) {
-      console.error("Error parsing route response:", String(e));
+      console.error("Error parsing route response:", e);
       throw e;
     }
   }

--- a/web/src/ferrostar-map.ts
+++ b/web/src/ferrostar-map.ts
@@ -297,7 +297,12 @@ export class FerrostarMap extends LitElement {
     });
 
     const responseData = new Uint8Array(await response.arrayBuffer());
-    return this.routeAdapter.parseResponse(responseData);
+    try {
+      return this.routeAdapter.parseResponse(responseData);
+    } catch (e) {
+      console.error("Error parsing route response:", String(e));
+      throw e;
+    }
   }
 
   // TODO: types


### PR DESCRIPTION
Fixes #170 

Significant step toward logging desired for #263 #313 

When routing APIs return error responses (like "no route found" or "distance exceeded"), the error message was being lost during processing. Instead of showing the actual API error message, users would see a generic JSON parsing error like:
```
Failed to parse route json object: missing field `routes`
```
OR
```
Failed to parse route json object: missing field 'routes' at line 1 column 85
```
### Problem
Previously, when routing APIs returned error responses, JSON parsing would fail before we could extract the actual error message. This happened because error responses often don't include routes and waypoints fields.

### Solution
We're taking advantage of the existing `#[serde(default)]` annotations on the `RouteResponse` struct fields. This makes missing fields use default values (empty vectors) instead of failing to parse.

Now the parsing succeeds even for error responses, allowing our code to check the code field and properly extract the error message.

Now the error looks like this
```
Uncaught (in promise) Routing adapter returned an unexpected status code: DistanceExceeded: Path distance exceeds the max distance limit..
```