### PR TITLE
fix: working cargo ndk

### DIFF
--- a/android/core/build.gradle
+++ b/android/core/build.gradle
@@ -1,3 +1,4 @@
+import com.github.willir.rust.CargoNdkConfig
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import com.vanniktech.maven.publish.SonatypeHost
 
@@ -79,9 +80,10 @@ cargoNdk {
 
 android.libraryVariants.all { variant ->
     def bDir = layout.buildDirectory.dir("generated/source/uniffi/${variant.name}/java").get()
+    def cargoPath = CargoNdkConfig.resolveCargoExecutable(cargoNdk.cargoExecutable)
     def generateBindings = tasks.register("generate${variant.name.capitalize()}UniFFIBindings", Exec) {
         workingDir '../../common'
-        commandLine 'cargo', 'run', '-p', 'uniffi-bindgen', 'generate', '--library', '../android/core/src/main/jniLibs/arm64-v8a/libferrostar.so', '--language', 'kotlin', '--out-dir', bDir
+        commandLine cargoPath, 'run', '-p', 'uniffi-bindgen', 'generate', '--library', '../android/core/src/main/jniLibs/arm64-v8a/libferrostar.so', '--language', 'kotlin', '--out-dir', bDir
 
         dependsOn "buildCargoNdk${variant.name.capitalize()}"
     }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-agp = "9.0.0"
-kotlin = "2.2.21"
-cargo-ndk = "0.3.4"
-ktfmt = "0.21.0"                     # 0.22.0 -> https://github.com/cortinico/ktfmt-gradle/issues/413
+agp = "9.0.1"
+kotlin = "2.3.10"
+cargo-ndk = "0.5.3"
+ktfmt = "0.25.0"                     # 0.22.0 -> https://github.com/cortinico/ktfmt-gradle/issues/413
 androidx-lifecycle = "2.10.0"
 paparazzi = "2.0.0-alpha04"
 desugar_jdk_libs = "2.1.5"
@@ -11,14 +11,14 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.10.0"
 androidx-appcompat = "1.7.1"
-androidx-activity-compose = "1.12.3"
-compose = "2026.01.01"
+androidx-activity-compose = "1.12.4"
+compose = "2026.02.01"
 okhttp = "5.3.2"
-maplibre-compose = "1.2.0"
+maplibre-compose = "1.4.1"
 playServicesLocation = "21.3.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
-junitCompose = "1.10.2"
+junitCompose = "1.10.4"
 espressoCore = "3.7.0"
 okhttp-mock = "2.1.0"
 mockk = "1.14.9"
@@ -78,7 +78,7 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
-cargo-ndk = { id = "com.github.willir.rust.cargo-ndk-android", version.ref = "cargo-ndk" }
+cargo-ndk = { id = "com.gemwallet.cargo-ndk", version.ref = "cargo-ndk" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }


### PR DESCRIPTION
- Installs https://github.com/gemwalletcom/cargo-ndk-android-gradle in favor of abandoned upstream.
- Uses `def cargoPath = CargoNdkConfig.resolveCargoExecutable(cargoNdk.cargoExecutable)` for custom cargo paths.

Closes #310 