### PR TITLE
Declare function types as Sendable to address swift concurrency warning

### DIFF
--- a/apple/Sources/FerrostarCore/FFIWrappers/RouteDeviationWrapper.swift
+++ b/apple/Sources/FerrostarCore/FFIWrappers/RouteDeviationWrapper.swift
@@ -3,9 +3,9 @@ import FerrostarCoreFFI
 import Foundation
 
 private class DetectorImpl: RouteDeviationDetector {
-    let detectorFunc: (UserLocation, Route, RouteStep) -> RouteDeviation
+    let detectorFunc: @Sendable (UserLocation, Route, RouteStep) -> RouteDeviation
 
-    init(detectorFunc: @escaping (UserLocation, Route, RouteStep) -> RouteDeviation) {
+    init(detectorFunc: @escaping @Sendable (UserLocation, Route, RouteStep) -> RouteDeviation) {
         self.detectorFunc = detectorFunc
     }
 
@@ -20,7 +20,7 @@ public enum SwiftRouteDeviationTracking {
 
     case staticThreshold(minimumHorizontalAccuracy: UInt16, maxAcceptableDeviation: Double)
 
-    case custom(detector: (UserLocation, Route, RouteStep) -> RouteDeviation)
+    case custom(detector: @Sendable (UserLocation, Route, RouteStep) -> RouteDeviation)
 
     var ffiValue: FerrostarCoreFFI.RouteDeviationTracking {
         switch self {


### PR DESCRIPTION
```
/Users/bolsinga/Documents/code/git/ferrostar/apple/Sources/FerrostarCore/FFIWrappers/RouteDeviationWrapper.swift:6:9: warning: stored property 'detectorFunc' of 'Sendable'-conforming class 'DetectorImpl' has non-sendable type '(UserLocation, Route, RouteStep) -> RouteDeviation'; this is an error in the Swift 6 language mode
    let detectorFunc: (UserLocation, Route, RouteStep) -> RouteDeviation
        ^
/Users/bolsinga/Documents/code/git/ferrostar/apple/Sources/FerrostarCore/FFIWrappers/RouteDeviationWrapper.swift:6:9: note: a function type must be marked '@Sendable' to conform to 'Sendable'
    let detectorFunc: (UserLocation, Route, RouteStep) -> RouteDeviation
        ^
```