### PR TITLE
fix: returns raw user location when there is no deviation

### DIFF
--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/extensions/TripStateExtensions.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/extensions/TripStateExtensions.kt
@@ -112,8 +112,8 @@ fun TripState.preferredUserLocation() =
     when (this) {
       is TripState.Navigating -> {
         when (this.deviation) {
-          is RouteDeviation.NoDeviation -> this.userLocation
-          is RouteDeviation.OffRoute -> this.snappedUserLocation
+          is RouteDeviation.NoDeviation -> this.snappedUserLocation
+          is RouteDeviation.OffRoute -> this.userLocation
         }
       }
       is TripState.Idle -> this.userLocation


### PR DESCRIPTION
The snapped location should be returned when there is no deviation and the users raw location when there is. This fixes https://github.com/stadiamaps/ferrostar/issues/682 and maybe even https://github.com/stadiamaps/ferrostar/issues/414