### PR TITLE
run latest swiftformat

### DIFF
--- a/apple/Tests/FerrostarCarPlayUITests/CarPlaysModels/CPTravelEstimateTests.swift
+++ b/apple/Tests/FerrostarCarPlayUITests/CarPlaysModels/CPTravelEstimateTests.swift
@@ -7,7 +7,7 @@ import Testing
 
 struct CPTravelEstimatesTests {
     @Test("Initialize TripProgress for Trip")
-    func testFromTrip() async throws {
+    func fromTrip() async throws {
         let tripProgress = TripProgress(
             distanceToNextManeuver: 11.1,
             distanceRemaining: 22.2,
@@ -25,7 +25,7 @@ struct CPTravelEstimatesTests {
     }
 
     @Test("Initialize TripProgress for Step")
-    func testFromStep() async throws {
+    func fromStep() async throws {
         let tripProgress = TripProgress(
             distanceToNextManeuver: 11.1,
             distanceRemaining: 22.2,

--- a/apple/Tests/FerrostarCarPlayUITests/CarPlaysModels/CPTripTests.swift
+++ b/apple/Tests/FerrostarCarPlayUITests/CarPlaysModels/CPTripTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 struct CPTripTests {
     @Test("CPTrip creation")
-    func testCPTripCreation() async throws {
+    func cPTripCreation() async throws {
         let route = Route(
             geometry: [],
             bbox: .init(sw: .init(lat: 0, lng: 0), ne: .init(lat: 1, lng: 1)),

--- a/apple/Tests/FerrostarCarPlayUITests/Measurement/TestCarPlayMeasurementLength.swift
+++ b/apple/Tests/FerrostarCarPlayUITests/Measurement/TestCarPlayMeasurementLength.swift
@@ -15,7 +15,7 @@ struct TestCarPlayMeasurementLength {
             (47.6, 50.0),
         ]
     )
-    func testRoundingUnder50(testCase: (input: Double, expected: Double)) throws {
+    func roundingUnder50(testCase: (input: Double, expected: Double)) throws {
         let measurement = CarPlayMeasurementLength(
             units: .imperial,
             distance: testCase.input * 0.3048 // Convert feet to meters
@@ -34,7 +34,7 @@ struct TestCarPlayMeasurementLength {
             (95.6, 100.0),
         ]
     )
-    func testRoundingBetween50And100(testCase: (input: Double, expected: Double)) throws {
+    func roundingBetween50And100(testCase: (input: Double, expected: Double)) throws {
         let measurement = CarPlayMeasurementLength(
             units: .imperial,
             distance: testCase.input * 0.3048
@@ -53,7 +53,7 @@ struct TestCarPlayMeasurementLength {
             (476.0, 500.0),
         ]
     )
-    func testRoundingBetween100And500(testCase: (input: Double, expected: Double)) throws {
+    func roundingBetween100And500(testCase: (input: Double, expected: Double)) throws {
         let measurement = CarPlayMeasurementLength(
             units: .imperial,
             distance: testCase.input * 0.3048
@@ -71,7 +71,7 @@ struct TestCarPlayMeasurementLength {
             (751.0, 800.0),
         ]
     )
-    func testRoundingAbove500(testCase: (input: Double, expected: Double)) throws {
+    func roundingAbove500(testCase: (input: Double, expected: Double)) throws {
         let measurement = CarPlayMeasurementLength(
             units: .imperial,
             distance: testCase.input * 0.3048
@@ -92,7 +92,7 @@ struct TestCarPlayMeasurementLength {
             (9.95, 10.0),
         ]
     )
-    func testRoundingKilometersUnder10(testCase: (input: Double, expected: Double)) throws {
+    func roundingKilometersUnder10(testCase: (input: Double, expected: Double)) throws {
         let measurement = CarPlayMeasurementLength(
             units: .metric,
             distance: testCase.input * 1000 // Convert km to meters
@@ -111,7 +111,7 @@ struct TestCarPlayMeasurementLength {
             (19.7, 20.0),
         ]
     )
-    func testRoundingKilometersAbove10(testCase: (input: Double, expected: Double)) throws {
+    func roundingKilometersAbove10(testCase: (input: Double, expected: Double)) throws {
         let measurement = CarPlayMeasurementLength(
             units: .metric,
             distance: testCase.input * 1000
@@ -130,7 +130,7 @@ struct TestCarPlayMeasurementLength {
             (9.95, 9.9),
         ]
     )
-    func testRoundingMilesUnder10(testCase: (input: Double, expected: Double)) throws {
+    func roundingMilesUnder10(testCase: (input: Double, expected: Double)) throws {
         let measurement = CarPlayMeasurementLength(
             units: .imperial,
             distance: testCase.input * 1609.34 // Convert miles to meters
@@ -149,7 +149,7 @@ struct TestCarPlayMeasurementLength {
             (19.7, 20.0),
         ]
     )
-    func testRoundingMilesAbove10(testCase: (input: Double, expected: Double)) throws {
+    func roundingMilesAbove10(testCase: (input: Double, expected: Double)) throws {
         let measurement = CarPlayMeasurementLength(
             units: .imperial,
             distance: testCase.input * 1609.34

--- a/apple/Tests/FerrostarCarPlayUITests/Measurement/TestMKDistanceFormatterUnits.swift
+++ b/apple/Tests/FerrostarCarPlayUITests/Measurement/TestMKDistanceFormatterUnits.swift
@@ -9,7 +9,7 @@ struct TestMKDistanceFormatterUnits {
         Locale(identifier: "de_DE"),
         Locale(identifier: "ja_JP"),
     ])
-    func testMetricUnits(locale: Locale) throws {
+    func metricUnits(locale: Locale) throws {
         let (shortUnit, longUnit) = MKDistanceFormatter.Units.metric.getShortAndLong(
             for: locale
         )
@@ -21,7 +21,7 @@ struct TestMKDistanceFormatterUnits {
         Locale(identifier: "en_US"),
         Locale(identifier: "en_CA"),
     ])
-    func testImperialUnits(locale: Locale) throws {
+    func imperialUnits(locale: Locale) throws {
         let (shortUnit, longUnit) = MKDistanceFormatter.Units.imperial.getShortAndLong(
             for: locale
         )
@@ -47,7 +47,7 @@ struct TestMKDistanceFormatterUnits {
         Locale(identifier: "de_DE"),
         Locale(identifier: "ja_JP"),
     ])
-    func testMetricThreshold(locale: Locale) throws {
+    func metricThreshold(locale: Locale) throws {
         #expect(MKDistanceFormatter.Units.metric.thresholdForLargeUnit(for: locale) == 1000)
     }
 
@@ -55,14 +55,14 @@ struct TestMKDistanceFormatterUnits {
         Locale(identifier: "en_US"),
         Locale(identifier: "en_CA"),
     ])
-    func testImperialUnitsThreshold(locale: Locale) throws {
+    func imperialUnitsThreshold(locale: Locale) throws {
         #expect(MKDistanceFormatter.Units.imperial.thresholdForLargeUnit(for: locale) == 289)
     }
 
     @Test("Test imperial UK threshold", arguments: [
         Locale(identifier: "en_GB"),
     ])
-    func testImperialUKThreshold(locale _: Locale) throws {
+    func imperialUKThreshold(locale _: Locale) throws {
         #expect(
             MKDistanceFormatter.Units.imperialWithYards.thresholdForLargeUnit(for: .current) == 300
         )


### PR DESCRIPTION
- Use SwiftFormat 0.56.1
- It changes the test names, probably due to https://github.com/nicklockwood/SwiftFormat/pull/1979
- Fixes #570