### PR TITLE
iOS: DemoCarPlayModel now has CPInterfaceController property

### DIFF
--- a/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
+++ b/apple/DemoApp/Demo/CarPlaySceneDelegate.swift
@@ -43,7 +43,7 @@ class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
             return
         }
 
-        let carPlayModel = DemoCarPlayModel(model: model)
+        let carPlayModel = DemoCarPlayModel(model: model, interfaceController: interfaceController)
         templateApplicationScene.session.model = carPlayModel
 
         let view = DemoCarPlayNavigationView(model: carPlayModel)

--- a/apple/DemoApp/Demo/DemoCarPlayModel.swift
+++ b/apple/DemoApp/Demo/DemoCarPlayModel.swift
@@ -61,12 +61,14 @@ private extension DemoAppState {
 @MainActor
 @Observable final class DemoCarPlayModel: NSObject, @preconcurrency CPMapTemplateDelegate {
     private var model: DemoModel
+    private var interfaceController: CPInterfaceController
     private var session: CPNavigationSession?
 
     private let formatterCollection: FormatterCollection = FoundationFormatterCollection()
 
-    init(model: DemoModel) {
+    init(model: DemoModel, interfaceController: CPInterfaceController) {
         self.model = model
+        self.interfaceController = interfaceController
     }
 
     func createAndAttachTemplate() -> CPMapTemplate {


### PR DESCRIPTION
- This is plumbing for upcoming work where `CPInterfaceController.pushTemplate` may be used.