### PR TITLE
feat: Allow custom MapOptions in high-level navigation views (Android)

### DIFF
--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoNavigationScene.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoNavigationScene.kt
@@ -133,13 +133,14 @@ fun DemoNavigationScene(viewModel: DemoNavigationViewModel = AppModule.viewModel
         viewModel.selectDestination(position)
         NavigationMapClickResult.Consume
       },
-      mapOptions = MapOptions(
-          ornamentOptions =
-              OrnamentOptions(
-                  isCompassEnabled = false,
-                  isScaleBarEnabled = false,
-              ),
-      ),
+      mapOptions =
+          MapOptions(
+              ornamentOptions =
+                  OrnamentOptions(
+                      isCompassEnabled = false,
+                      isScaleBarEnabled = false,
+                  ),
+          ),
   ) {
     DemoDroppedPinOverlay(sceneState.droppedPin)
   }

--- a/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoNavigationScene.kt
+++ b/android/demo-app/src/main/java/com/stadiamaps/ferrostar/DemoNavigationScene.kt
@@ -33,6 +33,8 @@ import com.stadiamaps.ferrostar.ui.DestinationSelectionCameraEffect
 import kotlinx.serialization.json.buildJsonObject
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.map.MapOptions
+import org.maplibre.compose.map.OrnamentOptions
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.compose.style.BaseStyle
@@ -131,6 +133,13 @@ fun DemoNavigationScene(viewModel: DemoNavigationViewModel = AppModule.viewModel
         viewModel.selectDestination(position)
         NavigationMapClickResult.Consume
       },
+      mapOptions = MapOptions(
+          ornamentOptions =
+              OrnamentOptions(
+                  isCompassEnabled = false,
+                  isScaleBarEnabled = false,
+              ),
+      ),
   ) {
     DemoDroppedPinOverlay(sceneState.droppedPin)
   }
@@ -172,5 +181,5 @@ internal fun droppedPinFeatureCollection(pin: GeographicCoordinate) =
         Feature(
             geometry = Point(longitude = pin.lng, latitude = pin.lat),
             properties = buildJsonObject {},
-        )
+        ),
     )

--- a/android/ui-maplibre/src/main/java/com/stadiamaps/ferrostar/maplibreui/runtime/MapControls.kt
+++ b/android/ui-maplibre/src/main/java/com/stadiamaps/ferrostar/maplibreui/runtime/MapControls.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.stadiamaps.ferrostar.composeui.runtime.paddingForGridView
 import org.maplibre.compose.map.MapOptions
@@ -25,6 +26,7 @@ internal fun rememberMapOptionsForProgressViewHeight(
     horizontalPadding: Dp = 16.dp,
     verticalPadding: Dp = 8.dp,
     contentPadding: PaddingValues = PaddingValues(0.dp),
+    baseMapOptions: MapOptions = defaultNavigationMapOptions(),
 ): MapOptions {
   val layoutDirection = LocalLayoutDirection.current
   val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
@@ -35,39 +37,70 @@ internal fun rememberMapOptionsForProgressViewHeight(
       horizontalPadding,
       verticalPadding,
       contentPadding,
+      baseMapOptions,
+      layoutDirection,
       isLandscape,
       gridPadding,
   ) {
-    val startPadding = contentPadding.calculateStartPadding(layoutDirection)
-    val endPadding =
-        contentPadding.calculateEndPadding(layoutDirection) +
-            gridPadding.calculateEndPadding(layoutDirection) +
-            horizontalPadding
-    val topPadding = contentPadding.calculateTopPadding() + verticalPadding
-    val bottomPadding =
-        contentPadding.calculateBottomPadding() +
-            gridPadding.calculateBottomPadding() +
-            if (isLandscape) {
-              verticalPadding
-            } else {
-              progressViewHeight + verticalPadding
-            }
+    mapOptionsForProgressViewHeight(
+        progressViewHeight = progressViewHeight,
+        horizontalPadding = horizontalPadding,
+        verticalPadding = verticalPadding,
+        contentPadding = contentPadding,
+        baseMapOptions = baseMapOptions,
+        layoutDirection = layoutDirection,
+        isLandscape = isLandscape,
+        gridPadding = gridPadding,
+    )
+  }
+}
 
