### PR TITLE
wrap a test in an availabity check

### DIFF
--- a/apple/Tests/FerrostarCarPlayUITests/CarPlaysModels/CPManeuverTests.swift
+++ b/apple/Tests/FerrostarCarPlayUITests/CarPlaysModels/CPManeuverTests.swift
@@ -36,7 +36,9 @@ struct CPManeuverTests {
         #expect(maneuver?.instructionVariants.first == "Maneuver instruction.")
 
         #expect(maneuver?.initialTravelEstimates?.distanceRemaining == meters)
-        #expect(maneuver?.initialTravelEstimates?.distanceRemainingToDisplay == meters)
+        if #available(iOS 17.4, *) {
+            #expect(maneuver?.initialTravelEstimates?.distanceRemainingToDisplay == meters)
+        }
         #expect(maneuver?.initialTravelEstimates?.timeRemaining == 10.0)
     }
 }


### PR DESCRIPTION
```
@__swiftmacro_23FerrostarCarPlayUITests0026CPManeuverTestsswift_DsAGgfMX38_8_6expectfMf1_.swift:1:66: error: 'distanceRemainingToDisplay' is only available in iOS 17.4 or newer
Testing.__checkBinaryOperation(maneuver?.initialTravelEstimates?.distanceRemainingToDisplay,{ $0 == $1() },meters,expression: .__fromBinaryOperation(.__fromSyntaxNode("maneuver?.initialTravelEstimates?.distanceRemainingToDisplay"),"==",.__fromSyntaxNode("meters")),comments: [],isRequired: false,sourceLocation: Testing.SourceLocation.__here()).__expected()
                                                                 ^
/Users/bolsinga/Documents/code/git/ferrostar/apple/Tests/FerrostarCarPlayUITests/CarPlaysModels/CPManeuverTests.swift:39:9: note: in expansion of macro 'expect' here
        #expect(maneuver?.initialTravelEstimates?.distanceRemainingToDisplay == meters)
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```