### PR TITLE
Use let for these SwiftUI view properties

### DIFF
--- a/apple/Sources/FerrostarMapLibreUI/Views/DynamicallyOrientingNavigationView.swift
+++ b/apple/Sources/FerrostarMapLibreUI/Views/DynamicallyOrientingNavigationView.swift
@@ -19,7 +19,7 @@ public struct DynamicallyOrientingNavigationView: View,
     let navigationCamera: MapViewCamera
     public var mapInsets: NavigationMapViewContentInsetBundle
 
-    private var navigationState: NavigationState?
+    private let navigationState: NavigationState?
     private let userLayers: [StyleLayerDefinition]
 
     public var speedLimit: Measurement<UnitSpeed>?

--- a/apple/Sources/FerrostarMapLibreUI/Views/LandscapeNavigationView.swift
+++ b/apple/Sources/FerrostarMapLibreUI/Views/LandscapeNavigationView.swift
@@ -18,7 +18,7 @@ public struct LandscapeNavigationView: View,
     let navigationCamera: MapViewCamera
     public var mapInsets: NavigationMapViewContentInsetBundle
 
-    private var navigationState: NavigationState?
+    private let navigationState: NavigationState?
     private let userLayers: [StyleLayerDefinition]
 
     public var speedLimit: Measurement<UnitSpeed>?

--- a/apple/Sources/FerrostarMapLibreUI/Views/NavigationMapView.swift
+++ b/apple/Sources/FerrostarMapLibreUI/Views/NavigationMapView.swift
@@ -21,7 +21,7 @@ public struct NavigationMapView: View {
 
     // TODO: Configurable camera and user "puck" rotation modes
 
-    private var navigationState: NavigationState?
+    private let navigationState: NavigationState?
 
     @State private var locationManager = StaticLocationManager(initialLocation: CLLocation())
 

--- a/apple/Sources/FerrostarMapLibreUI/Views/PortraitNavigationView.swift
+++ b/apple/Sources/FerrostarMapLibreUI/Views/PortraitNavigationView.swift
@@ -17,7 +17,7 @@ public struct PortraitNavigationView: View,
     let navigationCamera: MapViewCamera
     public var mapInsets: NavigationMapViewContentInsetBundle
 
-    private var navigationState: NavigationState?
+    private let navigationState: NavigationState?
     private let userLayers: [StyleLayerDefinition]
 
     public var speedLimit: Measurement<UnitSpeed>?


### PR DESCRIPTION
- They do not change for the lifecycle of the View, and if they do, SwiftUI will re-create the View.
- Trying to track down unusual state stickiness with some other branches.