+internal fun defaultNavigationMapOptions(): MapOptions =
     MapOptions(
         ornamentOptions =
             OrnamentOptions(
-                padding =
-                    PaddingValues(
-                        start = startPadding,
-                        end = endPadding,
-                        top = topPadding,
-                        bottom = bottomPadding,
-                    ),
                 isCompassEnabled = false,
                 isScaleBarEnabled = false,
                 logoAlignment = Alignment.BottomStart,
                 attributionAlignment = Alignment.BottomEnd,
             ),
     )
-  }
+
+internal fun mapOptionsForProgressViewHeight(
+    progressViewHeight: Dp,
+    horizontalPadding: Dp,
+    verticalPadding: Dp,
+    contentPadding: PaddingValues,
+    baseMapOptions: MapOptions,
+    layoutDirection: LayoutDirection,
+    isLandscape: Boolean,
+    gridPadding: PaddingValues,
+): MapOptions {
+  val startPadding = contentPadding.calculateStartPadding(layoutDirection)
+  val endPadding =
+      contentPadding.calculateEndPadding(layoutDirection) +
+          gridPadding.calculateEndPadding(layoutDirection) +
+          horizontalPadding
+  val topPadding = contentPadding.calculateTopPadding() + verticalPadding
+  val bottomPadding =
+      contentPadding.calculateBottomPadding() +
+          gridPadding.calculateBottomPadding() +
+          if (isLandscape) {
+            verticalPadding
+          } else {
+            progressViewHeight + verticalPadding
+          }
+
+  return baseMapOptions.copy(
+      ornamentOptions =
+          baseMapOptions.ornamentOptions.copy(
+              padding =
+                  PaddingValues(
+                      start = startPadding,
+                      end = endPadding,
+                      top = topPadding,
+                      bottom = bottomPadding,
+                  ),
+          ),
+  )
 }

--- a/android/ui-maplibre/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
+++ b/android/ui-maplibre/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/DynamicallyOrientingNavigationView.kt
@@ -36,10 +36,12 @@ import com.stadiamaps.ferrostar.maplibreui.extensions.cameraControlState
 import com.stadiamaps.ferrostar.maplibreui.routeline.RouteOverlayBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.NavigationCameraOptions
 import com.stadiamaps.ferrostar.maplibreui.runtime.NavigationMapState
+import com.stadiamaps.ferrostar.maplibreui.runtime.defaultNavigationMapOptions
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationCameraOptions
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapOptionsForProgressViewHeight
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberNavigationMapState
 import com.stadiamaps.ferrostar.maplibreui.runtime.withNavigationBottomInset
+import org.maplibre.compose.map.MapOptions
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.util.MaplibreComposable
 
@@ -52,6 +54,9 @@ import org.maplibre.compose.util.MaplibreComposable
  * @param overlayPadding Optional padding applied to Ferrostar-owned overlay chrome such as
  *   instructions, controls, and custom overlays. Defaults to `WindowInsets.systemBars` when not
  *   provided.
