### PR TITLE
iOS: Update DemoApp CarPlay Support

### DIFF
--- a/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
+++ b/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
@@ -10,16 +10,16 @@ private extension Logger {
     static let carPlay = Logger(subsystem: "ferrostar", category: "carplaydelegate")
 }
 
-private let CarPlaySceneDelegateKey = "ferrostar"
+private let ModelKey = "com.stadiamaps.ferrostar.model"
 
 private extension UISceneSession {
-    var carPlayManager: FerrostarCarPlayManager? {
+    var model: DemoCarPlayModel? {
         get {
-            userInfo?[CarPlaySceneDelegateKey] as? FerrostarCarPlayManager
+            userInfo?[ModelKey] as? DemoCarPlayModel
         }
         set {
             var info = userInfo ?? [:]
-            info[CarPlaySceneDelegateKey] = newValue
+            info[ModelKey] = newValue
             userInfo = info
         }
     }
@@ -33,7 +33,7 @@ class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
     ) {
         Logger.carPlay.debug("\(#function)")
 
-        guard templateApplicationScene.session.carPlayManager == nil else {
+        guard templateApplicationScene.session.model == nil else {
             Logger.carPlay.error("CarPlay already connected?")
             return
         }
@@ -43,98 +43,42 @@ class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
             return
         }
 
-        let manager = setupCarPlay(on: window, model: model)
-        let mapTemplate = manager.mapTemplate
+        let carPlayModel = DemoCarPlayModel(model: model)
+        templateApplicationScene.session.model = carPlayModel
 
-        // Set the root template
-        interfaceController.setRootTemplate(mapTemplate, animated: true) { success, error in
-            if let error {
-                Logger.carPlay.error("Failed setRootTemplet: \(error)")
-            } else {
-                Logger.carPlay.debug("Template presented: \(success)")
+        let view = DemoCarPlayNavigationView(model: carPlayModel)
+
+        let vc = UIHostingController(rootView: view)
+        window.rootViewController = vc
+        window.makeKeyAndVisible()
+
+        let mapTemplate = carPlayModel.createAndAttachTemplate()
+
+        Task { @MainActor in
+            do {
+                _ = try await interfaceController.setRootTemplate(mapTemplate, animated: true)
+            } catch {
+                Logger.carPlay.error("Cannot setRootTemplate")
+                carPlayModel.errorMessage = error.localizedDescription
             }
         }
-
-        templateApplicationScene.session.carPlayManager = manager
     }
 
     public func templateApplicationScene(
         _ templateApplicationScene: CPTemplateApplicationScene,
         didDisconnect _: CPInterfaceController,
-        from _: CPWindow
+        from window: CPWindow
     ) {
         Logger.carPlay.debug("\(#function)")
 
-        guard let manager = templateApplicationScene.session.carPlayManager else {
+        guard let model = templateApplicationScene.session.model else {
             Logger.carPlay.error("CarPlay not connected?")
             return
         }
 
-        manager.disconnect()
+        model.stop(cancelTrip: true, mapTemplate: nil)
+        window.isHidden = true
 
-        templateApplicationScene.session.carPlayManager = nil
+        templateApplicationScene.session.model = nil
     }
-
-    private func setupCarPlay(on window: UIWindow, model: DemoModel) -> FerrostarCarPlayManager {
-        let view = DemoCarPlayNavigationView(model: model, styleURL: AppDefaults.mapStyleURL)
-
-        let carPlayViewController = UIHostingController(rootView: view)
-
-        let carPlayManager = FerrostarCarPlayManager(
-            model.core,
-            distanceUnits: .default,
-            // TODO: We may need to hold the view or viewController here, but it seems
-            //       to work for now.
-            showCentering: !model.camera.isTrackingUserLocationWithCourse,
-            onCenter: { model.camera = .automotiveNavigation(pitch: 25)
-            },
-            onStartTrip: {
-                // TODO: This will require some work on the FerrostarCore side - to accept a route before starting.
-            },
-            onCancelTrip: {
-                model.core.stopNavigation()
-            }
-        )
-
-        window.rootViewController = carPlayViewController
-        window.makeKeyAndVisible()
-
-        return carPlayManager
-    }
-}
-
-extension CarPlaySceneDelegate: CPTemplateApplicationDashboardSceneDelegate {
-    func templateApplicationDashboardScene(
-        _: CPTemplateApplicationDashboardScene,
-        didConnect _: CPDashboardController,
-        to _: UIWindow
-    ) {
-        Logger.carPlay.info("\(#function)")
-    }
-
-    func templateApplicationDashboardScene(
-        _: CPTemplateApplicationDashboardScene,
-        didDisconnect _: CPDashboardController,
-        from _: UIWindow
-    ) {
-        Logger.carPlay.info("\(#function)")
-    }
-}
-
-extension CarPlaySceneDelegate: CPTemplateApplicationInstrumentClusterSceneDelegate {
-    // swiftlint:disable identifier_name vertical_parameter_alignment
-    func templateApplicationInstrumentClusterScene(
-        _: CPTemplateApplicationInstrumentClusterScene,
-        didConnect _: CPInstrumentClusterController
-    ) {
-        Logger.carPlay.info("\(#function)")
-    }
-
-    func templateApplicationInstrumentClusterScene(
-        _: CPTemplateApplicationInstrumentClusterScene,
-        didDisconnectInstrumentClusterController _: CPInstrumentClusterController
-    ) {
-        Logger.carPlay.info("\(#function)")
-    }
-    // swiftlint:enable identifier_name vertical_parameter_alignment
 }

--- a/apple/DemoApp/Demo/DemoCarPlayModel.swift
+++ b/apple/DemoApp/Demo/DemoCarPlayModel.swift
@@ -1,0 +1,233 @@
+@preconcurrency import CarPlay
+import FerrostarCarPlayUI
+import FerrostarCore
+import FerrostarCoreFFI
+import FerrostarSwiftUI
+import Foundation
+import MapLibreSwiftUI
+
+@MainActor
+private extension CPBarButton {
+    convenience init(appState: DemoAppState, model: DemoCarPlayModel, mapTemplate: CPMapTemplate) {
+        self.init(title: appState.buttonText, handler: appState.handler(model, mapTemplate: mapTemplate))
+    }
+
+    convenience init(model: DemoCarPlayModel, mapTemplate: CPMapTemplate) {
+        let appState = model.appState
+        self.init(appState: appState, model: model, mapTemplate: mapTemplate)
+    }
+}
+
+private extension DemoAppState {
+    @MainActor
+    func handler(_ model: DemoCarPlayModel, mapTemplate: CPMapTemplate) -> CPBarButtonHandler {
+        { _ in
+            switch self {
+            case .idle:
+                model.chooseDestination(mapTemplate)
+            case let .destination(coordinate):
+                Task {
+                    await model.loadRoute(coordinate, mapTemplate)
+                }
+            case let .routes(routes):
+                model.preview(routes, mapTemplate: mapTemplate)
+            case let .selectedRoute(route):
+                model.startNavigationSession(route, mapTemplate: mapTemplate)
+            case .navigating:
+                model.stop(cancelTrip: false, mapTemplate: mapTemplate)
+            }
+        }
+    }
+
+    var leadingNavigationBarButtonsEmpty: Bool {
+        switch self {
+        case .idle, .destination, .routes:
+            false
+        case .selectedRoute, .navigating:
+            true
+        }
+    }
+
+    var trailingNavigationBarButtonsEmpty: Bool {
+        switch self {
+        case .idle:
+            true
+        case .destination, .routes, .selectedRoute, .navigating:
+            false
+        }
+    }
+}
+
+@MainActor
+@Observable final class DemoCarPlayModel: NSObject, @preconcurrency CPMapTemplateDelegate {
+    private var model: DemoModel
+    private var session: CPNavigationSession?
+
+    private let formatterCollection: FormatterCollection = FoundationFormatterCollection()
+
+    init(model: DemoModel) {
+        self.model = model
+    }
+
+    func createAndAttachTemplate() -> CPMapTemplate {
+        let mapTemplate = CPMapTemplate()
+        mapTemplate.mapDelegate = self
+        updateTemplate(mapTemplate)
+        return mapTemplate
+    }
+
+    var appState: DemoAppState { model.appState }
+    var errorMessage: String? {
+        get {
+            model.errorMessage
+        }
+        set {
+            model.errorMessage = newValue
+        }
+    }
+
+    var coreState: NavigationState? { model.coreState }
+    var camera: MapViewCamera {
+        get {
+            model.camera
+        }
+        set {
+            model.camera = newValue
+        }
+    }
+
+    func chooseDestination(_ mapTemplate: CPMapTemplate) {
+        model.chooseDestination()
+        updateTemplate(mapTemplate)
+    }
+
+    func loadRoute(_ destination: CLLocationCoordinate2D, _ mapTemplate: CPMapTemplate) async {
+        await model.loadRoute(destination)
+        updateTemplate(mapTemplate)
+    }
+
+    func stop(cancelTrip: Bool, mapTemplate: CPMapTemplate?) {
+        if cancelTrip {
+            session?.cancelTrip()
+        } else {
+            session?.finishTrip()
+        }
+        session = nil
+        model.stop()
+        if let mapTemplate {
+            updateTemplate(mapTemplate)
+        }
+    }
+
+    private func start(choice: CPRouteChoice, mapTemplate: CPMapTemplate) {
+        do {
+            guard let route = choice.route else { throw DemoError.invalidCPRouteChoice }
+            startNavigationSession(route, mapTemplate: mapTemplate)
+        } catch {
+            model.errorMessage = error.localizedDescription
+            model.appState = .idle
+        }
+    }
+
+    private func select(choice: CPRouteChoice, mapTemplate: CPMapTemplate) {
+        do {
+            guard let route = choice.route else { throw DemoError.invalidCPRouteChoice }
+            model.chooseRoute(route)
+            updateTemplate(mapTemplate)
+        } catch {
+            model.errorMessage = error.localizedDescription
+            model.appState = .idle
+        }
+    }
+
+    private func observeFerrorstarChanges(_ mapTemplate: CPMapTemplate, units: MKDistanceFormatter.Units = .default) {
+        withObservationTracking {
+            guard let session else {
+                return
+            }
+
+            guard let state = coreState else {
+                // This occurs when navigation hasn't yet started.
+                return
+            }
+
+            if case .complete = state.tripState {
+                stop(cancelTrip: false, mapTemplate: mapTemplate)
+            } else {
+                state.updateEstimates(mapTemplate: mapTemplate, session: session, units: units)
+            }
+        } onChange: {
+            Task { @MainActor in
+                // Observe again after a change.
+                self.observeFerrorstarChanges(mapTemplate, units: units)
+            }
+        }
+    }
+
+    private var start: MKMapItem { MKMapItem(placemark: MKPlacemark(coordinate: model.origin)) }
+    private var end: MKMapItem { MKMapItem(placemark: MKPlacemark(coordinate: model.destination)) }
+
+    private func trip(_ routes: [Route]) -> CPTrip {
+        CPTrip.fromFerrostar(
+            routes: routes,
+            origin: start,
+            destination: end,
+            distanceFormatter: formatterCollection.distanceFormatter,
+            durationFormatter: formatterCollection.durationFormatter
+        )
+    }
+
+    func startNavigationSession(_ route: Route, mapTemplate: CPMapTemplate) {
+        let trip = trip([route])
+        session = mapTemplate.startNavigationSession(for: trip)
+        model.navigate(route)
+        observeFerrorstarChanges(mapTemplate)
+        updateTemplate(mapTemplate)
+    }
+
+    func preview(_ routes: [Route], mapTemplate: CPMapTemplate) {
+        let trip = trip(routes)
+        mapTemplate.showRouteChoicesPreview(for: trip, textConfiguration: nil)
+        updateTemplate(mapTemplate)
+    }
+
+    private func leadingNavigationBarButtons(_ mapTemplate: CPMapTemplate) -> [CPBarButton] {
+        if appState.leadingNavigationBarButtonsEmpty {
+            []
+        } else {
+            [CPBarButton(model: self, mapTemplate: mapTemplate)]
+        }
+    }
+
+    private func trailingNavigationBarButtons(_ mapTemplate: CPMapTemplate) -> [CPBarButton] {
+        if appState.trailingNavigationBarButtonsEmpty {
+            []
+        } else {
+            [CPBarButton(appState: .navigating, model: self, mapTemplate: mapTemplate)]
+        }
+    }
+
+    private func updateTemplate(_ mapTemplate: CPMapTemplate) {
+        mapTemplate.automaticallyHidesNavigationBar = false
+        mapTemplate.leadingNavigationBarButtons = leadingNavigationBarButtons(mapTemplate)
+        mapTemplate.trailingNavigationBarButtons = trailingNavigationBarButtons(mapTemplate)
+        mapTemplate
+            .mapButtons = [CarPlayMapButtons.recenterButton { [self] in
+                model.camera = .automotiveNavigation(pitch: 25)
+            }]
+    }
+
+    func mapTemplate(_ mapTemplate: CPMapTemplate, selectedPreviewFor _: CPTrip, using routeChoice: CPRouteChoice) {
+        // FIXME: Show route overview on the map.
+        select(choice: routeChoice, mapTemplate: mapTemplate)
+    }
+
+    func mapTemplate(_ mapTemplate: CPMapTemplate, startedTrip _: CPTrip, using routeChoice: CPRouteChoice) {
+        start(choice: routeChoice, mapTemplate: mapTemplate)
+        mapTemplate.hideTripPreviews()
+    }
+
+    func mapTemplateDidCancelNavigation(_ mapTemplate: CPMapTemplate) {
+        stop(cancelTrip: true, mapTemplate: mapTemplate)
+    }
+}

--- a/apple/DemoApp/Demo/DemoCarPlayNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoCarPlayNavigationView.swift
@@ -4,11 +4,23 @@ import MapLibreSwiftUI
 import SwiftUI
 
 struct DemoCarPlayNavigationView: View {
-    var model: DemoModel
-    let styleURL: URL
+    @State var model: DemoCarPlayModel
 
     var body: some View {
-        @Bindable var bindableModel = model
-        CarPlayNavigationView(navigationState: model.coreState, styleURL: styleURL, camera: $bindableModel.camera)
+        ZStack {
+            if let errorMessage = model.errorMessage {
+                ContentUnavailableView(
+                    errorMessage, systemImage: "network.slash",
+                    description: Text("error navigating.")
+                )
+            } else {
+                @Bindable var bindableModel = model
+                CarPlayNavigationView(
+                    navigationState: model.coreState,
+                    styleURL: AppDefaults.mapStyleURL,
+                    camera: $bindableModel.camera
+                )
+            }
+        }
     }
 }

--- a/apple/DemoApp/Ferrostar Demo.xcodeproj/project.pbxproj
+++ b/apple/DemoApp/Ferrostar Demo.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		FE16E4A62E0CAB0A009D7B83 /* DemoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE16E4A52E0CAB0A009D7B83 /* DemoModel.swift */; };
 		FE16E4A82E0CAC34009D7B83 /* AppDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE16E4A72E0CAC34009D7B83 /* AppDefaults.swift */; };
 		FE9242DB2E0B0D610012C533 /* SwitchableLocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9242DA2E0B0D610012C533 /* SwitchableLocationProvider.swift */; };
