### PR TITLE
[Android] fix: Allow course propagation with unknown bearing accuracy

### DIFF
--- a/android/core/src/main/java/com/stadiamaps/ferrostar/core/Location.kt
+++ b/android/core/src/main/java/com/stadiamaps/ferrostar/core/Location.kt
@@ -257,8 +257,14 @@ fun android.location.Location.toUserLocation(): UserLocation {
         } else {
           Double.MAX_VALUE
         },
-        if (hasBearing() && hasBearingAccuracy()) {
-          CourseOverGround(bearing.toUInt().toUShort(), bearingAccuracyDegrees.toUInt().toUShort())
+        if (hasBearing()) {
+          CourseOverGround(
+              bearing.toUInt().toUShort(),
+              if (hasBearingAccuracy()) {
+                bearingAccuracyDegrees.toUInt().toUShort()
+              } else {
+                null
+              })
         } else {
           null
         },


### PR DESCRIPTION
Fixes an issue that @bjtrounson noted with mock location frameworks. This could also theoretically happen on a real device too, and since the accuracy is nullable anyways, we can still propagate the direction with a null accuracy.