### PR TITLE
Update MapLibreSwiftUI DSL to 0.21.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "82fd2565148fafa3478a2951bb709414950bda6f",
-        "version" : "6.12.3"
+        "revision" : "fa12216f30833c2b4d897714f7c1ca2f5608f685",
+        "version" : "6.22.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "68f3ed6c4b62afab27a84425494cb61421a61ac1",
-        "version" : "0.3.1"
+        "revision" : "55f846e4ea37ca37166a6d533b5144b956385b41",
+        "version" : "0.5.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/swiftui-dsl",
       "state" : {
-        "revision" : "ce0bf6e8b860938cd2f377822579c90a89ae676c",
-        "version" : "0.19.0"
+        "revision" : "e2da0e969a345c00e7524adf391d9be232be9c26",
+        "version" : "0.21.1"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
-        "version" : "1.5.2"
+        "revision" : "34e463e98ab8541c604af706c99bed7160f5ec70",
+        "version" : "1.8.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ if useLocalMapLibreSwiftUIDSL {
 } else {
     maplibreSwiftUIDSLPackage = .package(
         url: "https://github.com/maplibre/swiftui-dsl",
-        from: "0.17.0"
+        from: "0.21.1"
     )
 }
 

--- a/apple/DemoApp/Ferrostar Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apple/DemoApp/Ferrostar Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "46f977e213e19692434410bb273a7df20f7f91dbfeaadd3ed5fbc604b1559fcc",
+  "originHash" : "3e90030686b7a7719f19b1ef259d5f047c01f9fcd16dbba125c6e11e490ae70e",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "52421bf02a8b47a179ed11553e80aa400913e55e",
-        "version" : "6.18.1"
+        "revision" : "fa12216f30833c2b4d897714f7c1ca2f5608f685",
+        "version" : "6.22.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "ee133a696dce312da292b00d0944aafaa808eaca",
-        "version" : "0.4.0"
+        "revision" : "55f846e4ea37ca37166a6d533b5144b956385b41",
+        "version" : "0.5.1"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/swiftui-dsl",
       "state" : {
-        "revision" : "59fc604dfd9ba68de22b641f91ffc5cd579bc20a",
-        "version" : "0.17.0"
+        "revision" : "e2da0e969a345c00e7524adf391d9be232be9c26",
+        "version" : "0.21.1"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
-        "version" : "1.6.1"
+        "revision" : "34e463e98ab8541c604af706c99bed7160f5ec70",
+        "version" : "1.8.1"
       }
     }
   ],

--- a/apple/Sources/FerrostarMapLibreUI/Views/NavigationMapView.swift
+++ b/apple/Sources/FerrostarMapLibreUI/Views/NavigationMapView.swift
@@ -72,11 +72,11 @@ public struct NavigationMapView: View {
                 // Overlay any additional user layers.
                 userLayers
             }
-            .mapViewContentInset(calculatedMapViewInsets(for: geometry).uiEdgeInsets)
+            .mapContentInset(calculatedMapViewInsets(for: geometry).uiEdgeInsets)
             .mapControls {
                 // No controls
             }
-            .onStyleLoaded(onStyleLoaded)
+            .onMapStyleLoaded(onStyleLoaded)
             .ignoresSafeArea(.all)
         }
     }


### PR DESCRIPTION
Upgrades to the latest MapLibre SwiftUI DSL, and fixes some breakage from our recent API cleanup (breakage reported here: https://github.com/stadiamaps/ferrostar/discussions/772)