+		FEFEAA1C2E0F570B00101D5B /* DemoCarPlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFEAA1B2E0F570B00101D5B /* DemoCarPlayModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -50,6 +51,7 @@
 		FE16E4A52E0CAB0A009D7B83 /* DemoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoModel.swift; sourceTree = "<group>"; };
 		FE16E4A72E0CAC34009D7B83 /* AppDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDefaults.swift; sourceTree = "<group>"; };
 		FE9242DA2E0B0D610012C533 /* SwitchableLocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchableLocationProvider.swift; sourceTree = "<group>"; };
+		FEFEAA1B2E0F570B00101D5B /* DemoCarPlayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoCarPlayModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +80,7 @@
 				1611A5542B2E6E98006B131D /* Preview Content */,
 				1663679B2B2F6F79008BFF1F /* Helpers */,
 				1621C26C2CE2B42100034BA3 /* CarPlaySceneDelegate.swift */,
+				FEFEAA1B2E0F570B00101D5B /* DemoCarPlayModel.swift */,
 				FE0AFFBB2DDD23D500CF4DB8 /* DemoCarPlayNavigationView.swift */,
 				FE16E4A72E0CAC34009D7B83 /* AppDefaults.swift */,
 				FE9242DA2E0B0D610012C533 /* SwitchableLocationProvider.swift */,
