### PR TITLE
update maneuvers for all navstate updates

### DIFF
--- a/apple/Sources/FerrostarCarPlayUI/FerrostarCarPlayAdapter.swift
+++ b/apple/Sources/FerrostarCarPlayUI/FerrostarCarPlayAdapter.swift
@@ -97,6 +97,7 @@ class FerrostarCarPlayAdapter: NSObject {
                         print("CarPlay - startup error: \(error)")
                     }
                 }
+                navigatingTemplate?.update(navigationState: navState)
             case .complete:
                 navigatingTemplate?.completeTrip()
             case .idle:


### PR DESCRIPTION
Once navigation is going in CarPlay, maneuvers will now update, by counting down the distance to the next manuever, remaining total distance and ETA, etc.

This update method was added with #474, but not called.