### PR TITLE
iOS: Mark FerrostarCoreFFI as @preconcurrency

### DIFF
--- a/apple/DemoApp/Demo/DemoAppState.swift
+++ b/apple/DemoApp/Demo/DemoAppState.swift
@@ -1,4 +1,5 @@
 import CoreLocation
+
 // Temporary measure until we transition the demo app to Swift 6.
 // See https://github.com/stadiamaps/ferrostar/issues/164#issuecomment-3037767025
 @preconcurrency import FerrostarCoreFFI

--- a/apple/DemoApp/Demo/DemoAppState.swift
+++ b/apple/DemoApp/Demo/DemoAppState.swift
@@ -1,4 +1,6 @@
 import CoreLocation
+// Temporary measure until we transition the demo app to Swift 6.
+// See https://github.com/stadiamaps/ferrostar/issues/164#issuecomment-3037767025
 @preconcurrency import FerrostarCoreFFI
 import Foundation
 

--- a/apple/DemoApp/Demo/DemoAppState.swift
+++ b/apple/DemoApp/Demo/DemoAppState.swift
@@ -1,5 +1,5 @@
 import CoreLocation
-import FerrostarCoreFFI
+@preconcurrency import FerrostarCoreFFI
 import Foundation
 
 enum DemoAppState: CustomStringConvertible {


### PR DESCRIPTION
This will then allow DemoAppState to be interpreted as Sendable, thus removing the warning from DemoError. 

Route in FerrorstarCore is non-Sendable at the moment.

```
/Users/bolsinga/Documents/code/git/ferrostar/apple/DemoApp/Demo/DemoError.swift:9:10: error: associated value 'invalidState' of 'Sendable'-conforming enum 'DemoError' has non-sendable type 'DemoAppState'
    case invalidState(DemoAppState)
         ^
/Users/bolsinga/Documents/code/git/ferrostar/apple/DemoApp/Demo/DemoAppState.swift:5:6: note: consider making enum 'DemoAppState' conform to the 'Sendable' protocol
enum DemoAppState: CustomStringConvertible {
     ^
                                          , Sendable
```