### PR TITLE
Update action-gh-release to version 2.5.0

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -34,7 +34,7 @@ jobs:
         git push origin ${{ github.event.release.tag_name }} --force
 
     - name: Release
-      uses: softprops/action-gh-release@v2.2.2
+      uses: softprops/action-gh-release@v2.5.0
       with:
         files: common/target/ios/libferrostar-rs.xcframework.zip
         draft: false


### PR DESCRIPTION
- Updates gh-release action to latest (including race condition 442 error fix)