### PR TITLE
Android: Enable synchronous updates for NavigationPuckOverlay GeoJSON source

### DIFF
--- a/android/ui-maplibre/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationPuckOverlay.kt
+++ b/android/ui-maplibre/src/main/java/com/stadiamaps/ferrostar/maplibreui/NavigationPuckOverlay.kt
@@ -23,6 +23,7 @@ import org.maplibre.compose.expressions.value.IconRotationAlignment
 import org.maplibre.compose.expressions.value.SymbolAnchor
 import org.maplibre.compose.layers.SymbolLayer
 import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.compose.util.MaplibreComposable
 import org.maplibre.spatialk.geojson.Feature
@@ -70,6 +71,7 @@ internal fun NavigationPuckOverlay(
                   bearingDegrees = target.bearingDegrees,
               ),
           ),
+          options = GeoJsonOptions(synchronousUpdate = true),
       )
   val puckPainter = rememberNavigationPuckPainter(style.dotFillColorCurrentLocation)
   val puckSize = 80.dp


### PR DESCRIPTION
## Summary

Enable synchronous GeoJSON updates for the Android `NavigationPuckOverlay` source.

The navigation puck source contains a single point feature with the current position and bearing. This is a small, frequently updated, latency-sensitive source, so it is a good fit for MapLibre Compose's `GeoJsonOptions(synchronousUpdate = true)` (see https://github.com/maplibre/maplibre-compose/pull/761 and https://github.com/maplibre/maplibre-native/pull/3968).

## Motivation

The navigation puck should visually track position and bearing updates with as little latency as possible during active navigation. Applying this update synchronously avoids the extra async source update delay for this very small in-memory GeoJSON source.

## Notes

This is intentionally limited to the navigation puck source. Larger GeoJSON sources such as routes, shape collections, or clustered data should continue using the default asynchronous update path to avoid hurting frame performance.

## Testing

- Tested demo app with simulated location
  - I tested with both values (true and false) and also checked the profile - could't observe increased CPU usage