### PR TITLE
iOS: Add SwitchableLocationProvider to DemoApp

### DIFF
--- a/apple/DemoApp/Demo/DemoNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoNavigationView.swift
@@ -8,6 +8,17 @@ import MapLibreSwiftDSL
 import MapLibreSwiftUI
 import SwiftUI
 
+extension SwitchableLocationProvider.State {
+    @ViewBuilder var label: some View {
+        switch self {
+        case .simulated:
+            Label("Sim", systemImage: "location.slash.circle")
+        case .device:
+            Label("Device", systemImage: "location.circle")
+        }
+    }
+}
+
 struct DemoNavigationView: View {
     @EnvironmentObject private var appEnvironment: AppEnvironment
     @EnvironmentObject private var ferrostarCore: FerrostarCore
@@ -106,6 +117,12 @@ struct DemoNavigationView: View {
                                 Text("Enable Location Services")
                             }
                         }
+                        Button {
+                            appEnvironment.toggleLocationSimulation()
+                        } label: {
+                            appEnvironment.locationProvider.type.label
+                        }
+                        .buttonStyle(NavigationUIButtonStyle())
                     }
                 }
             )

--- a/apple/DemoApp/Demo/SwitchableLocationProvider.swift
+++ b/apple/DemoApp/Demo/SwitchableLocationProvider.swift
@@ -1,0 +1,83 @@
+import CoreLocation
+import FerrostarCore
+import FerrostarCoreFFI
+import Foundation
+
+@Observable final class SwitchableLocationProvider: LocationProviding {
+    enum State {
+        case simulated
+        case device
+    }
+
+    private let simulated: SimulatedLocationProvider
+    private let device = CoreLocationProvider(
+        activityType: .automotiveNavigation,
+        allowBackgroundLocationUpdates: false
+    )
+    var type: State
+
+    init(simulated: SimulatedLocationProvider, type: SwitchableLocationProvider.State) {
+        self.simulated = simulated
+        self.type = type
+    }
+
+    private var current: LocationProviding {
+        switch type {
+        case .simulated:
+            simulated
+        case .device:
+            device
+        }
+    }
+
+    var delegate: (any LocationManagingDelegate)? { get {
+        current.delegate
+    } set {
+        current.delegate = newValue
+    }
+    }
+
+    var authorizationStatus: CLAuthorizationStatus {
+        current.authorizationStatus
+    }
+
+    var lastLocation: FerrostarCoreFFI.UserLocation? {
+        current.lastLocation
+    }
+
+    var lastHeading: FerrostarCoreFFI.Heading? {
+        current.lastHeading
+    }
+
+    func startUpdating() {
+        current.startUpdating()
+    }
+
+    func stopUpdating() {
+        current.stopUpdating()
+    }
+
+    func use(route: Route) throws {
+        // This configures the simulator to the desired route.
+        // The ferrostarCore.startNavigation will still start the location
+        // provider/simulator.
+        simulated
+            .lastLocation = UserLocation(clCoordinateLocation2D: route.geometry.first!.clLocationCoordinate2D)
+        try simulated.setSimulatedRoute(route, resampleDistance: 5)
+    }
+
+    var locationServicesEnabled: Bool {
+        current.authorizationStatus == .authorizedAlways || current.authorizationStatus == .authorizedWhenInUse
+    }
+
+    func toggle() {
+        current.stopUpdating()
+        switch type {
+        case .simulated:
+            type = .device
+        case .device:
+            type = .simulated
+        }
+        current.startUpdating()
+    }
+}

--- a/apple/DemoApp/Ferrostar Demo.xcodeproj/project.pbxproj
+++ b/apple/DemoApp/Ferrostar Demo.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		E9505FCA2AD449B30016BF0A /* FerrostarCore in Frameworks */ = {isa = PBXBuildFile; productRef = E9505FC92AD449B30016BF0A /* FerrostarCore */; };
 		E9505FCC2AD449B30016BF0A /* FerrostarMapLibreUI in Frameworks */ = {isa = PBXBuildFile; productRef = E9505FCB2AD449B30016BF0A /* FerrostarMapLibreUI */; };
 		FE0AFFBC2DDD23D500CF4DB8 /* DemoCarPlayNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0AFFBB2DDD23D500CF4DB8 /* DemoCarPlayNavigationView.swift */; };
+		FE9242DB2E0B0D610012C533 /* SwitchableLocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9242DA2E0B0D610012C533 /* SwitchableLocationProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +45,7 @@
 		E9DD18E42B18EE7A00CAF29A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		E9DD18E52B18F4BD00CAF29A /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		FE0AFFBB2DDD23D500CF4DB8 /* DemoCarPlayNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoCarPlayNavigationView.swift; sourceTree = "<group>"; };
+		FE9242DA2E0B0D610012C533 /* SwitchableLocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchableLocationProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,6 +76,7 @@
 				1621C26C2CE2B42100034BA3 /* CarPlaySceneDelegate.swift */,
 				FE0AFFBB2DDD23D500CF4DB8 /* DemoCarPlayNavigationView.swift */,
 				16C8F1722CEEBE530014DE3D /* AppEnvironment.swift */,
+				FE9242DA2E0B0D610012C533 /* SwitchableLocationProvider.swift */,
 				E90D97902B8AF507005E43F8 /* NavigationDelegate.swift */,
 				1611A5562B2E6E98006B131D /* DemoNavigationView.swift */,
 				1611A5582B2E6E98006B131D /* DemoApp.swift */,
@@ -211,6 +214,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1611A55B2B2E6E98006B131D /* DemoNavigationView.swift in Sources */,
+				FE9242DB2E0B0D610012C533 /* SwitchableLocationProvider.swift in Sources */,
 				1621C26D2CE2B42700034BA3 /* CarPlaySceneDelegate.swift in Sources */,
 				1663679D2B2F6F85008BFF1F /* APIKeys.swift in Sources */,
 				1663679F2B2F8FB3008BFF1F /* MockLocationData.swift in Sources */,


### PR DESCRIPTION
Allows the location provider in the DemoApp to be switched from simulation to device on the fly. It demonstrates that this may not handle re-routing well, perhaps?