### PR TITLE
Allow for optional accuracy in Speed

### DIFF
--- a/apple/Sources/FerrostarCore/Extensions/CoreLocationExtensions.swift
+++ b/apple/Sources/FerrostarCore/Extensions/CoreLocationExtensions.swift
@@ -206,13 +206,12 @@ public extension UserLocation {
 ///   - accuracy: The CLLocation user speed accuracy in meters per second.
 /// - Returns: The FFI Speed object for ferrostar.
 private func ffiSpeed(_ speed: CLLocationSpeed?, accuracy: CLLocationSpeedAccuracy?) -> Speed? {
-    guard let speed = parseCLValidityToOptional(speed),
-          let accuracy = parseCLValidityToOptional(accuracy)
+    guard let speed = parseCLValidityToOptional(speed)
     else {
         return nil
     }
 
-    return Speed(value: speed, accuracy: accuracy)
+    return Speed(value: speed, accuracy: parseCLValidityToOptional(accuracy))
 }
 
 private func parseCLValidityToOptional(_ value: Double?) -> Double? {


### PR DESCRIPTION
At the moment whole Speed entity is discarded if speed is valid but accuracy is not. This case is very common with Xcode location simulation, making it hard to use UserLocation from FerrostarCore as it strips speed data out.

My suggestion is to pass speed through even if accuracy is nil.