### PR TITLE
iOS: Add Route Preview to Demo App and CarPlay

### DIFF
--- a/apple/DemoApp/Demo/DemoCarPlayModel.swift
+++ b/apple/DemoApp/Demo/DemoCarPlayModel.swift
@@ -4,6 +4,8 @@ import FerrostarCore
 import FerrostarCoreFFI
 import FerrostarSwiftUI
 import Foundation
+import MapLibre
+import MapLibreSwiftDSL
 import MapLibreSwiftUI
 
 @MainActor
@@ -95,6 +97,8 @@ private extension DemoAppState {
             model.camera = newValue
         }
     }
+
+    @MapViewContentBuilder var routePreview: [StyleLayerDefinition] { model.routePreview }
 
     func chooseDestination(_ mapTemplate: CPMapTemplate) {
         model.chooseDestination()
@@ -218,7 +222,6 @@ private extension DemoAppState {
     }
 
     func mapTemplate(_ mapTemplate: CPMapTemplate, selectedPreviewFor _: CPTrip, using routeChoice: CPRouteChoice) {
-        // FIXME: Show route overview on the map.
         select(choice: routeChoice, mapTemplate: mapTemplate)
     }
 

--- a/apple/DemoApp/Demo/DemoCarPlayNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoCarPlayNavigationView.swift
@@ -1,5 +1,6 @@
 import FerrostarCarPlayUI
 import FerrostarCore
+import FerrostarMapLibreUI
 import MapLibreSwiftUI
 import SwiftUI
 
@@ -19,7 +20,9 @@ struct DemoCarPlayNavigationView: View {
                     navigationState: model.coreState,
                     styleURL: AppDefaults.mapStyleURL,
                     camera: $bindableModel.camera
-                )
+                ) {
+                    model.routePreview
+                }
             }
         }
     }

--- a/apple/DemoApp/Demo/DemoModel+RoutePreview.swift
+++ b/apple/DemoApp/Demo/DemoModel+RoutePreview.swift
@@ -1,0 +1,24 @@
+import FerrostarMapLibreUI
+import MapLibreSwiftDSL
+import UIKit
+
+/// The preview route style is green with a white casing.
+private struct PreviewRouteStyle: RouteStyle {
+    public let color: UIColor = .systemGreen
+    public let casingColor: UIColor? = .white
+    public let lineCap: LineCap = .round
+    public let lineJoin: LineJoin = .round
+    public init() { /* No def */ }
+}
+
+extension DemoModel {
+    @MapViewContentBuilder var routePreview: [StyleLayerDefinition] {
+        if let selectedRoutePolyline {
+            RouteStyleLayer(
+                polyline: selectedRoutePolyline,
+                identifier: "preview-route-polyline",
+                style: PreviewRouteStyle()
+            )
+        }
+    }
+}

--- a/apple/DemoApp/Demo/DemoModel.swift
+++ b/apple/DemoApp/Demo/DemoModel.swift
@@ -3,13 +3,28 @@ import CoreLocation
 @preconcurrency import FerrostarCore
 @preconcurrency import FerrostarCoreFFI
 import Foundation
+import MapLibre
 import MapLibreSwiftUI
+
+private extension BoundingBox {
+    var coordinateBounds: MLNCoordinateBounds {
+        MLNCoordinateBounds(sw: sw.clLocationCoordinate2D, ne: ne.clLocationCoordinate2D)
+    }
+}
 
 private extension MapViewCamera {
     static func currentLocationCamera(locationProvider: LocationProviding) -> MapViewCamera {
         guard let coordinate = locationProvider.lastLocation?.clLocation.coordinate
         else { return MapViewCamera.default() }
         return .center(coordinate, zoom: 14)
+    }
+
+    private static func bounding(bbox: BoundingBox) -> MapViewCamera {
+        MapViewCamera.boundingBox(bbox.coordinateBounds)
+    }
+
+    static func bounding(route: Route) -> MapViewCamera {
+        bounding(bbox: route.bbox)
     }
 }
 
