### PR TITLE
CarPlayNavigationView does not have FerrostarCore state

### DIFF
--- a/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
+++ b/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
@@ -50,7 +50,7 @@ class CarPlaySceneDelegate: UIResponder, UIWindowSceneDelegate, CPTemplateApplic
     func setupCarPlay(on window: UIWindow) {
         guard carPlayManager == nil else { return }
 
-        let view = CarPlayNavigationView(
+        let view = DemoCarPlayNavigationView(
             ferrostarCore: appEnvironment.ferrostarCore,
             styleURL: AppDefaults.mapStyleURL,
             camera: Binding(

--- a/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
+++ b/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
@@ -11,7 +11,6 @@ private extension Logger {
 }
 
 class CarPlaySceneDelegate: UIResponder, UIWindowSceneDelegate, CPTemplateApplicationSceneDelegate {
-    private weak var ferrostarCore: FerrostarCore?
     private var carPlayViewController: UIViewController?
 
     private var carPlayManager: FerrostarCarPlayManager?
@@ -51,11 +50,8 @@ class CarPlaySceneDelegate: UIResponder, UIWindowSceneDelegate, CPTemplateApplic
     func setupCarPlay(on window: UIWindow) {
         guard carPlayManager == nil else { return }
 
-        // IMPORTANT: This is your app's shared FerrostarCore
-        ferrostarCore = appEnvironment.ferrostarCore
-
         let view = CarPlayNavigationView(
-            ferrostarCore: ferrostarCore!,
+            ferrostarCore: appEnvironment.ferrostarCore,
             styleURL: AppDefaults.mapStyleURL,
             camera: Binding(
                 get: { appEnvironment.camera.camera },
@@ -66,7 +62,7 @@ class CarPlaySceneDelegate: UIResponder, UIWindowSceneDelegate, CPTemplateApplic
         carPlayViewController = UIHostingController(rootView: view)
 
         carPlayManager = FerrostarCarPlayManager(
-            ferrostarCore!,
+            appEnvironment.ferrostarCore,
             camera: Binding(
                 get: { appEnvironment.camera.camera },
                 set: { appEnvironment.camera.camera = $0 }

--- a/apple/DemoApp/Demo/DemoCarPlayNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoCarPlayNavigationView.swift
@@ -1,0 +1,14 @@
+import FerrostarCarPlayUI
+import FerrostarCore
+import MapLibreSwiftUI
+import SwiftUI
+
+struct DemoCarPlayNavigationView: View {
+    @StateObject var ferrostarCore: FerrostarCore
+    let styleURL: URL
+    @Binding public var camera: MapViewCamera
+
+    var body: some View {
+        CarPlayNavigationView(navigationState: ferrostarCore.state, styleURL: styleURL, camera: $camera)
+    }
+}

--- a/apple/DemoApp/Ferrostar Demo.xcodeproj/project.pbxproj
+++ b/apple/DemoApp/Ferrostar Demo.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		E90D97912B8AF507005E43F8 /* NavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90D97902B8AF507005E43F8 /* NavigationDelegate.swift */; };
 		E9505FCA2AD449B30016BF0A /* FerrostarCore in Frameworks */ = {isa = PBXBuildFile; productRef = E9505FC92AD449B30016BF0A /* FerrostarCore */; };
 		E9505FCC2AD449B30016BF0A /* FerrostarMapLibreUI in Frameworks */ = {isa = PBXBuildFile; productRef = E9505FCB2AD449B30016BF0A /* FerrostarMapLibreUI */; };
+		FE0AFFBC2DDD23D500CF4DB8 /* DemoCarPlayNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0AFFBB2DDD23D500CF4DB8 /* DemoCarPlayNavigationView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +43,7 @@
 		E9505FB72AD449700016BF0A /* Ferrostar Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Ferrostar Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9DD18E42B18EE7A00CAF29A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		E9DD18E52B18F4BD00CAF29A /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		FE0AFFBB2DDD23D500CF4DB8 /* DemoCarPlayNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoCarPlayNavigationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,6 +72,7 @@
 				1611A5542B2E6E98006B131D /* Preview Content */,
 				1663679B2B2F6F79008BFF1F /* Helpers */,
 				1621C26C2CE2B42100034BA3 /* CarPlaySceneDelegate.swift */,
+				FE0AFFBB2DDD23D500CF4DB8 /* DemoCarPlayNavigationView.swift */,
 				16C8F1722CEEBE530014DE3D /* AppEnvironment.swift */,
 				E90D97902B8AF507005E43F8 /* NavigationDelegate.swift */,
 				1611A5562B2E6E98006B131D /* DemoNavigationView.swift */,
@@ -213,6 +216,7 @@
 				1663679F2B2F8FB3008BFF1F /* MockLocationData.swift in Sources */,
 				16C8F1732CEEBE570014DE3D /* AppEnvironment.swift in Sources */,
 				1611A55D2B2E6E98006B131D /* DemoApp.swift in Sources */,
+				FE0AFFBC2DDD23D500CF4DB8 /* DemoCarPlayNavigationView.swift in Sources */,
 				E90D97912B8AF507005E43F8 /* NavigationDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apple/Sources/FerrostarCarPlayUI/UI/CarPlayNavigationView.swift
+++ b/apple/Sources/FerrostarCarPlayUI/UI/CarPlayNavigationView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 public struct CarPlayNavigationView: View,
     SpeedLimitViewHost, NavigationViewConfigurable
 {
-    @StateObject var ferrostarCore: FerrostarCore
+    private let navigationState: NavigationState?
     @Environment(\.navigationFormatterCollection) var formatterCollection: any FormatterCollection
 
     let styleURL: URL
@@ -30,13 +30,13 @@ public struct CarPlayNavigationView: View,
     public var currentRoadNameView: ((NavigationState?) -> AnyView)?
 
     public init(
-        ferrostarCore: FerrostarCore,
+        navigationState: NavigationState?,
         styleURL: URL,
         camera: Binding<MapViewCamera>,
         minimumSafeAreaInsets: EdgeInsets = EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16),
         @MapViewContentBuilder makeMapContent: () -> [StyleLayerDefinition] = { [] }
     ) {
-        _ferrostarCore = StateObject(wrappedValue: ferrostarCore)
+        self.navigationState = navigationState
         self.styleURL = styleURL
         _camera = camera
         mapInsets = NavigationMapViewContentInsetBundle()
@@ -50,7 +50,7 @@ public struct CarPlayNavigationView: View,
                 NavigationMapView(
                     styleURL: styleURL,
                     camera: $camera,
-                    navigationState: ferrostarCore.state,
+                    navigationState: navigationState,
                     activity: .carplay,
                     onStyleLoaded: { _ in
                         // camera = .automotiveNavigation(zoom: 17.0)


### PR DESCRIPTION
- Match the behavior of library clients of `DynamicallyOrientingNavigationView`. The state is in the app, not in the library.
- Depends upon #559, stacked diffs in GitHub are rough.
