### PR TITLE
Use non iOS 17.4 CPManeuver travel estimates where necessary

### DIFF
--- a/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
+++ b/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
@@ -15,11 +15,16 @@ extension CPManeuver {
         let maneuver = CPManeuver()
 
         // CarPlay take the "initial" estimates and internally tracks the reduction.
-        maneuver.initialTravelEstimates = CPTravelEstimates(
-            distanceRemaining: stepDistance,
-            distanceRemainingToDisplay: stepDistance,
-            timeRemaining: stepDuration
+        maneuver.initialTravelEstimates =
+      if #available(iOS 17.4, *) {
+        CPTravelEstimates(
+          distanceRemaining: stepDistance,
+          distanceRemainingToDisplay: stepDistance,
+          timeRemaining: stepDuration
         )
+      } else {
+    CPTravelEstimates(distanceRemaining: stepDistance, timeRemaining: stepDuration)
+  }
 
         // The instructions. CPManeuver lists them from
         // highest (idx-0) to lowest priority.

--- a/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
+++ b/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
@@ -16,15 +16,15 @@ extension CPManeuver {
 
         // CarPlay take the "initial" estimates and internally tracks the reduction.
         maneuver.initialTravelEstimates =
-      if #available(iOS 17.4, *) {
-        CPTravelEstimates(
-          distanceRemaining: stepDistance,
-          distanceRemainingToDisplay: stepDistance,
-          timeRemaining: stepDuration
-        )
-      } else {
-    CPTravelEstimates(distanceRemaining: stepDistance, timeRemaining: stepDuration)
-  }
+            if #available(iOS 17.4, *) {
+                CPTravelEstimates(
+                    distanceRemaining: stepDistance,
+                    distanceRemainingToDisplay: stepDistance,
+                    timeRemaining: stepDuration
+                )
+            } else {
+                CPTravelEstimates(distanceRemaining: stepDistance, timeRemaining: stepDuration)
+            }
 
         // The instructions. CPManeuver lists them from
         // highest (idx-0) to lowest priority.


### PR DESCRIPTION
These build errors happen with Xcode 16.3.

Fixes:
```
/Users/bolsinga/Documents/code/git/ferrostar/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift:18:43: error: 'init(distanceRemaining:distanceRemainingToDisplay:timeRemaining:)' is only available in iOS 17.4 or newer
        maneuver.initialTravelEstimates = CPTravelEstimates(
                                          ^
/Users/bolsinga/Documents/code/git/ferrostar/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift:18:43: note: add 'if #available' version check
        maneuver.initialTravelEstimates = CPTravelEstimates(
                                          ^
/Users/bolsinga/Documents/code/git/ferrostar/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift:7:17: note: add @available attribute to enclosing static method
    static func fromFerrostar(_ instruction: VisualInstruction?,
                ^
/Users/bolsinga/Documents/code/git/ferrostar/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift:6:1: note: add @available attribute to enclosing extension
extension CPManeuver {
^
```