### PR TITLE
FerrorstarCore always creates and owns the SpokenInstructionObserver

### DIFF
--- a/apple/DemoApp/Demo/AppEnvironment.swift
+++ b/apple/DemoApp/Demo/AppEnvironment.swift
@@ -20,7 +20,6 @@ enum DemoAppError: Error {
 class AppEnvironment: ObservableObject {
     var locationProvider: LocationProviding
     @Published var ferrostarCore: FerrostarCore
-    @Published var spokenInstructionObserver: SpokenInstructionObserver
     @Published var camera = SharedMapViewCamera(camera: .center(AppDefaults.initialLocation.coordinate, zoom: 14))
 
     let navigationDelegate = NavigationDelegate()
@@ -29,9 +28,6 @@ class AppEnvironment: ObservableObject {
         let simulated = SimulatedLocationProvider(location: initialLocation)
         simulated.warpFactor = 2
         locationProvider = simulated
-
-        // Set up the a standard Apple AV Speech Synth.
-        spokenInstructionObserver = .initAVSpeechSynthesizer()
 
         // Configure the navigation session.
         // You have a lot of flexibility here based on your use case.
@@ -61,14 +57,6 @@ class AppEnvironment: ObservableObject {
 
         // NOTE: Not all applications will need a delegate. Read the NavigationDelegate documentation for details.
         ferrostarCore.delegate = navigationDelegate
-
-        // Initialize text-to-speech; note that this is NOT automatic.
-        // You must set a spokenInstructionObserver.
-        // Fortunately, this is pretty easy with the provided class
-        // backed by AVSpeechSynthesizer.
-        // You can customize the instance it further as needed,
-        // or replace with your own.
-        ferrostarCore.spokenInstructionObserver = spokenInstructionObserver
     }
 
     func getRoutes() async throws -> [Route] {

--- a/apple/DemoApp/Demo/DemoNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoNavigationView.swift
@@ -32,8 +32,8 @@ struct DemoNavigationView: View {
                 styleURL: AppDefaults.mapStyleURL,
                 camera: $appEnvironment.camera.camera,
                 navigationState: appEnvironment.ferrostarCore.state,
-                isMuted: appEnvironment.spokenInstructionObserver.isMuted,
-                onTapMute: appEnvironment.spokenInstructionObserver.toggleMute,
+                isMuted: appEnvironment.ferrostarCore.spokenInstructionObserver.isMuted,
+                onTapMute: appEnvironment.ferrostarCore.spokenInstructionObserver.toggleMute,
                 onTapExit: { stopNavigation() },
                 makeMapContent: {
                     let source = ShapeSource(identifier: "userLocation") {

--- a/apple/Sources/FerrostarCore/FerrostarCore.swift
+++ b/apple/Sources/FerrostarCore/FerrostarCore.swift
@@ -72,7 +72,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
     public weak var delegate: FerrostarCoreDelegate?
 
     /// The spoken instruction observer; responsible for text-to-speech announcements.
-    public var spokenInstructionObserver: SpokenInstructionObserver?
+    public let spokenInstructionObserver: SpokenInstructionObserver
 
     /// The minimum time to wait before initiating another route recalculation.
     ///
@@ -124,13 +124,16 @@ public protocol FerrostarCoreDelegate: AnyObject {
         locationProvider: LocationProviding,
         navigationControllerConfig: SwiftNavigationControllerConfig,
         networkSession: URLRequestLoading,
-        annotation: (any AnnotationPublishing)? = nil
+        annotation: (any AnnotationPublishing)? = nil,
+        spokenInstructionObserver: SpokenInstructionObserver =
+            .initAVSpeechSynthesizer() // Set up the a standard Apple AV Speech Synth.
     ) {
         self.routeProvider = routeProvider
         self.locationProvider = locationProvider
         config = navigationControllerConfig
         self.networkSession = networkSession
         self.annotation = annotation
+        self.spokenInstructionObserver = spokenInstructionObserver
 
         super.init()
 
@@ -310,7 +313,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
         state = nil
         queuedUtteranceIDs.removeAll()
         locationProvider.stopUpdating()
-        spokenInstructionObserver?.stopAndClearQueue()
+        spokenInstructionObserver.stopAndClearQueue()
         lastRecalculationLocation = nil
     }
 
@@ -393,7 +396,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
                     // we'll probably remove the need for this eventually
                     // by making FerrostarCore its own actor
                     DispatchQueue.global(qos: .default).async {
-                        self.spokenInstructionObserver?.spokenInstructionTriggered(spokenInstruction)
+                        self.spokenInstructionObserver.spokenInstructionTriggered(spokenInstruction)
                     }
                 }
             default:

--- a/guide/src/ios-getting-started.md
+++ b/guide/src/ios-getting-started.md
@@ -108,7 +108,7 @@ or self-hosting.
 If your routes include spoken instructions,
 Ferrostar can trigger the speech synthesis at the right time.
 Ferrostar includes the `SpokenInstructionObserver` class, 
-which can use `AVSpeechSynthesizer` or your own speech synthesis.
+which can use `AVSpeechSynthesizer` or your own speech synthesis. This is the default for the `FerrostarCore` initializer.
 
 The `SpeechSynthesizer` protocol
 specifies the required interface,
@@ -122,11 +122,7 @@ Your navigation view can store the spoken instruction observer as an instance va
 @State private var spokenInstructionObserver = SpokenInstructionObserver.initAVSpeechSynthesizer()
 ```
 
-Then, you'll need to configure `FerrostarCore` to use it.
-
-```swift
-ferrostarCore.spokenInstructionObserver = spokenInstructionObserver
-```
+Then, you'll need to initialize `FerrostarCore` to reference it. As stated above, it has a default parameter to use `AVSpeechSynthesizer`.
 
 Finally, you can use this to drive state on navigation view.
 `DynamicallyOrientingNavigationView` has constructor arguments to configure the mute button UI.


### PR DESCRIPTION
The goal is to have less parts and an unified interface to the state. If this is non-optional it will just be a part of FerrostarCore. FerrostarCore is Observable, so its spokenInstructionObserver is Observable too.