@@ -230,6 +233,7 @@
 				FE16E4A32E0CAA73009D7B83 /* DemoAppState.swift in Sources */,
 				FE16E4A82E0CAC34009D7B83 /* AppDefaults.swift in Sources */,
 				FE16E4A12E0CAA61009D7B83 /* DemoError.swift in Sources */,
+				FEFEAA1C2E0F570B00101D5B /* DemoCarPlayModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apple/Sources/FerrostarCarPlayUI/CarPlayModels/NavigationState+CarPlay.swift
+++ b/apple/Sources/FerrostarCarPlayUI/CarPlayModels/NavigationState+CarPlay.swift
@@ -1,0 +1,20 @@
+import CarPlay
+import FerrostarCore
+import Foundation
+import MapKit
+
+public extension NavigationState {
+    func updateEstimates(mapTemplate: CPMapTemplate, session: CPNavigationSession, units: MKDistanceFormatter.Units) {
+        if let progress = currentProgress {
+            progress.updateUpcomingEstimates(
+                session: session,
+                mapTemplate: mapTemplate,
+                units: units
+            )
+        }
+
+        if let instruction = currentVisualInstruction, let step = currentStep {
+            session.updateEstimates(instruction: instruction, step: step, units: units)
+        }
+    }
+}

--- a/apple/Sources/FerrostarCarPlayUI/Templates/Buttons/CarPlayButtons.swift
+++ b/apple/Sources/FerrostarCarPlayUI/Templates/Buttons/CarPlayButtons.swift
@@ -1,7 +1,7 @@
 import CarPlay
 
-enum CarPlayMapButtons {
-    static func recenterButton(
+public enum CarPlayMapButtons {
+    public static func recenterButton(
         isHidden: Bool = false,
         isEnabled: Bool = true,
         _ action: @escaping () -> Void


### PR DESCRIPTION
- Add `DemoCarPlayModel`. It has a `DemoModel` and the CarPlay types. 
-- It is created from the shared `DemoModel` in the iOS application. The code must be able to exist w/o a `UIApplication`, so this global data is necessary.
- Update the `CarPlayDelegate` to use the `DemoCarPlayModel`.
- The SwiftUI Views in CarPlay use `@Observable` properties to populate the SwiftUI views.
- No longer uses the old code path; but that is currently kept for backwards compatibility. 
-- Basically the library has helpers, since a library should not implement an application level delegate. The client of the library has to do work to make the proper decisions for their application's use cases. 
-- The `DemoAppState` is tied up in what CarPlay UI to show. It's been a challenge to determine how to library-ify this code.