### PR TITLE
Declare DetectorImpl as final to address swift concurrency warning

### DIFF
--- a/apple/Sources/FerrostarCore/FFIWrappers/RouteDeviationWrapper.swift
+++ b/apple/Sources/FerrostarCore/FFIWrappers/RouteDeviationWrapper.swift
@@ -2,7 +2,7 @@ import CoreLocation
 import FerrostarCoreFFI
 import Foundation
 
-private class DetectorImpl: RouteDeviationDetector {
+private final class DetectorImpl: RouteDeviationDetector {
     let detectorFunc: (UserLocation, Route, RouteStep) -> RouteDeviation
 
     init(detectorFunc: @escaping (UserLocation, Route, RouteStep) -> RouteDeviation) {


### PR DESCRIPTION
```
/Users/bolsinga/Documents/code/git/ferrostar/apple/Sources/FerrostarCore/FFIWrappers/RouteDeviationWrapper.swift:5:15: warning: non-final class 'DetectorImpl' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in the Swift 6 language mode
private class DetectorImpl: RouteDeviationDetector {
              ^
```