### PR TITLE
Improve lint

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -41,6 +41,13 @@ export default [
       "no-undef": "off",
       "@typescript-eslint/no-unused-vars": "warn",
       "@typescript-eslint/ban-ts-comment": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "none", // Function args can be useful documentation
+          ignoreRestSiblings: true, // Allow `omit` syntax
+        },
+      ],
     },
   },
   prettier,

--- a/web/package.json
+++ b/web/package.json
@@ -30,7 +30,7 @@
     "pack:core": "wasm-pack pack ../common/ferrostar/pkg",
     "pack:all": "npm run pack:core && npm pack",
     "publish:core": "wasm-pack publish --access public ../common/ferrostar/pkg",
-    "lint": "eslint --cache --ext .js,.ts,.html src",
+    "lint": "eslint --cache --ext .js,.ts,.html src --max-warnings 17",
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,7 @@
     "pack:all": "npm run pack:core && npm pack",
     "publish:core": "wasm-pack publish --access public ../common/ferrostar/pkg",
     "lint": "eslint --cache --ext .js,.ts,.html src",
-    "lint:fix": "eslint --cache --ext .js,.ts,.html src --fix"
+    "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
     "@maptimy/platform-formatters": "^0.6.0",


### PR DESCRIPTION
Pulling in a couple of my favorite ESLint setup bits:

- Ignore unused arguments and rest siblings in `no-unused-vars` rule
- Pass the `--fix` flag to the existing `lint` command instead of duplicating the whole thing
- Add the `--max-warnings` flag to the lint command so we don't add warnings without being intentional about it (ideally this should be 0)