### PR TITLE
Update MapLibre SwiftUI DSL dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/swiftui-dsl",
       "state" : {
-        "revision" : "26eced8a6544f60d9979d35c99217599a97c80d6",
-        "version" : "0.10.0"
+        "revision" : "579c378d79effb93e43392f57bac625edb18565a",
+        "version" : "0.11.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ if useLocalMapLibreSwiftUIDSL {
 } else {
     maplibreSwiftUIDSLPackage = .package(
         url: "https://github.com/maplibre/swiftui-dsl",
-        from: "0.10.0"
+        from: "0.11.0"
     )
 }
 

--- a/apple/DemoApp/Ferrostar Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apple/DemoApp/Ferrostar Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/swiftui-dsl",
       "state" : {
-        "revision" : "26eced8a6544f60d9979d35c99217599a97c80d6",
-        "version" : "0.10.0"
+        "revision" : "579c378d79effb93e43392f57bac625edb18565a",
+        "version" : "0.11.0"
       }
     },
     {


### PR DESCRIPTION
This brings in the latest camera improvements, hopefully paving the way for route overview and generally being better on iOS.