### PR TITLE
Better Insets for Non Navigation

### DIFF
--- a/apple/Sources/FerrostarMapLibreUI/Views/NavigationMapView.swift
+++ b/apple/Sources/FerrostarMapLibreUI/Views/NavigationMapView.swift
@@ -83,7 +83,8 @@ public struct NavigationMapView: View {
 
     private func calculatedMapViewInsets(for geometry: GeometryProxy) -> NavigationMapViewContentInsetMode {
         if navigationState?.isNavigating == true {
-            return contentInsetConfig.bundle.dynamicWithCameraState(camera.state, isLandscape: geometry.isLandscape)(geometry)
+            return contentInsetConfig.bundle
+                .dynamicWithCameraState(camera.state, isLandscape: geometry.isLandscape)(geometry)
         }
 
         switch camera.state {


### PR DESCRIPTION
We use insets to "push down" the current location marker to the lower third during navigation, but thats not great while not navigating.

This PR addresses this by only using those insets when navigating, while passing in the parent safe area insets when not.

Before, notice how the dot is centered in the lower third even though we are not navigating.
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-16 at 10 48 58" src="https://github.com/user-attachments/assets/025cffe6-139b-4500-9ea8-eef144df1f3c" />

After it is now centered in the view.

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-20 at 15 21 53" src="https://github.com/user-attachments/assets/c192eba1-2960-4562-bde5-872814dc2c44" />


In non navigation states - it respects the safe areas provided by the parent - here a view is placed in the safe area at the bottom, and the puck is now centered in the visible area:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-20 at 15 59 19" src="https://github.com/user-attachments/assets/f9538673-d2a9-4a3b-9364-c511b86423d3" />
