### PR TITLE
One camera up in the AppEnvironment.

### DIFF
--- a/apple/DemoApp/Demo/AppEnvironment.swift
+++ b/apple/DemoApp/Demo/AppEnvironment.swift
@@ -1,4 +1,5 @@
 import CoreLocation
+import FerrostarCarPlayUI
 import FerrostarCore
 import FerrostarCoreFFI
 import SwiftUI
@@ -20,6 +21,7 @@ class AppEnvironment: ObservableObject {
     var locationProvider: LocationProviding
     @Published var ferrostarCore: FerrostarCore
     @Published var spokenInstructionObserver: SpokenInstructionObserver
+    @Published var camera = SharedMapViewCamera(camera: .center(AppDefaults.initialLocation.coordinate, zoom: 14))
 
     let navigationDelegate = NavigationDelegate()
 

--- a/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
+++ b/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
@@ -19,10 +19,6 @@ class CarPlaySceneDelegate: UIResponder, UIWindowSceneDelegate, CPTemplateApplic
 
     private var carPlayManager: FerrostarCarPlayManager?
 
-    // In your implementation, you would like want to init with a cached camera from your normal
-    // MapView/NavigationMapView.
-    let sharedCamera = SharedMapViewCamera(camera: .center(AppDefaults.initialLocation.coordinate, zoom: 14))
-
     func scene(
         _: UIScene, willConnectTo _: UISceneSession,
         options _: UIScene.ConnectionOptions
@@ -65,8 +61,8 @@ class CarPlaySceneDelegate: UIResponder, UIWindowSceneDelegate, CPTemplateApplic
             ferrostarCore: ferrostarCore!,
             styleURL: AppDefaults.mapStyleURL,
             camera: Binding(
-                get: { self.sharedCamera.camera },
-                set: { self.sharedCamera.camera = $0 }
+                get: { self.appDelegate.appEnvironment.camera.camera },
+                set: { self.appDelegate.appEnvironment.camera.camera = $0 }
             )
         )
 
@@ -75,8 +71,8 @@ class CarPlaySceneDelegate: UIResponder, UIWindowSceneDelegate, CPTemplateApplic
         carPlayManager = FerrostarCarPlayManager(
             ferrostarCore!,
             camera: Binding(
-                get: { self.sharedCamera.camera },
-                set: { self.sharedCamera.camera = $0 }
+                get: { self.appDelegate.appEnvironment.camera.camera },
+                set: { self.appDelegate.appEnvironment.camera.camera = $0 }
             ),
             distanceUnits: .default
             // TODO: We may need to hold the view or viewController here, but it seems

--- a/apple/DemoApp/Demo/DemoNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoNavigationView.swift
@@ -23,8 +23,6 @@ struct DemoNavigationView: View {
         }
     }
 
-    @State private var camera: MapViewCamera = .center(AppDefaults.initialLocation.coordinate, zoom: 14)
-
     var body: some View {
         let locationServicesEnabled = appEnvironment.locationProvider.authorizationStatus == .authorizedAlways
             || appEnvironment.locationProvider.authorizationStatus == .authorizedWhenInUse
@@ -32,7 +30,7 @@ struct DemoNavigationView: View {
         NavigationStack {
             DynamicallyOrientingNavigationView(
                 styleURL: AppDefaults.mapStyleURL,
-                camera: $camera,
+                camera: $appEnvironment.camera.camera,
                 navigationState: appEnvironment.ferrostarCore.state,
                 isMuted: appEnvironment.spokenInstructionObserver.isMuted,
                 onTapMute: appEnvironment.spokenInstructionObserver.toggleMute,
@@ -130,13 +128,13 @@ struct DemoNavigationView: View {
         }
 
         try appEnvironment.startNavigation(route: route)
-        camera = .automotiveNavigation()
+        appEnvironment.camera.camera = .automotiveNavigation()
         preventAutoLock()
     }
 
     func stopNavigation() {
         appEnvironment.stopNavigation()
-        camera = .center(AppDefaults.initialLocation.coordinate, zoom: 14)
+        appEnvironment.camera.camera = .center(AppDefaults.initialLocation.coordinate, zoom: 14)
         allowAutoLock()
     }
 


### PR DESCRIPTION
With this change, if the iphone simulator is launched *and* the CarPlay window is already open, then starting navigation on the phone will also show navigation on the CarPlay window. If the CarPlay window is *not* open on launch of the application in the iPhone simulator, it will not work. As discussed with @Archdoog this is just to move things towards a good state. Adding the options to have a separate camera for each MapView will come along after launch of CarPlay can be done after CarPlay Navigation works from the get-go

Note: This is using the `SharedMapCamera` in `AppEnvironment`. However just having `@Published var camera : MapViewCamera = ...` will work too. This diff preserves `SharedMapCamera`, but technically speaking it is no longer necessary for the DemoApp.