### PR TITLE
DemoApp: Clean up and simplification

### DIFF
--- a/apple/DemoApp/Demo/AppEnvironment.swift
+++ b/apple/DemoApp/Demo/AppEnvironment.swift
@@ -20,7 +20,6 @@ enum DemoAppError: Error {
 class AppEnvironment: ObservableObject {
     var locationProvider: LocationProviding
     @Published var ferrostarCore: FerrostarCore
-    @Published var spokenInstructionObserver: SpokenInstructionObserver
     @Published var camera = SharedMapViewCamera(camera: .center(AppDefaults.initialLocation.coordinate, zoom: 14))
 
     let navigationDelegate = NavigationDelegate()
@@ -29,9 +28,6 @@ class AppEnvironment: ObservableObject {
         let simulated = SimulatedLocationProvider(location: initialLocation)
         simulated.warpFactor = 2
         locationProvider = simulated
-
-        // Set up the a standard Apple AV Speech Synth.
-        spokenInstructionObserver = .initAVSpeechSynthesizer()
 
         // Configure the navigation session.
         // You have a lot of flexibility here based on your use case.
@@ -61,14 +57,6 @@ class AppEnvironment: ObservableObject {
 
         // NOTE: Not all applications will need a delegate. Read the NavigationDelegate documentation for details.
         ferrostarCore.delegate = navigationDelegate
-
-        // Initialize text-to-speech; note that this is NOT automatic.
-        // You must set a spokenInstructionObserver.
-        // Fortunately, this is pretty easy with the provided class
-        // backed by AVSpeechSynthesizer.
-        // You can customize the instance it further as needed,
-        // or replace with your own.
-        ferrostarCore.spokenInstructionObserver = spokenInstructionObserver
     }
 
     func getRoutes() async throws -> [Route] {

--- a/apple/DemoApp/Demo/DemoApp.swift
+++ b/apple/DemoApp/Demo/DemoApp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // This AppDelegate setup is an easy way to share your environment with CarPlay
 class DemoAppDelegate: NSObject, UIApplicationDelegate {
-    let appEnvironment = AppEnvironment()
+    let appEnvironment = try! AppEnvironment()
 }
 
 @main

--- a/apple/DemoApp/Demo/DemoNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoNavigationView.swift
@@ -32,8 +32,8 @@ struct DemoNavigationView: View {
                 styleURL: AppDefaults.mapStyleURL,
                 camera: $appEnvironment.camera.camera,
                 navigationState: appEnvironment.ferrostarCore.state,
-                isMuted: appEnvironment.spokenInstructionObserver.isMuted,
-                onTapMute: appEnvironment.spokenInstructionObserver.toggleMute,
+                isMuted: appEnvironment.ferrostarCore.spokenInstructionObserver.isMuted,
+                onTapMute: appEnvironment.ferrostarCore.spokenInstructionObserver.toggleMute,
                 onTapExit: { stopNavigation() },
                 makeMapContent: {
                     let source = ShapeSource(identifier: "userLocation") {

--- a/apple/Sources/FerrostarCore/FerrostarCore.swift
+++ b/apple/Sources/FerrostarCore/FerrostarCore.swift
@@ -72,7 +72,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
     public weak var delegate: FerrostarCoreDelegate?
 
     /// The spoken instruction observer; responsible for text-to-speech announcements.
-    public var spokenInstructionObserver: SpokenInstructionObserver?
+    public let spokenInstructionObserver: SpokenInstructionObserver
 
     /// The minimum time to wait before initiating another route recalculation.
     ///
@@ -124,13 +124,16 @@ public protocol FerrostarCoreDelegate: AnyObject {
         locationProvider: LocationProviding,
         navigationControllerConfig: SwiftNavigationControllerConfig,
         networkSession: URLRequestLoading,
-        annotation: (any AnnotationPublishing)? = nil
+        annotation: (any AnnotationPublishing)? = nil,
+        spokenInstructionObserver: SpokenInstructionObserver =
+            .initAVSpeechSynthesizer() // Set up the a standard Apple AV Speech Synth.
     ) {
         self.routeProvider = routeProvider
         self.locationProvider = locationProvider
         config = navigationControllerConfig
         self.networkSession = networkSession
         self.annotation = annotation
+        self.spokenInstructionObserver = spokenInstructionObserver
 
         super.init()
 
@@ -310,7 +313,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
         state = nil
         queuedUtteranceIDs.removeAll()
         locationProvider.stopUpdating()
-        spokenInstructionObserver?.stopAndClearQueue()
+        spokenInstructionObserver.stopAndClearQueue()
         lastRecalculationLocation = nil
     }
 
@@ -393,7 +396,7 @@ public protocol FerrostarCoreDelegate: AnyObject {
                     // we'll probably remove the need for this eventually
                     // by making FerrostarCore its own actor
                     DispatchQueue.global(qos: .default).async {
-                        self.spokenInstructionObserver?.spokenInstructionTriggered(spokenInstruction)
+                        self.spokenInstructionObserver.spokenInstructionTriggered(spokenInstruction)
                     }
                 }
             default:


### PR DESCRIPTION
    - Also Initialize FerrostarCore via an extension to encapsulate details
    - Use `try!` at the last possible moment and let the intervening items `throw`.
    - use an extension to create the `SimulatedLocationProvider`
    - Depends upon #541
