### PR TITLE
Add hysteresis to route deviation tracking

### DIFF
--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoConfigs.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoConfigs.kt
@@ -4,6 +4,7 @@ import uniffi.ferrostar.CourseFiltering
 import uniffi.ferrostar.NavigationCachingConfig
 import uniffi.ferrostar.NavigationControllerConfig
 import uniffi.ferrostar.RouteDeviationTracking
+import uniffi.ferrostar.StaticThresholdConfig
 import uniffi.ferrostar.WaypointAdvanceMode
 import uniffi.ferrostar.stepAdvanceDistanceEntryAndExit
 import uniffi.ferrostar.stepAdvanceDistanceToEndOfStep
@@ -13,7 +14,13 @@ fun NavigationControllerConfig.Companion.demoConfig(): NavigationControllerConfi
       WaypointAdvanceMode.WaypointWithinRange(100.0),
       stepAdvanceDistanceEntryAndExit(30u, 5u, 32u),
       stepAdvanceDistanceToEndOfStep(10u, 32u),
-      RouteDeviationTracking.StaticThreshold(15U, 50.0),
+      RouteDeviationTracking.StaticThreshold(
+          StaticThresholdConfig(
+              minimumHorizontalAccuracy = 15U,
+              maxAcceptableDeviation = 50.0,
+              returnBuffer = 0.0
+          )
+      ),
       CourseFiltering.SNAP_TO_ROUTE)
 }
 

--- a/apple/Sources/FerrostarCore/FFIWrappers/RouteDeviationWrapper.swift
+++ b/apple/Sources/FerrostarCore/FFIWrappers/RouteDeviationWrapper.swift
@@ -18,10 +18,17 @@ private final class DetectorImpl: RouteDeviationDetector {
 public enum SwiftRouteDeviationTracking {
     case none
 
+    /// Static threshold deviation tracking with hysteresis support.
+    ///
+    /// - Parameters:
+    ///   - minimumHorizontalAccuracy: Minimum GPS accuracy required to trigger deviation checks
+    ///   - maxAcceptableDeviation: Maximum distance from route before going off-route (must be >= 0)
+    ///   - returnBuffer: Buffer distance for hysteresis (must be >= 0 and <= maxAcceptableDeviation).
+    ///     If nil, defaults to 0 (no hysteresis).
     case staticThreshold(
         minimumHorizontalAccuracy: UInt16,
         maxAcceptableDeviation: Double,
-        onRouteThreshold: Double? = nil
+        returnBuffer: Double? = nil
     )
 
     case custom(detector: @Sendable (Route, TripState) -> RouteDeviation)
@@ -33,12 +40,14 @@ public enum SwiftRouteDeviationTracking {
         case let .staticThreshold(
             minimumHorizontalAccuracy: minimumHorizontalAccuracy,
             maxAcceptableDeviation: maxAcceptableDeviation,
-            onRouteThreshold: onRouteThreshold
+            returnBuffer: returnBuffer
         ):
             .staticThreshold(
-                minimumHorizontalAccuracy: minimumHorizontalAccuracy,
-                maxAcceptableDeviation: maxAcceptableDeviation,
-                onRouteThreshold: onRouteThreshold ?? maxAcceptableDeviation
+                StaticThresholdConfig(
+                    minimumHorizontalAccuracy: minimumHorizontalAccuracy,
+                    maxAcceptableDeviation: maxAcceptableDeviation,
+                    returnBuffer: returnBuffer ?? 0.0
+                )
             )
         case let .custom(detector: detectorFunc):
             .custom(detector: DetectorImpl(detectorFunc: detectorFunc))

--- a/common/ferrostar/src/navigation_controller/test_helpers.rs
+++ b/common/ferrostar/src/navigation_controller/test_helpers.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::deviation_detection::RouteDeviation;
 use crate::deviation_detection::RouteDeviationTracking;
+use crate::deviation_detection::StaticThresholdConfig;
 use crate::models::{
     BoundingBox, GeographicCoordinate, Route, RouteStep, UserLocation, Waypoint, WaypointKind,
 };
@@ -26,11 +27,14 @@ pub fn get_test_navigation_controller_config(
         // Careful setup: if the user is ever off the route
         // (ex: because of an improper automatic step advance),
         // we want to know about it.
-        route_deviation_tracking: RouteDeviationTracking::StaticThreshold {
-            minimum_horizontal_accuracy: 0,
-            max_acceptable_deviation: 0.0,
-            on_route_threshold: 0.0,
-        },
+        route_deviation_tracking: RouteDeviationTracking::StaticThreshold(
+            StaticThresholdConfig::new(
+                0,   // minimum_horizontal_accuracy
+                0.0, // max_acceptable_deviation
+                0.0, // return_buffer (no hysteresis)
+            )
+            .expect("Valid static threshold config for tests"),
+        ),
         snapped_location_course_filtering: CourseFiltering::Raw,
         step_advance_condition,
         arrival_step_advance_condition: Arc::new(DistanceToEndOfStepCondition {

--- a/common/ferrostar/src/navigation_session/recording/snapshots/ferrostar__navigation_session__recording__tests__recording_serialization.snap
+++ b/common/ferrostar/src/navigation_session/recording/snapshots/ferrostar__navigation_session__recording__tests__recording_serialization.snap
@@ -11,7 +11,7 @@ config:
     StaticThreshold:
       max_acceptable_deviation: 0
       minimum_horizontal_accuracy: 0
-      on_route_threshold: 0
+      return_buffer: 0
   snapped_location_course_filtering: Raw
   step_advance_condition:
     DistanceToEndOfStep:


### PR DESCRIPTION
Adds `on_route_threshold` parameter to `StaticThreshold` route deviation tracking. When set lower than `max_acceptable_deviation`, this creates a buffer zone that prevents users from oscillating between on-route and off-route states near the threshold boundary.

For example, with max_acceptable_deviation=50m and on_route_threshold=40m:
- User goes off-route when deviation exceeds 50m
- User returns on-route only when deviation drops to 40m or less
- This 10m buffer prevents rapid state changes when GPS accuracy fluctuates

This is especially useful for slow-paced navigation, such as when walking. Otherwise, when the user is at the max_acceptable_deviation, on- and off-route alerts keep triggering constantly, which can be quite annoying.