### PR TITLE
AppEnvironment is a global variable.

### DIFF
--- a/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
+++ b/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
@@ -11,9 +11,6 @@ private extension Logger {
 }
 
 class CarPlaySceneDelegate: UIResponder, UIWindowSceneDelegate, CPTemplateApplicationSceneDelegate {
-    // Get the AppDelegate associated with the SwiftUI App/@main as the type you defined it as.
-    @UIApplicationDelegateAdaptor(DemoAppDelegate.self) var appDelegate
-
     private weak var ferrostarCore: FerrostarCore?
     private var carPlayViewController: UIViewController?
 
@@ -55,14 +52,14 @@ class CarPlaySceneDelegate: UIResponder, UIWindowSceneDelegate, CPTemplateApplic
         guard carPlayManager == nil else { return }
 
         // IMPORTANT: This is your app's shared FerrostarCore
-        ferrostarCore = appDelegate.appEnvironment.ferrostarCore
+        ferrostarCore = appEnvironment.ferrostarCore
 
         let view = CarPlayNavigationView(
             ferrostarCore: ferrostarCore!,
             styleURL: AppDefaults.mapStyleURL,
             camera: Binding(
-                get: { self.appDelegate.appEnvironment.camera.camera },
-                set: { self.appDelegate.appEnvironment.camera.camera = $0 }
+                get: { appEnvironment.camera.camera },
+                set: { appEnvironment.camera.camera = $0 }
             )
         )
 
@@ -71,8 +68,8 @@ class CarPlaySceneDelegate: UIResponder, UIWindowSceneDelegate, CPTemplateApplic
         carPlayManager = FerrostarCarPlayManager(
             ferrostarCore!,
             camera: Binding(
-                get: { self.appDelegate.appEnvironment.camera.camera },
-                set: { self.appDelegate.appEnvironment.camera.camera = $0 }
+                get: { appEnvironment.camera.camera },
+                set: { appEnvironment.camera.camera = $0 }
             ),
             distanceUnits: .default
             // TODO: We may need to hold the view or viewController here, but it seems

--- a/apple/DemoApp/Demo/DemoApp.swift
+++ b/apple/DemoApp/Demo/DemoApp.swift
@@ -1,19 +1,14 @@
 import SwiftUI
 
-// This AppDelegate setup is an easy way to share your environment with CarPlay
-class DemoAppDelegate: NSObject, UIApplicationDelegate {
-    let appEnvironment = try! AppEnvironment()
-}
+let appEnvironment = try! AppEnvironment()
 
 @main
 struct DemoApp: App {
-    @UIApplicationDelegateAdaptor(DemoAppDelegate.self) private var appDelegate: DemoAppDelegate
-
     var body: some Scene {
         WindowGroup {
             DemoNavigationView()
-                .environmentObject(appDelegate.appEnvironment)
-                .environmentObject(appDelegate.appEnvironment.ferrostarCore)
+                .environmentObject(appEnvironment)
+                .environmentObject(appEnvironment.ferrostarCore)
         }
     }
 }


### PR DESCRIPTION
- The old code would instantiate the `DemoAppDelegate` twice via `UIApplicationDelegateAdaptor`. This would make starting up the app when the CarPlay window was open behave differently based upon the order of launching.
- The documentation for `UIApplicationDelegateAdaptor` indicates that the application delegate will be in the `Environment` if it conforms to `ObservableObject`. This attempt showed it was true in the application, but not in CarPlay.
- Then an attempt was made to put the `AppEnvironment` into SwiftUI's `Environment` to be read on the CarPlay side of things. The App's `CarPlaySceneDelegate` could not read the `Environment`, since it is not SwiftUI. An attempt was made to have a SwiftUI view in the application that hosted a Ferrostar `CarPlayNavigationView`, so that the app's `View` could access the `Environment` and pass it to the library `View`. However this `Environment` did not have the `AppEnvironment` either.
- The [most promising idea](https://stackoverflow.com/a/57089965), which a few attempts were close, but not close enough was to have the `application(_:configurationForConnecting:options:)` pass the `AppEnvironment` into the `UISceneSession.userInfo`. This would work but unfortunately, `CarPlaySceneDelegate` was still instantiated twice. Basically the code would configure the `UIScene` much like the `UISceneManifest` in the Info.plist would. If I removed data from the `UISceneManifest` in the Info.plist, hoping it would not instantiate twice, the runtime would crash because the information wasn't there. I'm sure this is "the way" to pass data from `UIApplication` to `UIScene`, but it isn't working out yet. Just a matter of getting that configuration right. [Interesting information about SwiftUI lifecycle and CarPlay](https://github.com/vanities/carplay-swiftui).
- So this is a quick fix so that launch of CarPlay works better and it is connected to CarPlay from the get go.

Fixes #544 and a better fix should be addressed in the future.