### PR TITLE
Associate VisualInstruction with CPManeuver

### DIFF
--- a/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
+++ b/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
@@ -3,6 +3,30 @@ import FerrostarCore
 import FerrostarCoreFFI
 import FerrostarSwiftUI
 
+private let InstructionKey = "com.stadiamaps.ferrostar.instruction"
+
+extension CPManeuver {
+    private var userDictionary: [String: Any]? {
+        get {
+            userInfo as? [String: Any] ?? [:]
+        }
+        set {
+            userInfo = newValue
+        }
+    }
+
+    public var visualInstruction: VisualInstruction? {
+        get {
+            userDictionary?[InstructionKey] as? VisualInstruction
+        }
+        set {
+            var info = userDictionary ?? [:]
+            info[InstructionKey] = newValue
+            userDictionary = info
+        }
+    }
+}
+
 extension VisualInstruction {
     func maneuver(stepDuration: TimeInterval, stepDistance: Measurement<UnitLength>) -> CPManeuver {
         let maneuver = CPManeuver()
@@ -33,6 +57,8 @@ extension VisualInstruction {
             let maneuverImage = ManeuverUIImage(maneuverType: maneuverType, maneuverModifier: maneuverModifier)
             maneuver.symbolImage = maneuverImage.uiImage
         }
+
+        maneuver.visualInstruction = self
 
         return maneuver
     }

--- a/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
+++ b/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
@@ -6,33 +6,28 @@ import FerrostarSwiftUI
 private let InstructionKey = "com.stadiamaps.ferrostar.instruction"
 
 extension CPManeuver {
-    private var userDictionary: [String: Any]? {
-        get {
-            userInfo as? [String: Any] ?? [:]
-        }
-        set {
-            userInfo = newValue
-        }
+    convenience init(
+        initialTravelEstimates: CPTravelEstimates,
+        instructionVariants: [String],
+        symbolImage _: UIImage?,
+        visualInstruction: VisualInstruction
+    ) {
+        self.init()
+        self.initialTravelEstimates = initialTravelEstimates
+        self.instructionVariants = instructionVariants
+        userInfo = [InstructionKey: visualInstruction]
     }
 
     public var visualInstruction: VisualInstruction? {
-        get {
-            userDictionary?[InstructionKey] as? VisualInstruction
-        }
-        set {
-            var info = userDictionary ?? [:]
-            info[InstructionKey] = newValue
-            userDictionary = info
-        }
+        guard let info = userInfo as? [String: Any] else { return nil }
+        return info[InstructionKey] as? VisualInstruction
     }
 }
 
 extension VisualInstruction {
     func maneuver(stepDuration: TimeInterval, stepDistance: Measurement<UnitLength>) -> CPManeuver {
-        let maneuver = CPManeuver()
-
         // CarPlay take the "initial" estimates and internally tracks the reduction.
-        maneuver.initialTravelEstimates =
+        let initialTravelEstimates =
             if #available(iOS 17.4, *) {
                 CPTravelEstimates(
                     distanceRemaining: stepDistance,
@@ -49,17 +44,20 @@ extension VisualInstruction {
             primaryContent.text,
             secondaryContent?.text,
         ]
-        maneuver.instructionVariants = instructions.compactMap { $0 }
 
         // Display a maneuver image if one could be calculated.
+        var symbolImage: UIImage?
         if let maneuverType = primaryContent.maneuverType {
             let maneuverModifier = primaryContent.maneuverModifier
             let maneuverImage = ManeuverUIImage(maneuverType: maneuverType, maneuverModifier: maneuverModifier)
-            maneuver.symbolImage = maneuverImage.uiImage
+            symbolImage = maneuverImage.uiImage
         }
 
-        maneuver.visualInstruction = self
-
-        return maneuver
+        return CPManeuver(
+            initialTravelEstimates: initialTravelEstimates,
+            instructionVariants: instructions.compactMap { $0 },
+            symbolImage: symbolImage,
+            visualInstruction: self
+        )
     }
 }

--- a/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
+++ b/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPManeuver.swift
@@ -9,12 +9,13 @@ extension CPManeuver {
     convenience init(
         initialTravelEstimates: CPTravelEstimates,
         instructionVariants: [String],
-        symbolImage _: UIImage?,
+        symbolImage: UIImage?,
         visualInstruction: VisualInstruction
     ) {
         self.init()
         self.initialTravelEstimates = initialTravelEstimates
         self.instructionVariants = instructionVariants
+        self.symbolImage = symbolImage
         userInfo = [InstructionKey: visualInstruction]
     }
 


### PR DESCRIPTION
- This will allow future work to see if the current `VisualInstruction` was made to create a `CPManeuver`.
- It uses `CPManeuver.userInfo` to store this data.