### PR TITLE
Fix Minor Inconsistency between Road/Street Name [ANDROID]

### DIFF
--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/config/NavigationViewComponentBuilder.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/config/NavigationViewComponentBuilder.kt
@@ -26,7 +26,7 @@ data class NavigationViewComponentBuilder(
     internal val progressView:
         @Composable
         (modifier: Modifier, uiState: NavigationUiState, onTapExit: (() -> Unit)?) -> Unit,
-    internal val streetNameView:
+    internal val roadNameView:
         @Composable
         (modifier: Modifier, roadName: String?, cameraControlState: CameraControlState) -> Unit,
     internal val customOverlayView: @Composable (BoxScope.(Modifier) -> Unit)? = null,
@@ -58,7 +58,7 @@ data class NavigationViewComponentBuilder(
                     onTapExit = onTapExit)
               }
             },
-            streetNameView = { modifier, roadName, cameraControlState ->
+            roadNameView = { modifier, roadName, cameraControlState ->
               if (cameraControlState is CameraControlState.ShowRouteOverview) {
                 roadName?.let { roadName ->
                   Row(
@@ -94,12 +94,12 @@ fun NavigationViewComponentBuilder.withProgressView(
   return copy(progressView = progressView)
 }
 
-fun NavigationViewComponentBuilder.withStreetNameView(
-    streetNameView:
+fun NavigationViewComponentBuilder.withRoadNameView(
+    roadNameView:
         @Composable
         (modifier: Modifier, roadName: String?, cameraControlState: CameraControlState) -> Unit
 ): NavigationViewComponentBuilder {
-  return copy(streetNameView = streetNameView)
+  return copy(roadNameView = roadNameView)
 }
 
 fun NavigationViewComponentBuilder.withCustomOverlayView(

--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/views/overlays/LandscapeNavigationOverlayView.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/views/overlays/LandscapeNavigationOverlayView.kt
@@ -104,7 +104,7 @@ fun LandscapeNavigationOverlayView(
           onClickZoomIn = { onClickZoomIn?.invoke() },
           onClickZoomOut = { onClickZoomOut?.invoke() },
           bottomCenter = {
-            views.streetNameView(Modifier, uiState.currentStepRoadName, cameraControlState)
+            views.roadNameView(Modifier, uiState.currentStepRoadName, cameraControlState)
           })
     }
   }

--- a/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/views/overlays/PortraitNavigationOverlayView.kt
+++ b/android/composeui/src/main/java/com/stadiamaps/ferrostar/composeui/views/overlays/PortraitNavigationOverlayView.kt
@@ -85,7 +85,7 @@ fun PortraitNavigationOverlayView(
         onClickZoomIn = { onClickZoomIn?.invoke() },
         onClickZoomOut = { onClickZoomOut?.invoke() },
         bottomCenter = {
-          views.streetNameView(Modifier, uiState.currentStepRoadName, cameraControlState)
+          views.roadNameView(Modifier, uiState.currentStepRoadName, cameraControlState)
         },
     )
 


### PR DESCRIPTION
Just fixed a small inconsistency with the use of `roadName` and `streetName` - favoured RoadName as this is common with the rest of the codebase.
Maybe there was a reason for this difference that I've missed...