### PR TITLE
feat: fix deviation before arrive on demo app

### DIFF
--- a/apple/DemoApp/Demo/DemoModel.swift
+++ b/apple/DemoApp/Demo/DemoModel.swift
@@ -34,7 +34,7 @@ private extension FerrostarCore {
                 minimumHorizontalAccuracy: 32
             ),
             arrivalStepAdvanceCondition: stepAdvanceDistanceToEndOfStep(
-                distance: 30,
+                distance: 10,
                 minimumHorizontalAccuracy: 32
             ),
             routeDeviationTracking: .staticThreshold(minimumHorizontalAccuracy: 25, maxAcceptableDeviation: 20),


### PR DESCRIPTION
- Fixes the demo app to prevent a forced offRoute at arrival. (Step before arrival advances at 30 meters, but deviation was 20 meters).