### PR TITLE
Add German Android localizations

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -11,6 +11,7 @@ extend-exclude = [
     "**/dist/*",
     "guide/**/*.js",
     "**/fixtures/*",
+    "android/**/src/main/res/values-de*/*",
     "react-native/cpp/generated/*",
     "react-native/src/generated/*",
 ]

--- a/android/car-app/src/main/res/values-de/strings.xml
+++ b/android/car-app/src/main/res/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stop_nav">Stopp</string>
+    <string name="notification_description">Schrittweise Navigationsführung</string>
+</resources>

--- a/android/core/src/main/res/values-de/strings.xml
+++ b/android/core/src/main/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="notification_channel_description">Navigationshinweise</string>
+</resources>

--- a/android/demo-app/build.gradle
+++ b/android/demo-app/build.gradle
@@ -43,6 +43,9 @@ android {
     buildFeatures {
         compose true
     }
+    androidResources {
+        generateLocaleConfig true
+    }
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/NotNavigatingOverlay.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/NotNavigatingOverlay.kt
@@ -96,7 +96,7 @@ fun NotNavigatingOverlay(
               Text(nextLocationText)
             }
 
-            val currentLocationText = 
+            val currentLocationText =
                 if (isSimulating) {
                   stringResource(R.string.location_is_simulated)
                 } else {

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/NotNavigatingOverlay.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/NotNavigatingOverlay.kt
@@ -87,24 +87,24 @@ fun NotNavigatingOverlay(
         bottomEnd = {
           Column(modifier = Modifier.padding(bottom = 24.dp), horizontalAlignment = Alignment.End) {
             Button({ viewModel.toggleSimulation() }) {
-              val nextLocation =
+              val nextLocationText =
                   if (!isSimulating) {
-                    "simulated"
+                    stringResource(R.string.set_location_to_simulated)
                   } else {
-                    "GPS"
+                    stringResource(R.string.set_location_to_gps)
                   }
-              Text("Set location to $nextLocation")
+              Text(nextLocationText)
             }
 
-            val currentLocation =
+            val currentLocationText = 
                 if (isSimulating) {
-                  "simulated"
+                  stringResource(R.string.location_is_simulated)
                 } else {
-                  "GPS"
+                  stringResource(R.string.location_is_gps)
                 }
 
             Text(
-                "Location is $currentLocation",
+                currentLocationText,
                 style =
                     MaterialTheme.typography.titleSmall.copy(
                         color = MaterialTheme.colorScheme.onTertiary,

--- a/android/demo-app/src/main/res/resources.properties
+++ b/android/demo-app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en

--- a/android/demo-app/src/main/res/values-de/strings.xml
+++ b/android/demo-app/src/main/res/values-de/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Ferrostar Demo App</string>
+    <string name="dropped_pin_title">Gesetzte Markierung</string>
+    <string name="destination_coordinates">Koordinaten: %1$s</string>
+    <string name="start_navigation">Navigation starten</string>
+    <string name="close_destination_sheet">Schließen</string>
+    <string name="center_on_my_location">Auf meinen Standort zentrieren</string>
+    <string name="set_location_to_simulated">Simulierten Standort verwenden</string>
+    <string name="set_location_to_gps">GPS-Standort verwenden</string>
+    <string name="location_is_simulated">Standort: simuliert</string>
+    <string name="location_is_gps">Standort: GPS</string>
+</resources>

--- a/android/demo-app/src/main/res/values/strings.xml
+++ b/android/demo-app/src/main/res/values/strings.xml
@@ -5,4 +5,8 @@
     <string name="start_navigation">Start navigation</string>
     <string name="close_destination_sheet">Close</string>
     <string name="center_on_my_location">Center on my location</string>
+    <string name="set_location_to_simulated">Set location to simulated</string>
+    <string name="set_location_to_gps">Set location to GPS</string>
+    <string name="location_is_simulated">Location is simulated</string>
+    <string name="location_is_gps">Location is GPS</string>
 </resources>

--- a/android/ui-compose/src/main/res/values-de/strings.xml
+++ b/android/ui-compose/src/main/res/values-de/strings.xml
@@ -12,6 +12,7 @@
     <string name="maneuver_image">Bild der Fahranweisung</string>
     <string name="stop_navigation">Navigation beenden</string>
     <string name="maneuver_instruction_image">Bild der Navigationsanweisung</string>
+    <string name="dot">•</string>
     <string name="instruction_image">Bild der Anweisung</string>
     <string name="preparing">Wird vorbereitet…</string>
     <string name="arrived_title">Angekommen</string>

--- a/android/ui-compose/src/main/res/values-de/strings.xml
+++ b/android/ui-compose/src/main/res/values-de/strings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="recenter">Karte zentrieren</string>
+    <string name="unmute_description">Stummschaltung aufheben</string>
+    <string name="mute_description">Stummschalten</string>
+    <string name="zoom_in">Vergrößern</string>
+    <string name="zoom_out">Verkleinern</string>
+    <string name="arrival">Ankunft</string>
+    <string name="distance">Distanz</string>
+    <string name="duration">Dauer</string>
+    <string name="end_navigation">Navigation beenden</string>
+    <string name="maneuver_image">Bild der Fahranweisung</string>
+    <string name="stop_navigation">Navigation beenden</string>
+    <string name="maneuver_instruction_image">Bild der Navigationsanweisung</string>
+    <string name="instruction_image">Bild der Anweisung</string>
+    <string name="preparing">Wird vorbereitet…</string>
+    <string name="arrived_title">Angekommen</string>
+    <string name="arrived_description">Sie haben Ihr Ziel erreicht.</string>
+    <string name="route_overview">Routenübersicht</string>
+    <string name="speed">Tempo</string>
+    <string name="limit">Limit</string>
+</resources>


### PR DESCRIPTION
## Summary

- Add German `values-de` string resources for Android UI, demo app, core, and car app modules.
- Localize demo app simulation controls by moving hardcoded labels into string resources.
- Enable generated Android locale config for the demo app and mark unqualified resources as English.
- Use compact German wording where UI space is constrained, including `Tempo` for the MUTCD speed-limit label.

## Testing

- `xmllint --noout` on the new German string resource files
- `./gradlew :demo-app:generateDebugLocaleConfig`
- `./gradlew :ui-compose:ktfmtCheckSources`