### PR TITLE
iOS: DemoModel uses MKMapItem for origin/destination

### DIFF
--- a/apple/DemoApp/Demo/DemoAppState.swift
+++ b/apple/DemoApp/Demo/DemoAppState.swift
@@ -4,10 +4,11 @@ import CoreLocation
 // See https://github.com/stadiamaps/ferrostar/issues/164#issuecomment-3037767025
 @preconcurrency import FerrostarCoreFFI
 import Foundation
+@preconcurrency import MapKit
 
-enum DemoAppState: CustomStringConvertible {
+enum DemoAppState: CustomStringConvertible, Sendable {
     case idle
-    case destination(CLLocationCoordinate2D)
+    case destination(MKMapItem)
     case routes([Route])
     case selectedRoute(Route)
     case navigating
@@ -16,8 +17,8 @@ enum DemoAppState: CustomStringConvertible {
         switch self {
         case .idle:
             "Idle"
-        case let .destination(location):
-            "Destination: (\(location)"
+        case let .destination(item):
+            "Destination: (\(item)"
         case let .routes(routes):
             "Routes: \(routes.count)"
         case let .selectedRoute(route):
@@ -44,10 +45,10 @@ enum DemoAppState: CustomStringConvertible {
 }
 
 extension DemoAppState {
-    func setDestination(_ destination: CLLocationCoordinate2D) throws -> DemoAppState {
+    func setDestination(_ destination: MKMapItem) throws -> DemoAppState {
         switch self {
         case .idle:
-            guard destination != kCLLocationCoordinate2DInvalid else { throw DemoError.invalidDestination }
+            guard destination != .invalid else { throw DemoError.invalidDestination }
             return .destination(destination)
         case .destination(_), .routes(_), .selectedRoute(_), .navigating:
             throw DemoError.invalidState(self)

--- a/apple/DemoApp/Demo/DemoCarPlayModel.swift
+++ b/apple/DemoApp/Demo/DemoCarPlayModel.swift
@@ -25,9 +25,9 @@ private extension DemoAppState {
             switch self {
             case .idle:
                 model.chooseDestination(mapTemplate)
-            case let .destination(coordinate):
+            case let .destination(item):
                 Task {
-                    await model.loadRoute(coordinate, mapTemplate)
+                    await model.loadRoute(item, mapTemplate)
                 }
             case let .routes(routes):
                 model.preview(routes, mapTemplate: mapTemplate)
@@ -101,7 +101,7 @@ private extension DemoAppState {
         updateTemplate(mapTemplate)
     }
 
-    func loadRoute(_ destination: CLLocationCoordinate2D, _ mapTemplate: CPMapTemplate) async {
+    func loadRoute(_ destination: MKMapItem, _ mapTemplate: CPMapTemplate) async {
         await model.loadRoute(destination)
         updateTemplate(mapTemplate)
     }
@@ -164,14 +164,11 @@ private extension DemoAppState {
         }
     }
 
-    private var start: MKMapItem { MKMapItem(placemark: MKPlacemark(coordinate: model.origin)) }
-    private var end: MKMapItem { MKMapItem(placemark: MKPlacemark(coordinate: model.destination)) }
-
     private func trip(_ routes: [Route]) -> CPTrip {
         CPTrip.fromFerrostar(
             routes: routes,
-            origin: start,
-            destination: end,
+            origin: model.origin,
+            destination: model.destination,
             distanceFormatter: formatterCollection.distanceFormatter,
             durationFormatter: formatterCollection.durationFormatter
         )

--- a/apple/DemoApp/Demo/DemoModel.swift
+++ b/apple/DemoApp/Demo/DemoModel.swift
@@ -3,6 +3,7 @@ import CoreLocation
 @preconcurrency import FerrostarCore
 @preconcurrency import FerrostarCoreFFI
 import Foundation
+import MapKit
 import MapLibreSwiftUI
 
 private extension MapViewCamera {
@@ -63,15 +64,26 @@ extension DemoModel {
             type: .simulated
         ))
 
-        origin = (locationProvider.lastLocation != nil) ? locationProvider.lastLocation!.clLocation
+        let originCoordinate = (locationProvider.lastLocation != nil) ? locationProvider.lastLocation!.clLocation
             .coordinate : AppDefaults.initialLocation.coordinate
+        origin = MKMapItem(coordinate: originCoordinate)
 
         // "Cupertino HS"
-        destination = CLLocationCoordinate2D(latitude: 37.31910, longitude: -122.01018)
+        destination = MKMapItem(coordinate: CLLocationCoordinate2D(latitude: 37.31910, longitude: -122.01018))
     }
 }
 
 @MainActor let demoModel = DemoModel()
+
+extension MKMapItem {
+    static var invalid: MKMapItem {
+        MKMapItem(coordinate: kCLLocationCoordinate2DInvalid)
+    }
+
+    convenience init(coordinate: CLLocationCoordinate2D) {
+        self.init(placemark: MKPlacemark(coordinate: coordinate))
+    }
+}
 
 @MainActor
 @Observable final class DemoModel {
@@ -79,8 +91,8 @@ extension DemoModel {
     var appState: DemoAppState = .idle
     let locationProvider: SwitchableLocationProvider
     let core: FerrostarCore
-    var origin: CLLocationCoordinate2D = kCLLocationCoordinate2DInvalid
-    var destination: CLLocationCoordinate2D = kCLLocationCoordinate2DInvalid
+    var origin: MKMapItem = .invalid
+    var destination: MKMapItem = .invalid
     var selectedRoute: Route?
     var camera: MapViewCamera
 
@@ -118,11 +130,14 @@ extension DemoModel {
     var lastCoordinate: CLLocationCoordinate2D? { locationProvider.lastLocation?.clLocation.coordinate }
     var horizontalAccuracy: Double? { locationProvider.lastLocation?.horizontalAccuracy }
 
-    private func routes(from: CLLocationCoordinate2D, to: CLLocationCoordinate2D) async throws -> [Route] {
-        guard from != kCLLocationCoordinate2DInvalid else { throw DemoError.invalidOrigin }
+    private func routes(from: MKMapItem, to: MKMapItem) async throws -> [Route] {
+        guard from != .invalid else { throw DemoError.invalidOrigin }
+        let originCoordinate = from.placemark.coordinate
+        let destinationCoordinate = to.placemark.coordinate
+
         async let routes = try await core.getRoutes(
-            initialLocation: UserLocation(clCoordinateLocation2D: from),
-            waypoints: [Waypoint(coordinate: GeographicCoordinate(cl: to), kind: .break)]
+            initialLocation: UserLocation(clCoordinateLocation2D: originCoordinate),
+            waypoints: [Waypoint(coordinate: GeographicCoordinate(cl: destinationCoordinate), kind: .break)]
         )
         return try await routes
     }
@@ -166,10 +181,10 @@ extension DemoModel {
         }
     }
 
-    func loadRoute(_ destination: CLLocationCoordinate2D) async {
+    func loadRoute(_ destination: MKMapItem) async {
         await wrap {
             guard let lastCoordinate else { throw DemoError.noOrigin }
-            origin = lastCoordinate
+            origin = .init(coordinate: lastCoordinate)
             let routes = try await routes(from: origin, to: destination)
             guard !routes.isEmpty else { throw DemoError.noRoutesLoaded }
             return .routes(routes)

--- a/apple/DemoApp/Demo/DemoNavigationView.swift
+++ b/apple/DemoApp/Demo/DemoNavigationView.swift
@@ -102,10 +102,10 @@ struct DemoNavigationView: View {
                                 switch model.appState {
                                 case .idle:
                                     model.chooseDestination()
-                                case let .destination(coordinate):
+                                case let .destination(item):
                                     Task {
                                         isFetchingRoutes = true
-                                        await model.loadRoute(coordinate)
+                                        await model.loadRoute(item)
                                         isFetchingRoutes = false
                                     }
                                 case let .routes(routes):


### PR DESCRIPTION
- This is just so that the addition of search ui and waiting for the result and then setting it does not get mixed up with this plumbing change.