### PR TITLE
fix: hide road label on iOS when off route

### DIFF
--- a/apple/Sources/FerrostarSwiftUI/ViewModifiers/NavigationViewComponentsViewModifier.swift
+++ b/apple/Sources/FerrostarSwiftUI/ViewModifiers/NavigationViewComponentsViewModifier.swift
@@ -222,6 +222,9 @@ public enum DefaultNavigationViewComponents {
     @ViewBuilder public static func defaultCurrentRoadNameView(_ navigationState: NavigationState?)
         -> some View
     {
-        CurrentRoadNameView(currentRoadName: navigationState?.currentRoadName)
+        // Only show the road view when on route.
+        if case .noDeviation = navigationState?.currentDeviation {
+            CurrentRoadNameView(currentRoadName: navigationState?.currentRoadName)
+        }
     }
 }


### PR DESCRIPTION
- Hides the current road name view when the user is not on route by requiring `.noDeviation`.