### PR TITLE
Create CPManeuver via an extension on VisualInstruction.

### DIFF
--- a/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
+++ b/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
@@ -3,15 +3,8 @@ import FerrostarCore
 import FerrostarCoreFFI
 import FerrostarSwiftUI
 
-extension CPManeuver {
-    static func fromFerrostar(_ instruction: VisualInstruction?,
-                              stepDuration: TimeInterval,
-                              stepDistance: Measurement<UnitLength>) -> CPManeuver?
-    {
-        guard let instruction else {
-            return nil
-        }
-
+extension VisualInstruction {
+    func maneuver(stepDuration: TimeInterval, stepDistance: Measurement<UnitLength>) -> CPManeuver {
         let maneuver = CPManeuver()
 
         // CarPlay take the "initial" estimates and internally tracks the reduction.
@@ -29,14 +22,14 @@ extension CPManeuver {
         // The instructions. CPManeuver lists them from
         // highest (idx-0) to lowest priority.
         let instructions = [
-            instruction.primaryContent.text,
-            instruction.secondaryContent?.text,
+            primaryContent.text,
+            secondaryContent?.text,
         ]
         maneuver.instructionVariants = instructions.compactMap { $0 }
 
         // Display a maneuver image if one could be calculated.
-        if let maneuverType = instruction.primaryContent.maneuverType {
-            let maneuverModifier = instruction.primaryContent.maneuverModifier
+        if let maneuverType = primaryContent.maneuverType {
+            let maneuverModifier = primaryContent.maneuverModifier
             let maneuverImage = ManeuverUIImage(maneuverType: maneuverType, maneuverModifier: maneuverModifier)
             maneuver.symbolImage = maneuverImage.uiImage
         }

--- a/apple/Sources/FerrostarCarPlayUI/Templates/NavigationTemplateHost.swift
+++ b/apple/Sources/FerrostarCarPlayUI/Templates/NavigationTemplateHost.swift
@@ -60,15 +60,10 @@ class NavigatingTemplateHost {
     func update(_ instruction: VisualInstruction, currentStep: RouteStep) {
         let stepDistance = CarPlayMeasurementLength(units: units, distance: currentStep.distance)
 
-        let maneuvers = [
-            CPManeuver.fromFerrostar(
-                instruction,
-                stepDuration: currentStep.duration,
-                stepDistance: stepDistance.rounded()
-            ),
-        ].compactMap { $0 }
-
-        currentSession?.upcomingManeuvers = maneuvers
+        currentSession?.upcomingManeuvers = [instruction.maneuver(
+            stepDuration: currentStep.duration,
+            stepDistance: stepDistance.rounded()
+        )]
     }
 
     func cancelTrip() {


### PR DESCRIPTION
Two things: `VisualInstruction` cannot be `Optional` this way. Additionally, this always returns a non-`Optional` `CPManeuver`. Cleaning this up to learn when sometimes the maneuver does not show in the CarPlay UI. This change proves it is not because the `CPManeuver` is `nil`.