### PR TITLE
Use CPMapSession.trip instead of holding another reference

### DIFF
--- a/apple/Sources/FerrostarCarPlayUI/Templates/NavigationTemplateHost.swift
+++ b/apple/Sources/FerrostarCarPlayUI/Templates/NavigationTemplateHost.swift
@@ -8,7 +8,6 @@ class NavigatingTemplateHost {
     private let formatters: FormatterCollection
     private let units: MKDistanceFormatter.Units
 
-    private var currentTrip: CPTrip?
     private var currentSession: CPNavigationSession?
 
     init(
@@ -51,10 +50,7 @@ class NavigatingTemplateHost {
             durationFormatter: formatters.durationFormatter
         )
 
-        let currentSession = mapTemplate.startNavigationSession(for: currentTrip)
-
-        self.currentTrip = currentTrip
-        self.currentSession = currentSession
+        currentSession = mapTemplate.startNavigationSession(for: currentTrip)
     }
 
     func update(navigationState: NavigationState) {
@@ -78,17 +74,15 @@ class NavigatingTemplateHost {
     func cancelTrip() {
         currentSession?.cancelTrip()
         currentSession = nil
-        currentTrip = nil
     }
 
     func completeTrip() {
         currentSession?.finishTrip()
         currentSession = nil
-        currentTrip = nil
     }
 
     private func updateArrival(_ progress: TripProgress?) {
-        guard let currentTrip, let progress else {
+        guard let currentSession, let progress else {
             // TODO: Remove Progress?
             return
         }
@@ -99,16 +93,16 @@ class NavigatingTemplateHost {
             locale: .current
         )
 
-        mapTemplate.updateEstimates(estimates, for: currentTrip)
+        mapTemplate.updateEstimates(estimates, for: currentSession.trip)
 
-        if let currentManeuer = currentSession?.upcomingManeuvers.first {
+        if let currentManeuer = currentSession.upcomingManeuvers.first {
             let estimates = CPTravelEstimates.fromFerrostarForStep(
                 progress: progress,
                 units: units,
                 locale: .current
             )
 
-            currentSession?.updateEstimates(estimates, for: currentManeuer)
+            currentSession.updateEstimates(estimates, for: currentManeuer)
         }
     }
 }


### PR DESCRIPTION
- This will prevent the possibilty of a mismatch.
- CarPlay is in the "navigating state" if there is a current `CPNavigationSession`.