### PR TITLE
iOS: Make APIKeys Swift 6 compatible

### DIFF
--- a/apple/DemoApp/Demo/AppDefaults.swift
+++ b/apple/DemoApp/Demo/AppDefaults.swift
@@ -4,5 +4,5 @@ import Foundation
 enum AppDefaults {
     static let initialLocation = CLLocation(latitude: 37.332726, longitude: -122.031790)
     static let mapStyleURL =
-        URL(string: "https://tiles.stadiamaps.com/styles/outdoors.json?api_key=\(APIKeys.shared.stadiaMapsAPIKey)")!
+        URL(string: "https://tiles.stadiamaps.com/styles/outdoors.json?api_key=\(sharedAPIKeys.stadiaMapsAPIKey)")!
 }

--- a/apple/DemoApp/Demo/DemoModel.swift
+++ b/apple/DemoApp/Demo/DemoModel.swift
@@ -37,7 +37,7 @@ private extension FerrostarCore {
 
         try self.init(
             valhallaEndpointUrl: URL(
-                string: "https://api.stadiamaps.com/route/v1?api_key=\(APIKeys.shared.stadiaMapsAPIKey)"
+                string: "https://api.stadiamaps.com/route/v1?api_key=\(sharedAPIKeys.stadiaMapsAPIKey)"
             )!,
             profile: "bicycle",
             locationProvider: locationProvider,

--- a/apple/DemoApp/Demo/Helpers/APIKeys.swift
+++ b/apple/DemoApp/Demo/Helpers/APIKeys.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-class APIKeys {
-    static let shared = APIKeys()
+let sharedAPIKeys = APIKeys()
 
+struct APIKeys {
     let stadiaMapsAPIKey: String
 
     init() {


### PR DESCRIPTION
- Found this unrelated but valid issue while trying to build with Swift 6 to diagnose concurrency issues.
- Make it a global value instead of a global reference.