### PR TITLE
iOS: Toggle the delegate when toggling the LocationProvider

### DIFF
--- a/apple/DemoApp/Demo/SwitchableLocationProvider.swift
+++ b/apple/DemoApp/Demo/SwitchableLocationProvider.swift
@@ -72,12 +72,16 @@ import Foundation
 
     func toggle() {
         current.stopUpdating()
+        let delegate = current.delegate
+
         switch type {
         case .simulated:
             type = .device
         case .device:
             type = .simulated
         }
+
+        current.delegate = delegate
         current.startUpdating()
     }
 }


### PR DESCRIPTION
- This allows the toggle to work! Without it only the first LocationProvider used would get the delegate.