### PR TITLE
Dismiss Live Activity on Terminate

### DIFF
--- a/apple/Sources/FerrostarSwiftUI/DynamicIsland/FerrostarWidgetProvider.swift
+++ b/apple/Sources/FerrostarSwiftUI/DynamicIsland/FerrostarWidgetProvider.swift
@@ -42,7 +42,7 @@ public class FerrostarWidgetProvider: WidgetProviding {
 
     public func terminate() {
         Task {
-            await activity?.end()
+            await activity?.end(nil, dismissalPolicy: .immediate)
             lastUpdateDistance = nil
         }
     }


### PR DESCRIPTION
When you cancel a navigation by hitting the X button in ferrostar, the live activity can "linger", continuing to show instructions. Using "immediate" this is prevented - which makes sense as showing a "turn left" or similar for a few minutes makes little sense.

<img width="660" height="1434" alt="IMG_5907" src="https://github.com/user-attachments/assets/28ae3808-29c7-4e49-97a2-524fdad3b93b" />
