### PR TITLE
iOS: Allow CPTrip to be created with origin / destination

### DIFF
--- a/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPTrip.swift
+++ b/apple/Sources/FerrostarCarPlayUI/CarPlayModels/CPTrip.swift
@@ -25,6 +25,22 @@ extension CPRouteChoice {
     }
 }
 
+private extension [Waypoint] {
+    func originDestination() throws -> (origin: MKMapItem, destination: MKMapItem) {
+        guard let originWaypoint = first, let destinationWaypoint = last else {
+            throw FerrostarCarPlayError.invalidTrip
+        }
+
+        // TODO: We could improve this with an address dictionary/CPPostalAddress if we enhanced
+        //       the optional metadata associated to a ferrostar waypoint. Especially common for
+        //       the origin and destination, less so for intermediate.
+        let origin = MKMapItem(placemark: MKPlacemark(coordinate: originWaypoint.coordinate.clLocationCoordinate2D))
+        let destination =
+            MKMapItem(placemark: MKPlacemark(coordinate: destinationWaypoint.coordinate.clLocationCoordinate2D))
+        return (origin, destination)
+    }
+}
+
 extension CPTrip {
     /// Create a new CarPlay Trip definition from the routes and waypoints supplied to/by
     /// Ferrostar. This object is used to outline the various route option metadata and the associated
@@ -40,20 +56,26 @@ extension CPTrip {
         routes: [Route],
         waypoints: [Waypoint],
         distanceFormatter: Formatter,
-        durationFormatter _: DateComponentsFormatter
+        durationFormatter: DateComponentsFormatter
     ) throws -> CPTrip {
-        guard let originWaypoint = waypoints.first,
-              let destinationWaypoint = waypoints.last
-        else {
-            throw FerrostarCarPlayError.invalidTrip
-        }
+        let (origin, destination) = try waypoints.originDestination()
 
-        // TODO: We could improve this with an address dictionary/CPPostalAddress if we enhanced
-        //       the optional metadata associated to a ferrostar waypoint. Especially common for
-        //       the origin and destination, less so for intermediate.
-        let origin = MKPlacemark(coordinate: originWaypoint.coordinate.clLocationCoordinate2D)
-        let destination = MKPlacemark(coordinate: destinationWaypoint.coordinate.clLocationCoordinate2D)
+        return fromFerrostar(
+            routes: routes,
+            origin: origin,
+            destination: destination,
+            distanceFormatter: distanceFormatter,
+            durationFormatter: durationFormatter
+        )
+    }
 
+    public static func fromFerrostar(
+        routes: [Route],
+        origin: MKMapItem,
+        destination: MKMapItem,
+        distanceFormatter: Formatter,
+        durationFormatter _: DateComponentsFormatter
+    ) -> CPTrip {
         let routeChoices: [CPRouteChoice] = routes.enumerated().map { index, route in
             let routeNumber = index + 1
             let distance = distanceFormatter.string(for: route.distance)
@@ -68,8 +90,8 @@ extension CPTrip {
         }
 
         return CPTrip(
-            origin: .init(placemark: origin),
-            destination: .init(placemark: destination),
+            origin: origin,
+            destination: destination,
             routeChoices: routeChoices
         )
     }


### PR DESCRIPTION
- This is because taking the Waypoints from the first Route may not be correct? It's confusing because I do not know how multiple routes in the response may or may not have differing origin/destinations. This way the app can decide what the origin/destination are of the CPTrip, which may be different than the multiple CPRouteChoices to use...