+ * @param mapOptions MapLibre map options to use as the base configuration. The wrapper replaces
+ *   `mapOptions.ornamentOptions.padding` with the computed padding needed to keep ornaments clear
+ *   of navigation overlays.
  */
 @Composable
 fun DynamicallyOrientingNavigationView(
@@ -72,6 +77,7 @@ fun DynamicallyOrientingNavigationView(
     onTapExit: (() -> Unit)? = null,
     onMapClick: NavigationMapClickHandler = { _, _ -> NavigationMapClickResult.Pass },
     onMapLongClick: NavigationMapClickHandler = { _, _ -> NavigationMapClickResult.Pass },
+    mapOptions: MapOptions = defaultNavigationMapOptions(),
     mapContent: @Composable @MaplibreComposable ((NavigationUiState) -> Unit)? = null,
 ) {
   val configuration = LocalConfiguration.current
@@ -85,10 +91,11 @@ fun DynamicallyOrientingNavigationView(
   val systemBarsPadding = WindowInsets.systemBars.asPaddingValues()
   val resolvedOrnamentPadding = ornamentPadding ?: systemBarsPadding
   val resolvedOverlayPadding = overlayPadding ?: systemBarsPadding
-  val mapOptions =
+  val effectiveMapOptions =
       rememberMapOptionsForProgressViewHeight(
           progressViewHeight = if (uiState.isNavigating()) progressViewHeight else 0.dp,
           contentPadding = resolvedOrnamentPadding,
+          baseMapOptions = mapOptions,
       )
   val effectiveNavigationCameraOptions =
       if (uiState.isNavigating()) {
@@ -106,7 +113,7 @@ fun DynamicallyOrientingNavigationView(
         baseStyle = baseStyle,
         navigationMapState = navigationMapState,
         uiState = uiState,
-        mapOptions = mapOptions,
+        mapOptions = effectiveMapOptions,
         navigationCameraOptions = effectiveNavigationCameraOptions,
         routeOverlayBuilder = routeOverlayBuilder,
         locationPuckStyle = locationPuckStyle,

--- a/android/ui-maplibre/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
+++ b/android/ui-maplibre/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/LandscapeNavigationView.kt
@@ -36,15 +36,25 @@ import com.stadiamaps.ferrostar.maplibreui.extensions.cameraControlState
 import com.stadiamaps.ferrostar.maplibreui.routeline.RouteOverlayBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.NavigationCameraOptions
 import com.stadiamaps.ferrostar.maplibreui.runtime.NavigationMapState
+import com.stadiamaps.ferrostar.maplibreui.runtime.defaultNavigationMapOptions
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationCameraOptions
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapOptionsForProgressViewHeight
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberNavigationMapState
 import com.stadiamaps.ferrostar.maplibreui.runtime.withNavigationBottomInset
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.maplibre.compose.map.MapOptions
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.util.MaplibreComposable
 
+/**
+ * A landscape orientation of the navigation view with instructions, default controls and the
+ * navigation map view.
+ *
+ * @param mapOptions MapLibre map options to use as the base configuration. The wrapper replaces
+ *   `mapOptions.ornamentOptions.padding` with the computed padding needed to keep ornaments clear
+ *   of navigation overlays.
+ */
 @Composable
 fun LandscapeNavigationView(
     modifier: Modifier,
@@ -62,13 +72,14 @@ fun LandscapeNavigationView(
     onTapExit: (() -> Unit)? = null,
     onMapClick: NavigationMapClickHandler = { _, _ -> NavigationMapClickResult.Pass },
     onMapLongClick: NavigationMapClickHandler = { _, _ -> NavigationMapClickResult.Pass },
+    mapOptions: MapOptions = defaultNavigationMapOptions(),
     mapContent: @Composable @MaplibreComposable ((NavigationUiState) -> Unit)? = null,
 ) {
   val uiState by viewModel.navigationUiState.collectAsState()
   val configuration = androidx.compose.ui.platform.LocalConfiguration.current
   val layoutDirection = LocalLayoutDirection.current
   val gridPadding = paddingForGridView()
-  val mapOptions = rememberMapOptionsForProgressViewHeight()
+  val effectiveMapOptions = rememberMapOptionsForProgressViewHeight(baseMapOptions = mapOptions)
   val effectiveNavigationCameraOptions =
       if (uiState.isNavigating()) {
         navigationCameraOptions.withNavigationBottomInset(
@@ -85,7 +96,7 @@ fun LandscapeNavigationView(
         baseStyle = baseStyle,
         navigationMapState = navigationMapState,
         uiState = uiState,
-        mapOptions = mapOptions,
+        mapOptions = effectiveMapOptions,
         navigationCameraOptions = effectiveNavigationCameraOptions,
         routeOverlayBuilder = routeOverlayBuilder,
         showDefaultPuck = showDefaultPuck,

--- a/android/ui-maplibre/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
+++ b/android/ui-maplibre/src/main/java/com/stadiamaps/ferrostar/maplibreui/views/PortraitNavigationView.kt
@@ -35,10 +35,12 @@ import com.stadiamaps.ferrostar.maplibreui.extensions.cameraControlState
 import com.stadiamaps.ferrostar.maplibreui.routeline.RouteOverlayBuilder
 import com.stadiamaps.ferrostar.maplibreui.runtime.NavigationCameraOptions
 import com.stadiamaps.ferrostar.maplibreui.runtime.NavigationMapState
+import com.stadiamaps.ferrostar.maplibreui.runtime.defaultNavigationMapOptions
 import com.stadiamaps.ferrostar.maplibreui.runtime.navigationCameraOptions
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberMapOptionsForProgressViewHeight
 import com.stadiamaps.ferrostar.maplibreui.runtime.rememberNavigationMapState
 import com.stadiamaps.ferrostar.maplibreui.runtime.withNavigationBottomInset
+import org.maplibre.compose.map.MapOptions
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.util.MaplibreComposable
 
@@ -65,6 +67,9 @@ import org.maplibre.compose.util.MaplibreComposable
  *   position.
  * @param onMapLongClick Callback invoked for long presses on the map with geographic coordinates
  *   and screen position.
+ * @param mapOptions MapLibre map options to use as the base configuration. The wrapper replaces
+ *   `mapOptions.ornamentOptions.padding` with the computed padding needed to keep ornaments clear
+ *   of navigation overlays.
  * @param mapContent Any additional composable map symbol content to render.
  */
 @Composable
@@ -84,13 +89,14 @@ fun PortraitNavigationView(
     onTapExit: (() -> Unit)? = null,
     onMapClick: NavigationMapClickHandler = { _, _ -> NavigationMapClickResult.Pass },
     onMapLongClick: NavigationMapClickHandler = { _, _ -> NavigationMapClickResult.Pass },
+    mapOptions: MapOptions = defaultNavigationMapOptions(),
     mapContent: @Composable @MaplibreComposable ((NavigationUiState) -> Unit)? = null,
 ) {
   val uiState by viewModel.navigationUiState.collectAsState()
   val configuration = androidx.compose.ui.platform.LocalConfiguration.current
   val layoutDirection = LocalLayoutDirection.current
   val gridPadding = paddingForGridView()
-  val mapOptions = rememberMapOptionsForProgressViewHeight()
+  val effectiveMapOptions = rememberMapOptionsForProgressViewHeight(baseMapOptions = mapOptions)
   val effectiveNavigationCameraOptions =
       if (uiState.isNavigating()) {
         navigationCameraOptions.withNavigationBottomInset(
@@ -107,7 +113,7 @@ fun PortraitNavigationView(
         baseStyle = baseStyle,
         navigationMapState = navigationMapState,
         uiState = uiState,
-        mapOptions = mapOptions,
+        mapOptions = effectiveMapOptions,
         navigationCameraOptions = effectiveNavigationCameraOptions,
         routeOverlayBuilder = routeOverlayBuilder,
         locationPuckStyle = locationPuckStyle,

--- a/android/ui-maplibre/src/test/java/com/stadiamaps/ferrostar/maplibreui/runtime/MapControlsTest.kt
+++ b/android/ui-maplibre/src/test/java/com/stadiamaps/ferrostar/maplibreui/runtime/MapControlsTest.kt
@@ -42,21 +42,23 @@ class MapControlsTest {
             progressViewHeight = 40.dp,
             horizontalPadding = 16.dp,
             verticalPadding = 8.dp,
-            contentPadding = PaddingValues(
-                start = 1.dp,
-                top = 2.dp,
-                end = 3.dp,
-                bottom = 4.dp,
-            ),
+            contentPadding =
+                PaddingValues(
+                    start = 1.dp,
+                    top = 2.dp,
+                    end = 3.dp,
+                    bottom = 4.dp,
+                ),
             baseMapOptions = baseOptions,
             layoutDirection = LayoutDirection.Ltr,
             isLandscape = false,
-            gridPadding = PaddingValues(
-                start = 5.dp,
-                top = 6.dp,
-                end = 7.dp,
-                bottom = 8.dp,
-            ),
+            gridPadding =
+                PaddingValues(
+                    start = 5.dp,
+                    top = 6.dp,
+                    end = 7.dp,
+                    bottom = 8.dp,
+                ),
         )
 
     assertEquals(RenderOptions.Debug, options.renderOptions)
@@ -80,22 +82,24 @@ class MapControlsTest {
             progressViewHeight = 40.dp,
             horizontalPadding = 16.dp,
             verticalPadding = 8.dp,
-            contentPadding = PaddingValues(
-                start = 1.dp,
-                top = 2.dp,
-                end = 3.dp,
-                bottom = 4.dp,
-            ),
+            contentPadding =
+                PaddingValues(
+                    start = 1.dp,
+                    top = 2.dp,
+                    end = 3.dp,
+                    bottom = 4.dp,
+                ),
             baseMapOptions =
                 MapOptions(ornamentOptions = OrnamentOptions(padding = PaddingValues(99.dp))),
             layoutDirection = LayoutDirection.Ltr,
             isLandscape = false,
-            gridPadding = PaddingValues(
-                start = 5.dp,
-                top = 6.dp,
-                end = 7.dp,
-                bottom = 8.dp,
-            ),
+            gridPadding =
+                PaddingValues(
+                    start = 5.dp,
+                    top = 6.dp,
+                    end = 7.dp,
+                    bottom = 8.dp,
+                ),
         )
 
     val padding = options.ornamentOptions.padding
@@ -112,21 +116,23 @@ class MapControlsTest {
             progressViewHeight = 40.dp,
             horizontalPadding = 16.dp,
             verticalPadding = 8.dp,
-            contentPadding = PaddingValues(
-                start = 1.dp,
-                top = 2.dp,
-                end = 3.dp,
-                bottom = 4.dp,
-            ),
+            contentPadding =
+                PaddingValues(
+                    start = 1.dp,
+                    top = 2.dp,
+                    end = 3.dp,
+                    bottom = 4.dp,
+                ),
             baseMapOptions = MapOptions(),
             layoutDirection = LayoutDirection.Ltr,
             isLandscape = true,
-            gridPadding = PaddingValues(
-                start = 5.dp,
-                top = 6.dp,
-                end = 7.dp,
-                bottom = 8.dp,
-            ),
+            gridPadding =
+                PaddingValues(
+                    start = 5.dp,
+                    top = 6.dp,
+                    end = 7.dp,
+                    bottom = 8.dp,
+                ),
         )
 
     assertEquals(20.dp, options.ornamentOptions.padding.calculateBottomPadding())
@@ -139,17 +145,19 @@ class MapControlsTest {
             progressViewHeight = 0.dp,
             horizontalPadding = 16.dp,
             verticalPadding = 8.dp,
-            contentPadding = PaddingValues(
-                start = 1.dp,
-                end = 3.dp,
-            ),
+            contentPadding =
+                PaddingValues(
+                    start = 1.dp,
+                    end = 3.dp,
+                ),
             baseMapOptions = MapOptions(),
             layoutDirection = LayoutDirection.Rtl,
             isLandscape = false,
-            gridPadding = PaddingValues(
-                start = 5.dp,
-                end = 7.dp,
-            ),
+            gridPadding =
+                PaddingValues(
+                    start = 5.dp,
+                    end = 7.dp,
+                ),
         )
 
     val padding = options.ornamentOptions.padding

--- a/android/ui-maplibre/src/test/java/com/stadiamaps/ferrostar/maplibreui/runtime/MapControlsTest.kt
+++ b/android/ui-maplibre/src/test/java/com/stadiamaps/ferrostar/maplibreui/runtime/MapControlsTest.kt
@@ -1,0 +1,159 @@
+package com.stadiamaps.ferrostar.maplibreui.runtime
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.maplibre.compose.map.GestureOptions
+import org.maplibre.compose.map.MapOptions
+import org.maplibre.compose.map.OrnamentOptions
+import org.maplibre.compose.map.RenderOptions
+
+class MapControlsTest {
+
+  @Test
+  fun mapOptionsForProgressViewHeightPreservesCallerOptions() {
+    val baseOptions =
+        MapOptions(
+            renderOptions = RenderOptions.Debug,
+            gestureOptions = GestureOptions.AllDisabled,
+            ornamentOptions =
+                OrnamentOptions(
+                    padding = PaddingValues(99.dp),
+                    isLogoEnabled = false,
+                    logoAlignment = Alignment.TopEnd,
+                    isAttributionEnabled = false,
+                    attributionAlignment = Alignment.TopStart,
+                    isCompassEnabled = true,
+                    compassAlignment = Alignment.BottomStart,
+                    isScaleBarEnabled = true,
+                    scaleBarAlignment = Alignment.BottomEnd,
+                ),
+        )
+
+    val options =
+        mapOptionsForProgressViewHeight(
+            progressViewHeight = 40.dp,
+            horizontalPadding = 16.dp,
+            verticalPadding = 8.dp,
+            contentPadding = PaddingValues(
+                start = 1.dp,
+                top = 2.dp,
+                end = 3.dp,
+                bottom = 4.dp,
+            ),
+            baseMapOptions = baseOptions,
+            layoutDirection = LayoutDirection.Ltr,
+            isLandscape = false,
+            gridPadding = PaddingValues(
+                start = 5.dp,
+                top = 6.dp,
+                end = 7.dp,
+                bottom = 8.dp,
+            ),
+        )
+
+    assertEquals(RenderOptions.Debug, options.renderOptions)
+    assertEquals(GestureOptions.AllDisabled, options.gestureOptions)
+
+    val ornamentOptions = options.ornamentOptions
+    assertFalse(ornamentOptions.isLogoEnabled)
+    assertEquals(Alignment.TopEnd, ornamentOptions.logoAlignment)
+    assertFalse(ornamentOptions.isAttributionEnabled)
+    assertEquals(Alignment.TopStart, ornamentOptions.attributionAlignment)
+    assertTrue(ornamentOptions.isCompassEnabled)
+    assertEquals(Alignment.BottomStart, ornamentOptions.compassAlignment)
+    assertTrue(ornamentOptions.isScaleBarEnabled)
+    assertEquals(Alignment.BottomEnd, ornamentOptions.scaleBarAlignment)
+  }
+
+  @Test
+  fun mapOptionsForProgressViewHeightReplacesOrnamentPadding() {
+    val options =
+        mapOptionsForProgressViewHeight(
+            progressViewHeight = 40.dp,
+            horizontalPadding = 16.dp,
+            verticalPadding = 8.dp,
+            contentPadding = PaddingValues(
+                start = 1.dp,
+                top = 2.dp,
+                end = 3.dp,
+                bottom = 4.dp,
+            ),
+            baseMapOptions =
+                MapOptions(ornamentOptions = OrnamentOptions(padding = PaddingValues(99.dp))),
+            layoutDirection = LayoutDirection.Ltr,
+            isLandscape = false,
+            gridPadding = PaddingValues(
+                start = 5.dp,
+                top = 6.dp,
+                end = 7.dp,
+                bottom = 8.dp,
+            ),
+        )
+
+    val padding = options.ornamentOptions.padding
+    assertEquals(1.dp, padding.calculateStartPadding(LayoutDirection.Ltr))
+    assertEquals(26.dp, padding.calculateEndPadding(LayoutDirection.Ltr))
+    assertEquals(10.dp, padding.calculateTopPadding())
+    assertEquals(60.dp, padding.calculateBottomPadding())
+  }
+
+  @Test
+  fun mapOptionsForProgressViewHeightExcludesProgressHeightInLandscape() {
+    val options =
+        mapOptionsForProgressViewHeight(
+            progressViewHeight = 40.dp,
+            horizontalPadding = 16.dp,
+            verticalPadding = 8.dp,
+            contentPadding = PaddingValues(
+                start = 1.dp,
+                top = 2.dp,
+                end = 3.dp,
+                bottom = 4.dp,
+            ),
+            baseMapOptions = MapOptions(),
+            layoutDirection = LayoutDirection.Ltr,
+            isLandscape = true,
+            gridPadding = PaddingValues(
+                start = 5.dp,
+                top = 6.dp,
+                end = 7.dp,
+                bottom = 8.dp,
+            ),
+        )
+
+    assertEquals(20.dp, options.ornamentOptions.padding.calculateBottomPadding())
+  }
+
+  @Test
+  fun mapOptionsForProgressViewHeightResolvesRtlPadding() {
+    val options =
+        mapOptionsForProgressViewHeight(
+            progressViewHeight = 0.dp,
+            horizontalPadding = 16.dp,
+            verticalPadding = 8.dp,
+            contentPadding = PaddingValues(
+                start = 1.dp,
+                end = 3.dp,
+            ),
+            baseMapOptions = MapOptions(),
+            layoutDirection = LayoutDirection.Rtl,
+            isLandscape = false,
+            gridPadding = PaddingValues(
+                start = 5.dp,
+                end = 7.dp,
+            ),
+        )
+
+    val padding = options.ornamentOptions.padding
+    assertEquals(1.dp, padding.calculateStartPadding(LayoutDirection.Rtl))
+    assertEquals(26.dp, padding.calculateEndPadding(LayoutDirection.Rtl))
+  }
+}

--- a/guide/src/jetpack-compose-customization.md
+++ b/guide/src/jetpack-compose-customization.md
@@ -53,6 +53,36 @@ See the [vendors page](./vendors.md) for some ideas.
 
 If you already manage styles yourself, `BaseStyle.Json(styleJson)` works as well.
 
+### Map options and built-in ornaments
+
+The high-level phone and tablet navigation views accept `MapOptions` for configuring
+MapLibre render, gesture, and ornament options.
+Ferrostar still computes `ornamentOptions.padding` in these views so built-in map ornaments
+stay clear of the navigation UI.
+Use the lower-level `NavigationMapView` if you need full control over ornament padding.
+
+```kotlin
+import androidx.compose.ui.Alignment
+import org.maplibre.compose.map.MapOptions
+import org.maplibre.compose.map.OrnamentOptions
+```
+
+```kotlin
+  DynamicallyOrientingNavigationView(
+      modifier = Modifier.fillMaxSize(),
+      baseStyle = BaseStyle.Uri(AppModule.mapStyleUrl),
+      viewModel = viewModel,
+      mapOptions = MapOptions(
+          ornamentOptions = OrnamentOptions(
+              isCompassEnabled = true,
+              isScaleBarEnabled = true,
+              logoAlignment = Alignment.BottomStart,
+              attributionAlignment = Alignment.BottomEnd,
+          ),
+      ),
+  )
+```
+
 ### Camera
 
 Ferrostar's Jetpack Compose views provide several forms of camera configuration.


### PR DESCRIPTION
Add support for passing custom `MapOptions` to `PortraitNavigationView`, `LandscapeNavigationView`, and `DynamicallyOrientingNavigationView`. This allows developers to configure MapLibre render options, gestures, and ornaments while the navigation components continue to automatically manage ornament padding to avoid overlap with UI elements.