@@ -81,8 +96,8 @@ extension DemoModel {
     let core: FerrostarCore
     var origin: CLLocationCoordinate2D = kCLLocationCoordinate2DInvalid
     var destination: CLLocationCoordinate2D = kCLLocationCoordinate2DInvalid
-    var selectedRoute: Route?
-    var camera: MapViewCamera
+    private var selectedRoute: Route?
+    private var demoCamera: MapViewCamera
 
     var coreRoute: Route?
     var coreState: NavigationState?
@@ -96,7 +111,7 @@ extension DemoModel {
         locationProvider: SwitchableLocationProvider
     ) {
         self.locationProvider = locationProvider
-        camera = MapViewCamera.currentLocationCamera(locationProvider: locationProvider)
+        demoCamera = MapViewCamera.currentLocationCamera(locationProvider: locationProvider)
         do {
             core = try FerrostarCore(locationProvider: locationProvider)
             core.delegate = navigationDelegate
@@ -117,6 +132,24 @@ extension DemoModel {
     var locationServicesEnabled: Bool { locationProvider.locationServicesEnabled }
     var lastCoordinate: CLLocationCoordinate2D? { locationProvider.lastLocation?.clLocation.coordinate }
     var horizontalAccuracy: Double? { locationProvider.lastLocation?.horizontalAccuracy }
+
+    var selectedRoutePolyline: MLNPolyline? {
+        guard let selectedRouteGeometry = selectedRoute?.geometry else { return nil }
+        return MLNPolylineFeature(coordinates: selectedRouteGeometry.map(\.clLocationCoordinate2D))
+    }
+
+    var camera: MapViewCamera {
+        get {
+            if let selectedRoute {
+                MapViewCamera.bounding(route: selectedRoute)
+            } else {
+                demoCamera
+            }
+        }
+        set {
+            demoCamera = newValue
+        }
+    }
 
     private func routes(from: CLLocationCoordinate2D, to: CLLocationCoordinate2D) async throws -> [Route] {
         guard from != kCLLocationCoordinate2DInvalid else { throw DemoError.invalidOrigin }
@@ -184,7 +217,10 @@ extension DemoModel {
     }
 
     func navigate(_ route: Route) {
-        wrap { try startNavigation(on: route) }
+        wrap {
+            selectedRoute = nil // Remove any preview routes.
+            return try startNavigation(on: route)
+        }
     }
 
     func stop() {

--- a/apple/DemoApp/Demo/DemoNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoNavigationView.swift
@@ -23,7 +23,6 @@ private extension DemoModel {
     func selectRoute(from routes: [Route]) {
         do {
             guard let route = routes.first else { throw DemoError.noFirstRoute }
-            selectedRoute = route
             chooseRoute(route)
         } catch {
             errorMessage = error.localizedDescription
@@ -66,6 +65,8 @@ struct DemoNavigationView: View {
                     }
                 }
                 CircleStyleLayer(identifier: "foo", source: source)
+
+                model.routePreview
             }
         )
         .navigationSpeedLimit(

--- a/apple/DemoApp/Ferrostar Demo.xcodeproj/project.pbxproj
+++ b/apple/DemoApp/Ferrostar Demo.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		FE16E4A32E0CAA73009D7B83 /* DemoAppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE16E4A22E0CAA73009D7B83 /* DemoAppState.swift */; };
 		FE16E4A62E0CAB0A009D7B83 /* DemoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE16E4A52E0CAB0A009D7B83 /* DemoModel.swift */; };
 		FE16E4A82E0CAC34009D7B83 /* AppDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE16E4A72E0CAC34009D7B83 /* AppDefaults.swift */; };
+		FE7D4EE12E1DB9A100E077CB /* DemoModel+RoutePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7D4EE02E1DB9A100E077CB /* DemoModel+RoutePreview.swift */; };
 		FE9242DB2E0B0D610012C533 /* SwitchableLocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9242DA2E0B0D610012C533 /* SwitchableLocationProvider.swift */; };
 		FEFEAA1C2E0F570B00101D5B /* DemoCarPlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFEAA1B2E0F570B00101D5B /* DemoCarPlayModel.swift */; };
 /* End PBXBuildFile section */
@@ -50,6 +51,7 @@
 		FE16E4A22E0CAA73009D7B83 /* DemoAppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppState.swift; sourceTree = "<group>"; };
 		FE16E4A52E0CAB0A009D7B83 /* DemoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoModel.swift; sourceTree = "<group>"; };
 		FE16E4A72E0CAC34009D7B83 /* AppDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDefaults.swift; sourceTree = "<group>"; };
+		FE7D4EE02E1DB9A100E077CB /* DemoModel+RoutePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DemoModel+RoutePreview.swift"; sourceTree = "<group>"; };
 		FE9242DA2E0B0D610012C533 /* SwitchableLocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchableLocationProvider.swift; sourceTree = "<group>"; };
 		FEFEAA1B2E0F570B00101D5B /* DemoCarPlayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoCarPlayModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -90,6 +92,7 @@
 				FE16E4A22E0CAA73009D7B83 /* DemoAppState.swift */,
 				1611A5582B2E6E98006B131D /* DemoApp.swift */,
 				FE16E4A52E0CAB0A009D7B83 /* DemoModel.swift */,
+				FE7D4EE02E1DB9A100E077CB /* DemoModel+RoutePreview.swift */,
 			);
 			path = Demo;
 			sourceTree = "<group>";
@@ -225,6 +228,7 @@
 				1611A55B2B2E6E98006B131D /* DemoNavigationView.swift in Sources */,
 				FE9242DB2E0B0D610012C533 /* SwitchableLocationProvider.swift in Sources */,
 				1621C26D2CE2B42700034BA3 /* CarPlaySceneDelegate.swift in Sources */,
+				FE7D4EE12E1DB9A100E077CB /* DemoModel+RoutePreview.swift in Sources */,
 				1663679D2B2F6F85008BFF1F /* APIKeys.swift in Sources */,
 				FE16E4A62E0CAB0A009D7B83 /* DemoModel.swift in Sources */,
 				1611A55D2B2E6E98006B131D /* DemoApp.swift in Sources */,


### PR DESCRIPTION
- It's Green, because why not?
- In `DemoModel`, the `MapViewCamera` is overridden if there is a `selectedRoute`. The `MapViewCamera` will then be the bounds of the `Route`. 
-- This works in the iOS application via `DynamicallyOrientingNavigationView`, but does **not** work in `CarPlayNavigationView`. It's not clear to me why yet.