### PR TITLE
canceling navigation now informs the CarPlay template

### DIFF
--- a/apple/Sources/FerrostarCarPlayUI/FerrostarCarPlayAdapter.swift
+++ b/apple/Sources/FerrostarCarPlayUI/FerrostarCarPlayAdapter.swift
@@ -84,7 +84,13 @@ class FerrostarCarPlayAdapter: NSObject {
         )
         .receive(on: DispatchQueue.main)
         .sink { [weak self] route, navState in
-            guard let self, let navState else { return }
+            guard let self else { return }
+            guard let navState else {
+                if case let .navigating = self.uiState {
+                    navigatingTemplate?.cancelTrip()
+                }
+                return
+            }
 
             switch navState.tripState {
             case .navigating:


### PR DESCRIPTION
- It seems that `navState` becoming `nil` is what to look for.
- Cancelling from the app or from CarPlay will remove the UI. Camera is still funky, but that's for another debug session.